### PR TITLE
build: Fix broken `install` and `dist` targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,14 +36,6 @@ metamath_SOURCES = \
 	mmwtex.c \
 	$(noinst_HEADERS)
 
-dist_pkgdata_DATA = \
-	big-unifier.mm \
-	demo0.mm \
-	miu.mm \
-	peano.mm \
-	ql.mm \
-	set.mm
-
 
 EXTRA_DIST = \
 	LICENSE.TXT \


### PR DESCRIPTION
Previously the automake variable `dist_pkgdata_DATA` was set to a list
of non-existing `*.mm` databases. This variable controls which files are
installed to `$(datadir)/metamath` during the make targets `install` and
`dist`, which were failing with an error due to the missing
dependencies.