### PR TITLE
add gitignore, fix c99 warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.o
+*.Po
+autom4te.cache/
+stamp-h1
+missing
+metamath
+Makefile
+Makefile.in
+compile
+configure
+config.*
+depcomp
+install-sh
+aclocal.m4

--- a/metamath.c
+++ b/metamath.c
@@ -1058,7 +1058,10 @@ void command(int argc, char *argv[]) {
           }
         }
         /* Do the operating system command */
-        (void)system(str1);
+        /* The use of (void)!f() is to ignore the value on both
+          clang (which takes (void) as an ignore indicator)
+          and gcc (which doesn't but is fooled by the ! operator). */
+        (void)!system(str1);
 #ifdef VAXC
         printf("\n"); /* Last line from VAX doesn't have new line */
 #endif

--- a/mminou.c
+++ b/mminou.c
@@ -81,16 +81,6 @@ flag print2(char* fmt, ...) {
   long i;
 
   char *printBuffer; /* Allocated dynamically */
-  /* gcc (Debian 4.9.2-10+deb8u2) 4.9.2 gives error for ssize_t if -c99
-     is specified; gcc (GCC) 7.3.0 doesn't complain if -c99 is specified */
-  /* See https://sourceforge.net/p/predef/wiki/Compilers/ for __LCC__ */
-#ifdef __LCC__   /* ssize_t not defined for lcc compiler */
-  long bufsiz;
-#else
-  ssize_t bufsiz; /* ssize_t (signed size_t) can represent the number -1 for
-                     error checking */
-#endif
-
 
   if (backBufferPos == 0) {
     /* Initialize backBuffer - 1st time in program */
@@ -216,7 +206,7 @@ flag print2(char* fmt, ...) {
 
   /* Allow unlimited output size */
   va_start(ap, fmt);
-  bufsiz = vsnprintf(NULL, 0, fmt, ap); /* Get the buffer size we need */
+  int bufsiz = vsnprintf(NULL, 0, fmt, ap); /* Get the buffer size we need */
   va_end(ap);
   /* Warning: some older complilers, including lcc-win32 version 3.8 (2004),
      return -1 instead of the buffer size */


### PR DESCRIPTION
There was only one use of `ssize_t` and it wasn't needed, so I've just removed it. It seems to give errors at `-std=c99` for some compilers, including mine (`gcc 9.3.0`).