### PR TITLE
remove code history comments & dead code

### DIFF
--- a/metamath.c
+++ b/metamath.c
@@ -2213,57 +2213,6 @@ void command(int argc, char *argv[])
     if (cmdMatches("WRITE SOURCE")) {
       let(&g_output_fn, g_fullArg[2]);
 
-      /********* Deleted 28-Dec-2013 nm Now opened in writeSource()
-      g_output_fp = fSafeOpen(g_output_fn, "w", 0/@noVersioningFlag@/);
-      if (!g_output_fp) continue; /@ Couldn't open it (error msg was provided)@/
-      ********/
-
-      /******* Deleted 3-May-2017 nm
-      /@ Added 24-Oct-03 nm @/
-      if (switchPos("/ CLEAN") > 0) {
-        c = 1; /@ Clean out any proof-in-progress (that user has flagged
-                        with a ? in its date comment field) @/
-      } else {
-        c = 0; /@ Output all proofs (normal) @/
-      }
-      *******/
-
-      /********* Deleted 3-May-2017 nm
-      writeSource((char)c, (char)r); /@ Added arg 24-Oct-03 nm 12-Jun-2011 nm @/
-      fclose(g_output_fp);
-      if (c == 0) g_sourceChanged = 0; /@ Don't unset flag if CLEAN option
-                                    since some new proofs may not be saved. @/
-      ***********/
-
-
-      /***** 3-Jan-2017 nm  This is now done with SET ROOT_DIRECTORY
-      /@ 31-Dec-2017 nm - Added ROOT_DIRECTORY switch @/
-      /@ TODO - remove this qualifier; too confusing.
-         Use SET ROOT_DIRECTORY instead. @/
-      i = switchPos("/ ROOT_DIRECTORY"); /@ Statement match to skip @/
-      if (i != 0) {
-        let(&g_rootDirectory, edit(g_fullArg[i + 1], 2/@discard spaces,tabs@/));
-        /@ Add trailing "/" to g_rootDirectory if missing @/
-        if (instr(1, g_rootDirectory, "\\") != 0
-            || instr(1, g_input_fn, "\\") != 0 ) {
-          /@ Using Windows-style path (not really supported, but at least
-             make full path consistent) @/
-          if (g_rootDirectory[strlen(g_rootDirectory) - 1] != '\\') {
-            let(&g_rootDirectory, cat(g_rootDirectory, "\\", NULL));
-          }
-        } else {
-          if (g_rootDirectory[strlen(g_rootDirectory) - 1] != '/') {
-            let(&g_rootDirectory, cat(g_rootDirectory, "/", NULL));
-          }
-        }
-      /@
-      } else {
-        let(&g_rootDirectory, "");
-      @/
-      }
-      */
-
-      /* Added 12-Jun-2011 nm */
       if (switchPos("/ REWRAP") > 0) {
         r = 2; /* Re-wrap then format (more aggressive than / FORMAT) */
       } else if (switchPos("/ FORMAT") > 0) {
@@ -2272,7 +2221,6 @@ void command(int argc, char *argv[])
         r = 0; /* Keep formatting as-is */
       }
 
-      /* 24-Aug-2020 nm */
       i = switchPos("/ EXTRACT");
       if (i > 0) {
         let(&str1, g_fullArg[i + 1]); /* List of labels */
@@ -2287,17 +2235,15 @@ void command(int argc, char *argv[])
         let(&str1, ""); /* Empty string means full db */
       }
 
-      /* 3-May-2017 nm */
-      writeSource((char)r, /* Rewrap type */ /* Added arg 12-Jun-2011 nm */
-        ((switchPos("/ SPLIT") > 0) ? 1 : 0),          /* 31-Dec-2017 nm */
-        ((switchPos("/ NO_VERSIONING") > 0) ? 1 : 0),  /* 31-Dec-2017 nm */
-        ((switchPos("/ KEEP_INCLUDES") > 0) ? 1 : 0),   /* 31-Dec-2017 nm */
-        str1 /* Label list to extract */  /* 24-Aug-2020 nm */
+      writeSource((char)r, /* Rewrap type */
+        ((switchPos("/ SPLIT") > 0) ? 1 : 0),
+        ((switchPos("/ NO_VERSIONING") > 0) ? 1 : 0),
+        ((switchPos("/ KEEP_INCLUDES") > 0) ? 1 : 0),
+        str1 /* Label list to extract */
           );
-      /*fclose(g_output_fp);*/
       g_sourceChanged = 0;
 
-      let(&str1, ""); /* Deallocate */ /* 24-Aug-2020 nm */
+      let(&str1, ""); /* Deallocate */
       continue;
     } /* End of WRITE SOURCE */
 
@@ -2317,25 +2263,6 @@ void command(int argc, char *argv[])
       }
       showLemmas = (switchPos("/ SHOW_LEMMAS") != 0);
       noVersioning = (switchPos("/ NO_VERSIONING") != 0);
-
-      /**** 17-Nov-2015 nm Deleted, no longer need this restriction
-      if (!g_texDefsRead) {
-        g_htmlFlag = 1;
-        print2("Reading definitions from $t statement of %s...\n", g_input_fn);
-        if (2/@error@/ == readTexDefs(0 /@ 1 = check errors only @/,
-            0 /@ 1 = no GIF file existence check @/ )) {
-          continue; /@ An error occurred @/
-        }
-      } else {
-        /@ Current limitation - can only read def's from .mm file once @/
-        if (!g_htmlFlag) {
-          print2("?You cannot use both LaTeX and HTML in the same session.\n");
-          print2(
-              "You must EXIT and restart Metamath to switch to the other.\n");
-          continue;
-        }
-      }
-      *** end of 17-Nov-2015 deletion */
 
       g_htmlFlag = 1;
       /* If not specified, for backwards compatibility in scripts
@@ -2363,13 +2290,10 @@ void command(int argc, char *argv[])
 
 
     if (cmdMatches("WRITE BIBLIOGRAPHY")) {
-      /* 10/10/02 */
       /* This command builds the bibliographical cross-references to various
          textbooks and updates the user-specified file normally called
          mmbiblio.html. */
 
-      /* 17-Nov-2015 nm code moved to writeBibliography() in mmwtex.c */
-      /* (Also called by verifyMarkup() in mmcmds.c for error checking) */
       writeBibliography(g_fullArg[2],
           "*", /* labelMatch - all labels */
           0,  /* 1 = no output, just warning msgs if any */
@@ -2379,8 +2303,7 @@ void command(int argc, char *argv[])
 
 
     if (cmdMatches("WRITE RECENT_ADDITIONS")) {
-      /* 18-Sep-03 -
-         This utility creates a list of recent proof descriptions and updates
+      /* This utility creates a list of recent proof descriptions and updates
          the user-specified file normally called mmrecent.html.
        */
 
@@ -2394,25 +2317,6 @@ void command(int argc, char *argv[])
       } else {
         i = RECENT_COUNT; /* Use the default value */
       }
-
-      /**** 17-Nov-2015 nm Deleted because readTeXDefs() now handles everything
-      if (!g_texDefsRead) {
-        g_htmlFlag = 1;
-        print2("Reading definitions from $t statement of %s...\n", g_input_fn);
-        if (2/@error@/ == readTexDefs(0 /@ 1 = check errors only @/,
-            0 /@ 1 = no GIF file existence check @/  )) {
-          continue; /@ An error occurred @/
-        }
-      } else {
-        /@ Current limitation - can only read def's from .mm file once @/
-        if (!g_htmlFlag) {
-          print2("?You cannot use both LaTeX and HTML in the same session.\n");
-          print2(
-              "You must EXIT and restart Metamath to switch to the other.\n");
-          continue;
-        }
-      }
-      **** end of 17-Nov-2015 deletion */
 
       g_htmlFlag = 1;
       /* If not specified, for backwards compatibility in scripts
@@ -2479,53 +2383,12 @@ void command(int argc, char *argv[])
       /* Get and parse today's date */
       parseDate(date(), &k /*dd*/, &l /*mmm*/, &m /*yyyy*/); /* 4-Nov-2015 */
 
-      /************ Deleted 4-Nov-2015
-      let(&str1, date());
-      j = instr(1, str1, "-");
-      k = (long)val(left(str1, j - 1)); /@ Day @/
-#define MONTHS "JanFebMarAprMayJunJulAugSepOctNovDec"
-      l = ((instr(1, MONTHS, mid(str1, j + 1, 3)) - 1) / 3) + 1; /@ 1 = Jan @/
-      m = str1[j + 6]; /@ Character after 2-digit year @/  /@ nm 10-Apr-06 @/
-      if (m == ' ' || m == ']') {                          /@ nm 10-Apr-06 @/
-        /@ Handle 2-digit year @/
-        m = (long)val(mid(str1, j + 5, 2));  /@ Year @/
-#define START_YEAR 93 /@ Earliest 19xx year in set.mm database @/
-        if (m < START_YEAR) {
-          m = m + 2000;
-        } else {
-          m = m + 1900;
-        }
-      } else {                                            /@ nm 10-Apr-06 @/
-        /@ Handle 4-digit year @/                         /@ nm 10-Apr-06 @/
-        m = (long)val(mid(str1, j + 5, 4));  /@ Year @/         /@ nm 10-Apr-06 @/
-      }                                                   /@ nm 10-Apr-06 @/
-      *********** end of 4-Nov-2015 deletion */
-
 #define START_YEAR 93 /* Earliest 19xx year in set.mm database */
       n = 0; /* Count of how many output so far */
       while (n < i /*RECENT_COUNT*/ && m > START_YEAR + 1900 - 1) {
 
         /* Build date string to match */
-        /* 4-Nov-2015 nm */
-        /*buildDate(k, l, m, &str5);*/
-        buildDate(k, l, m, &str1); /* 2-May-2017 nm */
-
-        /***** Deleted 2-May-2017 nm - we no longer match date below proof
-        let(&str5, cat("$([", str5, "]$)", NULL));
-        /@ 2-digit year is obsolete, but keep for backwards compatibility @/
-        let(&str1, cat(left(str5, (long)strlen(str5) - 7),
-            right(str5, (long)strlen(str5) - 4), NULL));
-        *******/
-
-        /************ Deleted 4-Nov-2015
-#define MONTHS "JanFebMarAprMayJunJulAugSepOctNovDec"
-        /@ Match for 2-digit year OBSOLETE @/
-        let(&str1, cat("$([", str((double)k), "-", mid(MONTHS, 3 @ l - 2, 3), "-",
-            right(str((double)m), 3), "]$)", NULL));
-        /@ Match for 4-digit year @/  /@ nm 10-Apr-06 @/
-        let(&str5, cat("$([", str((double)k), "-", mid(MONTHS, 3 @ l - 2, 3), "-",
-            str((double)m), "]$)", NULL));
-        *********** end of 4-Nov-2015 deletion */
+        buildDate(k, l, m, &str1);
 
         for (stmt = g_statements; stmt >= 1; stmt--) {
 
@@ -2534,31 +2397,11 @@ void command(int argc, char *argv[])
             continue;
           }
 
-          /******** Deleted 2-May-2017 nm
-          /@ Get the comment section after the statement @/
-          let(&str2, space(g_Statement[stmt + 1].labelSectionLen));
-          memcpy(str2, g_Statement[stmt + 1].labelSectionPtr,
-              (size_t)(g_Statement[stmt + 1].labelSectionLen));
-          p = instr(1, str2, "$)");
-          let(&str2, left(str2, p + 1)); /@ Get 1st comment (if any) @/
-          let(&str2, edit(str2, 2)); /@ Discard spaces @/
-          ******** end of 2-May-2017 deletion */
-          /* 2-May-2017 nm */
-          /******* Deleted 3-May-2017 nm
-          /@ In the call below, str3 is a dummy variable for a placeholder
-             (its value will be undefined because of multiple occurrences) @/
-          getContrib(stmt/@stmtNum@/, &str3, &str3, &str3, &str3, &str3, &str3,
-              &str2, /@mostRecentDate@/
-              0, /@printErrorsFlag@/
-              1); /@normal mode@/
-          **********/
-          /* 3-May-2017 nm */
           let(&str2, "");
-          str2 = getContrib(stmt/*stmtNum*/, MOST_RECENT_DATE);
+          str2 = getContrib(stmt, MOST_RECENT_DATE);
 
           /* See if the date comment matches */
-          /*if (instr(1, str2, str1) || instr(1, str2, str5)) {*/ /* 10-Apr-06 */
-          if (!strcmp(str2, str1)) { /* 2-May-2017 nm */
+          if (!strcmp(str2, str1)) {
             /* We have a match, so increment the match count */
             n++;
             let(&str3, "");
@@ -2578,7 +2421,6 @@ void command(int argc, char *argv[])
                      cat("<TR BGCOLOR=", PURPLISH_BIBLIO_COLOR, ">", NULL),
                 */
 
-                /* 29-Jul-2008 nm Sandbox stuff */
                 (stmt < g_extHtmlStmt)
                    ? "<TR>"
                    : (stmt < g_mathboxStmt)
@@ -2587,34 +2429,27 @@ void command(int argc, char *argv[])
                        : cat("<TR BGCOLOR=", SANDBOX_COLOR, ">", NULL),
 
                 "<TD NOWRAP>",  /* IE breaks up the date */
-                /* mid(str1, 4, (long)strlen(str1) - 6), */ /* Date */
-                /* Use 4-digit year */   /* 10-Apr-06 */
-                /* mid(str5, 4, (long)strlen(str5) - 6), */ /* Date */ /* 10-Apr-06 */
-                str2, /* Date */ /* 2-May-2017 nm */
+                str2, /* Date */
                 "</TD><TD ALIGN=CENTER><A HREF=\"",
                 g_Statement[stmt].labelName, ".html\">",
                 g_Statement[stmt].labelName, "</A>",
                 str4, "</TD><TD ALIGN=LEFT>", NULL),  /* Description */
-                            /* 28-Dec-05 nm Added ALIGN=LEFT for IE */
               " ",  /* Start continuation line with space */
               "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
 
             g_showStatement = stmt; /* For printTexComment */
             g_outputToString = 0; /* For printTexComment */
             g_texFilePtr = list2_fp;
-            /* 18-Sep-03 ???Future - make this just return a string??? */
-            /* printTexComment(str3, 0); */
-            /* 17-Nov-2015 nm Added 3rd & 4th arguments */
             printTexComment(str3,              /* Sends result to g_texFilePtr */
                 0, /* 1 = htmlCenterFlag */
-                PROCESS_EVERYTHING, /* actionBits */ /* 13-Dec-2018 nm */
+                PROCESS_EVERYTHING, /* actionBits */
                 0  /* 1 = noFileCheck */ );
             g_texFilePtr = NULL;
             g_outputToString = 1; /* Restore after printTexComment */
 
             /* Get HTML hypotheses => assertion */
             let(&str4, "");
-            str4 = getTexOrHtmlHypAndAssertion(stmt); /* In mmwtex.c */
+            str4 = getTexOrHtmlHypAndAssertion(stmt);
             printLongLine(cat("</TD></TR><TR",
 
                   /*
@@ -2623,7 +2458,6 @@ void command(int argc, char *argv[])
                        cat(" BGCOLOR=", PURPLISH_BIBLIO_COLOR, ">", NULL),
                   */
 
-                  /* 29-Jul-2008 nm Sandbox stuff */
                   (stmt < g_extHtmlStmt)
                      ? ">"
                      : (stmt < g_mathboxStmt)
@@ -2631,11 +2465,6 @@ void command(int argc, char *argv[])
                              NULL)
                          : cat(" BGCOLOR=", SANDBOX_COLOR, ">", NULL),
 
-                /*** old
-                "<TD BGCOLOR=white>&nbsp;</TD><TD COLSPAN=2 ALIGN=CENTER>",
-                str4, "</TD></TR>", NULL),
-                ****/
-                /* 27-Oct-03 nm */
                 "<TD COLSPAN=3 ALIGN=CENTER>",
                 str4, "</TD></TR>", NULL),
 
@@ -2780,7 +2609,6 @@ void command(int argc, char *argv[])
         if (!g_Statement[i].labelName[0]) continue; /* No label */
         if (!m && g_Statement[i].type != (char)p_ &&
             g_Statement[i].type != (char)a_) continue; /* No /ALL switch */
-        /* 30-Jan-06 nm Added single-character-match wildcard argument */
         if (!matchesList(g_Statement[i].labelName, g_fullArg[2], '*', '?')) {
           continue;
         }
@@ -2814,41 +2642,7 @@ void command(int argc, char *argv[])
           }
           j++;
         }
-
-        /* 2-Oct-2015 nm Deleted
-        let(&str1,cat(str((double)i)," ",
-            g_Statement[i].labelName," $",chr(g_Statement[i].type)," ",NULL));
-#define COL 19 /@ Characters per column @/
-        if (j + (long)strlen(str1) > MAX_LEN
-            || (linearFlag && j != 0)) { /@ j != 0 to suppress 1st CR @/
-          print2("\n");
-          j = 0;
-          k = 0;
-        }
-        if (strlen(str1) > COL || linearFlag) {
-          j = j + (long)strlen(str1);
-          k = k + (long)strlen(str1) - COL;
-          print2(str1);
-        } else {
-          if (k == 0) {
-            j = j + COL;
-            print2("%s%s",str1,space(COL - (long)strlen(str1)));
-          } else {
-            k = k - (COL - (long)strlen(str1));
-            if (k > 0) {
-              print2(str1);
-              j = j + (long)strlen(str1);
-            } else {
-              print2("%s%s",str1,space(COL - (long)strlen(str1)));
-              j = j + COL;
-              k = 0;
-            }
-          }
-        }
-        */
-
       } /* next i */
-      /* print2("\n"); */
       if (str2[0]) {
         print2("%s\n", str2);
         let(&str2, "");
@@ -2857,14 +2651,12 @@ void command(int argc, char *argv[])
       continue;
     }
 
-    if (cmdMatches("SHOW DISCOURAGED")) {  /* was SHOW RESTRICTED */
-      showDiscouraged(); /* In mmcmds.c */
+    if (cmdMatches("SHOW DISCOURAGED")) {
+      showDiscouraged();
       continue;
     }
 
     if (cmdMatches("SHOW SOURCE")) {
-
-      /* 14-Sep-2012 nm */
       /* Currently, SHOW SOURCE only handles one statement at a time,
          so use getStatementNum().  Eventually, SHOW SOURCE may become
          obsolete; I don't think anyone uses it. */
@@ -2882,22 +2674,8 @@ void command(int argc, char *argv[])
       }
       g_showStatement = s; /* Update for future defaults */
 
-      /*********** 14-Sep-2012 replaced by getStatementNum()
-      for (i = 1; i <= g_statements; i++) {
-        if (!strcmp(g_fullArg[2],g_Statement[i].labelName)) break;
-      }
-      if (i > g_statements) {
-        printLongLine(cat("?There is no statement with label \"",
-            g_fullArg[2], "\".  ",
-            "Use SHOW LABELS for a list of valid labels.", NULL), "", " ");
-        g_showStatement = 0;
-        continue;
-      }
-      g_showStatement = i;
-      ************** end 14-Sep-2012 *******/
-
       let(&str1, "");
-      str1 = outputStatement(g_showStatement, /*0, 3-May-2017 */ /* cleanFlag */
+      str1 = outputStatement(g_showStatement, /* cleanFlag */
           0 /* reformatFlag */);
       let(&str1,edit(str1,128)); /* Trim trailing spaces */
       if (str1[strlen(str1)-1] == '\n') let(&str1, left(str1,
@@ -2917,9 +2695,7 @@ void command(int argc, char *argv[])
          statement, a .html file is opened, the statement is output,
          and depending on statement type a proof or other information
          is output. */
-      /* if (g_rawArgs != 5) { */  /* obsolete */
 
-      /* 16-Aug-2016 nm */
       noVersioning = (switchPos("/ NO_VERSIONING") != 0);
       i = 5;  /* # arguments with only / HTML or / ALT_HTML */
       if (noVersioning) i = i + 2;
@@ -2930,34 +2706,12 @@ void command(int argc, char *argv[])
         continue;
       }
 
-      /* 16-Aug-2016 nm */
       printTime = 0;
       if (switchPos("/ TIME") != 0) {
         printTime = 1;
       }
 
-      /*** 17-Nov-2014 nm This restriction has been removed.
-      if (g_texDefsRead) {
-        /@ Current limitation - can only read def's from .mm file once @/
-        if (!g_htmlFlag) {
-          print2("?You cannot use both LaTeX and HTML in the same session.\n");
-          print2(
-              "You must EXIT and restart Metamath to switch to the other.\n");
-          goto htmlDone;
-        } else {
-          if ((switchPos("/ ALT_HTML") || switchPos("/ BRIEF_ALT_HTML"))
-              == (g_altHtmlFlag == 0)) {
-            print2(
-              "?You cannot use both HTML and ALT_HTML in the same session.\n");
-            print2(
-              "You must EXIT and restart Metamath to switch to the other.\n");
-            goto htmlDone;
-          }
-        }
-      }
-      *** End 17-Nov-2014 deletion */
-
-      g_htmlFlag = 1; /* 17-Nov-2015 nm */
+      g_htmlFlag = 1;
 
       if (switchPos("/ BRIEF_HTML") || switchPos("/ BRIEF_ALT_HTML")) {
         if (strcmp(g_fullArg[2], "*")) {
@@ -2988,9 +2742,7 @@ void command(int argc, char *argv[])
          statement label); with
                  SHOW STATEMENT ?* / HTML
          all statements will be output, but without mmascii.html etc. */
-      /* if (instr(1, g_fullArg[2], "*") || g_briefHtmlFlag) { */  /* obsolete */
       if (((char *)(g_fullArg[2]))[0] == '*' || g_briefHtmlFlag) {
-                                                            /* 6-Jul-2008 nm */
         s = -2; /* -2 is for ASCII table; -1 is for theorems;
                     0 is for definitions */
       } else {
@@ -3010,7 +2762,6 @@ void command(int argc, char *argv[])
 
         if (s > 0) {
           if (!g_Statement[s].labelName[0]) continue; /* No label */
-          /* 30-Jan-06 nm Added single-character-match wildcard argument */
           if (!matchesList(g_Statement[s].labelName, g_fullArg[2], '*', '?'))
             continue;
           if (g_Statement[s].type != (char)a_
@@ -3048,19 +2799,7 @@ void command(int argc, char *argv[])
                 NULL));
         }
         print2("Creating HTML file \"%s\"...\n", g_texFileName);
-        g_texFilePtr = fSafeOpen(g_texFileName, "w",    /* 17-Jul-2019 nm */
-            noVersioning /*noVersioningFlag*/);
-        /****** old code before 17-Jul-2019 *******
-        if (switchPos("/ NO_VERSIONING") == 0) {
-          g_texFilePtr = fSafeOpen(g_texFileName, "w", 0/@noVersioningFlag@/);
-        } else {
-          /@ 6-Jul-2008 nm Added / NO_VERSIONING @/
-          /@ Don't create the backup versions ~1, ~2,... @/
-          g_texFilePtr = fopen(g_texFileName, "w");
-          if (!g_texFilePtr) print2("?Could not open the file \"%s\".\n",
-              g_texFileName);
-        }
-        ********* end of old code before 17-Jul-2019 *******/
+        g_texFilePtr = fSafeOpen(g_texFileName, "w", noVersioning);
         if (!g_texFilePtr) goto htmlDone; /* Couldn't open it (err msg was
             provided) */
         g_texFileOpenFlag = 1;
@@ -3111,7 +2850,6 @@ void command(int argc, char *argv[])
               break;
             case 0:
               printLongLine(cat(
-/*"<CAPTION><B>List of Syntax (not <FONT COLOR=\"#00CC00\">|-&nbsp;</FONT>), ",*/
                   /* 2/9/02 (in case |- suppressed) */
                   "<CAPTION><B>List of Syntax, ",
                   "Axioms (<FONT COLOR=", GREEN_TITLE_COLOR, ">ax-</FONT>) and",
@@ -3138,24 +2876,8 @@ void command(int argc, char *argv[])
           print2("</B></TD></TR>\n");
           m = 0; /* Statement number map */
           let(&str3, ""); /* For storing ASCII token list in s=-2 mode */
-          let(&bgcolor, MINT_BACKGROUND_COLOR); /* 8-Aug-2008 nm Initialize */
+          let(&bgcolor, MINT_BACKGROUND_COLOR);
           for (i = 1; i <= g_statements; i++) {
-
-            /* 8-Aug-2008 nm Commented out: */
-            /*
-            if (i == g_extHtmlStmt && s != -2) {
-              / * Print a row that identifies the start of the extended
-                 database (e.g. Hilbert Space Explorer) * /
-              printLongLine(cat(
-                  "<TR><TD COLSPAN=2 ALIGN=CENTER><A NAME=\"startext\"></A>",
-                  "The list of syntax, axioms (ax-) and definitions (df-) for",
-                  " the <B><FONT COLOR=", GREEN_TITLE_COLOR, ">",
-                  g_extHtmlTitle,
-                  "</FONT></B> starts here</TD></TR>", NULL), "", "\"");
-            }
-            */
-
-            /* 8-Aug-2008 nm */
             if (s != -2 && (i == g_extHtmlStmt || i == g_mathboxStmt)) {
               /* Print a row that identifies the start of the extended
                  database (e.g. Hilbert Space Explorer) or the user
@@ -3171,8 +2893,6 @@ void command(int argc, char *argv[])
                   " the <B><FONT COLOR=", GREEN_TITLE_COLOR, ">",
                   (i == g_extHtmlStmt) ?
                     g_extHtmlTitle :
-                    /*"User Sandboxes",*/
-                    /* 24-Jul-2009 nm Changed name of sandbox to "mathbox" */
                     "User Mathboxes",
                   "</FONT></B> starts here</TD></TR>", NULL), "", "\"");
             }
@@ -3220,9 +2940,8 @@ void command(int argc, char *argv[])
                     } /* next k */
                     printLongLine(cat("<TR ALIGN=LEFT><TD>",
                         (g_altHtmlFlag ? cat("<SPAN ", g_htmlFont, ">", NULL) : ""),
-                                                           /* 14-Jan-2016 nm */
                         str2,
-                        (g_altHtmlFlag ? "</SPAN>" : ""),    /* 14-Jan-2016 nm */
+                        (g_altHtmlFlag ? "</SPAN>" : ""),
                         "&nbsp;", /* 10-Jan-2016 nm This will prevent a
                                      -4px shifted image from overlapping the
                                      lower border of the table cell */
@@ -3237,18 +2956,6 @@ void command(int argc, char *argv[])
                 break;
               case -1: /* Falls through to next case */
               case 0:
-                /* Count the number of essential hypotheses k */
-                /* Not needed anymore??? since getTexOrHtmlHypAndAssertion() */
-                /*
-                k = 0;
-                j = nmbrLen(g_Statement[i].reqHypList);
-                for (n = 0; n < j; n++) {
-                  if (g_Statement[g_Statement[i].reqHypList[n]].type
-                      == (char)e_) {
-                    k++;
-                  }
-                }
-                */
                 let(&str1, "");
                 if (s == 0 || g_briefHtmlFlag) {
                   let(&str1, "");
@@ -3258,8 +2965,6 @@ void command(int argc, char *argv[])
                   let(&str1, cat(str1, "</TD></TR>", NULL));
                 }
 
-                /* 13-Oct-2006 nm Made some changes to BRIEF_HTML/_ALT_HTML
-                   to use its mmtheoremsall.html output for the Palm PDA */
                 if (g_briefHtmlFlag) {
                   /* Get page number in mmtheorems*.html of WRITE THEOREMS */
                   k = ((g_Statement[i].pinkNumber - 1) /
@@ -3285,7 +2990,6 @@ void command(int argc, char *argv[])
                       "</A>", str4, NULL));
                   let(&str1, cat(str2, "</TD><TD>", str1, NULL));
                 }
-                /* End of 13-Oct-2006 changed section */
 
                 print2("\n");  /* New line for HTML source readability */
                 printLongLine(str1, "", "\"");
@@ -3313,14 +3017,11 @@ void command(int argc, char *argv[])
                 break;
             } /* end switch */
           } /* next i (statement number) */
-          /* print2("</TABLE></CENTER>\n"); */ /* 8/8/03 Removed - already
-              done somewhere else, causing validator.w3.org to fail */
           g_outputToString = 0;  /* closing will write out the string */
           let(&bgcolor, ""); /* Deallocate (to improve fragmentation) */
 
         } else { /* s > 0 */
 
-          /* 16-Aug-2016 nm */
           if (printTime == 1) {
             getRunTime(&timeIncr);  /* This call just resets the time */
           }
@@ -3332,7 +3033,6 @@ void command(int argc, char *argv[])
               1 /*texFlag*/,   /* means latex or html */
               1 /*g_htmlFlag*/);
 
-          /* 16-Aug-2016 nm */
           if (printTime == 1) {
             getRunTime(&timeIncr);
             print2("SHOW STATEMENT run time = %6.2f sec for \"%s\"\n",
@@ -3366,42 +3066,8 @@ void command(int argc, char *argv[])
     } /* if (cmdMatches("SHOW STATEMENT") && switchPos("/ HTML")...) */
 
 
-    /******* Section for / MNEMONICS added 12-May-2009 by Stefan Allan *****/
     /* Write mnemosyne.txt */
     if (cmdMatches("SHOW STATEMENT") && switchPos("/ MNEMONICS")) {
-
-      /*** 17-Nov-2015 nm Deleted - removed g_htmlFlag, g_altHtmlFlag
-            change prohibition
-      if (!g_texDefsRead) {
-        g_htmlFlag = 1;     /@ Use HTML, not TeX section @/
-        g_altHtmlFlag = 1;  /@ Use Unicode, not GIF @/
-        print2("Reading definitions from $t statement of %s...\n", g_input_fn);
-        if (2/@error@/ == readTexDefs(0 /@ 1 = check errors only @/,
-            0 /@ 1 = no GIF file existence check @/  )) {
-          print2(
-          "?There was an error in the $t comment's LaTeX/HTML definitions.\n");
-          print2("?HTML generation was aborted due to the error above.\n");
-          continue; /@ An error occurred @/
-        }
-      } else {
-        /@ Current limitation - can only read def's from .mm file once @/
-        if (!g_htmlFlag) {
-          print2("?You cannot use both LaTeX and HTML in the same session.\n");
-          print2(
-              "You must EXIT and restart Metamath to switch to the other.\n");
-          continue;
-        } else {
-          if (!g_altHtmlFlag) {
-            print2(
-              "?You cannot use both HTML and ALT_HTML in the same session.\n");
-            print2(
-              "You must EXIT and restart Metamath to switch to the other.\n");
-            continue;
-          }
-        }
-      }
-      *** end of 17-Nov-2015 deletion */
-
       g_htmlFlag = 1;     /* Use HTML, not TeX section */
       g_altHtmlFlag = 1;  /* Use Unicode, not GIF */
       /* readTexDefs() rereads based on changes to g_htmlFlag, g_altHtmlFlag */
@@ -3420,14 +3086,8 @@ void command(int argc, char *argv[])
 
       for (s = 1; s <= g_statements; s++) {
         g_showStatement = s;
-/*
-        if (strcmp("|-", g_MathToken[
-         (g_Statement[g_showStatement].mathString)[0]].tokenName)) {
-           subType = SYNTAX;
-        }
-*/
+
         if (!g_Statement[s].labelName[0]) continue; /* No label */
-        /* 30-Jan-06 nm Added single-character-match wildcard argument */
         if (!matchesList(g_Statement[s].labelName, g_fullArg[2], '*', '?'))
           continue;
         if (g_Statement[s].type != (char)a_
@@ -3493,14 +3153,12 @@ void command(int argc, char *argv[])
 
       continue;
     } /* if (cmdMatches("SHOW STATEMENT") && switchPos("/ MNEMONICS")) */
-    /** End of section for / MNEMONICS added 12-May-2009 by Stefan Allan *****/
 
     /* If we get here, the user did not specify one of the qualifiers /HTML,
        /BRIEF_HTML, /ALT_HTML, or /BRIEF_ALT_HTML */
     if (cmdMatches("SHOW STATEMENT") && !switchPos("/ HTML")) {
 
       texFlag = 0;
-      /* 14-Sep-2010 nm Added OLD_TEX */
       if (switchPos("/ TEX") || switchPos("/ OLD_TEX")
           || switchPos("/ HTML"))
         texFlag = 1;
@@ -3508,7 +3166,6 @@ void command(int argc, char *argv[])
       briefFlag = 1;
       g_oldTexFlag = 0;
       if (switchPos("/ TEX")) briefFlag = 0;
-      /* 14-Sep-2010 nm Added OLD_TEX */
       if (switchPos("/ OLD_TEX")) briefFlag = 0;
       if (switchPos("/ OLD_TEX")) g_oldTexFlag = 1;
       if (switchPos("/ FULL")) briefFlag = 0;
@@ -3544,14 +3201,12 @@ void command(int argc, char *argv[])
       for (s = 1; s <= g_statements; s++) {
         if (!g_Statement[s].labelName[0]) continue; /* No label */
         /* We are not in MM-PA mode, or the statement isn't "=" */
-        /* 30-Jan-06 nm Added single-character-match wildcard argument */
         if (!matchesList(g_Statement[s].labelName, g_fullArg[2], '*', '?'))
           continue;
 
         if (briefFlag || commentOnlyFlag || texFlag) {
           /* For brief or comment qualifier, if label has wildcards,
              show only $p and $a's */
-          /* 30-Jan-06 nm Added single-character-match wildcard argument */
           if (g_Statement[s].type != (char)p_
               && g_Statement[s].type != (char)a_ && (instr(1, g_fullArg[2], "*")
                   || instr(1, g_fullArg[2], "?")))
@@ -3559,7 +3214,6 @@ void command(int argc, char *argv[])
         }
 
         if (q && !texFlag) {
-          /* 17-Jul-2019 nm Changed "79" to "g_screenWidth" */
           if (!print2("%s\n", string(g_screenWidth, '-'))) /* Put line between
                                                    statements */
             break; /* Break for speedup if user quit */
@@ -3589,7 +3243,6 @@ void command(int argc, char *argv[])
 
       if (texFlag && !g_htmlFlag) {
         print2("The LaTeX source was written to \"%s\".\n", g_texFileName);
-        /* 14-Sep-2010 nm Added OLD_TEX */
         g_oldTexFlag = 0;
       }
       continue;
@@ -3663,13 +3316,11 @@ void command(int argc, char *argv[])
         print2("The %s file \"%s\" is open.\n", g_htmlFlag ? "HTML" : "LaTeX",
             g_texFileName);
       }
-      /* 17-Nov-2015 nm */
       print2(
   "(SHOW STATEMENT.../[TEX,HTML,ALT_HTML]) Current output mode is %s.\n",
           g_htmlFlag
              ? (g_altHtmlFlag ? "ALT_HTML" : "HTML")
              : "TEX (LaTeX)");
-      /* 21-Jun-2014 */
       print2("The program is compiled for a %ld-bit CPU.\n",
           (long)(8 * sizeof(long)));
       print2(
@@ -3680,7 +3331,6 @@ void command(int argc, char *argv[])
     }
 
     if (cmdMatches("SHOW MEMORY")) {
-      /*print2("%ld bytes of data memory have been used.\n",db+db3);*/
       j = 32000000; /* The largest we'ed ever look for */
       i = getFreeSpace(j);
       if (i > j-3) {
@@ -3691,7 +3341,6 @@ void command(int argc, char *argv[])
       continue;
     }
 
-    /* 21-Jun-2014 */
     if (cmdMatches("SHOW ELAPSED_TIME")) {
       timeTotal = getRunTime(&timeIncr);
       print2(
@@ -3702,21 +3351,6 @@ void command(int argc, char *argv[])
 
 
     if (cmdMatches("SHOW TRACE_BACK")) {
-
-
-      /* Pre-21-May-2008
-        for (i = 1; i <= g_statements; i++) {
-          if (!strcmp(g_fullArg[2],g_Statement[i].labelName)) break;
-        }
-        if (i > g_statements) {
-          printLongLine(cat("?There is no statement with label \"",
-              g_fullArg[2], "\".  ",
-              "Use SHOW LABELS for a list of valid labels.", NULL), "", " ");
-          g_showStatement = 0;
-          continue;
-        }
-       */
-
       essentialFlag = 0;
       axiomFlag = 0;
       endIndent = 0;
@@ -3729,7 +3363,6 @@ void command(int argc, char *argv[])
       i = switchPos("/ DEPTH"); /* Limit depth of printout */
       if (i) endIndent = (long)val(g_fullArg[i + 1]);
 
-       /* 19-May-2013 nm */
       i = switchPos("/ COUNT_STEPS");
       countStepsFlag = (i != 0 ? 1 : 0);
       i = switchPos("/ TREE");
@@ -3773,7 +3406,6 @@ void command(int argc, char *argv[])
         }
       }
 
-      /* 21-May-2008 nm Added wildcard handling */
       g_showStatement = 0;
       for (i = 1; i <= g_statements; i++) {
         if (g_Statement[i].type != (char)p_)
@@ -3783,36 +3415,7 @@ void command(int argc, char *argv[])
           continue;
 
         g_showStatement = i;
-        /*** start of 19-May-2013 deletion
-        j = switchPos("/ TREE");
-        if (j) {
-          if (axiomFlag) {
-            print2(
-                "(Note:  The AXIOMS switch is ignored in TREE mode.)\n");
-          }
-          if (switchPos("/ COUNT_STEPS")) {
-            print2(
-                "(Note:  The COUNT_STEPS switch is ignored in TREE mode.)\n");
-          }
-          traceProofTree(g_showStatement, essentialFlag, endIndent);
-        } else {
-          if (endIndent != 0) {
-           print2(
-"(Note:  The DEPTH is ignored if the TREE switch is not used.)\n");
-          }
 
-          j = switchPos("/ COUNT_STEPS");
-          if (j) {
-            countSteps(g_showStatement, essentialFlag);
-          } else {
-            traceProof(g_showStatement, essentialFlag, axiomFlag);
-          }
-        }
-        *** end of 19-May-2013 deletion */
-
-
-        /* 19-May-2013 nm - move /TREE and /COUNT_STEPS to outside loop,
-           assigning new variables, for cleaner code. */
         if (treeFlag) {
           traceProofTree(g_showStatement, essentialFlag, endIndent);
         } else {
@@ -3828,7 +3431,6 @@ void command(int argc, char *argv[])
           }
         }
 
-      /* 21-May-2008 nm Added wildcard handling */
       } /* next i */
       if (g_showStatement == 0) {
         printLongLine(cat("?There are no $p labels matching \"",
@@ -3844,7 +3446,6 @@ void command(int argc, char *argv[])
 
     if (cmdMatches("SHOW USAGE")) {
 
-      /* 7-Jan-2008 nm Added / ALL qualifier */
       if (switchPos("/ ALL")) {
         m = 1;  /* Always include $e, $f statements */
       } else {
@@ -3852,9 +3453,7 @@ void command(int argc, char *argv[])
       }
 
       g_showStatement = 0;
-      for (i = 1; i <= g_statements; i++) { /* 7-Jan-2008 */
-
-        /* 7-Jan-2008 nm Added wildcard handling */
+      for (i = 1; i <= g_statements; i++) {
         if (!g_Statement[i].labelName[0]) continue; /* No label */
         if (!m && g_Statement[i].type != (char)p_ &&
             g_Statement[i].type != (char)a_
@@ -3879,51 +3478,6 @@ void command(int argc, char *argv[])
             recursiveFlag,
             0 /* cutoffStmt */);
 
-
-
-        /************* 18-Jul-2015 nm Start of deleted code ************/
-        /*
-        /@ Count the number of statements = # of spaces @/
-        k = (long)strlen(str1) - (long)strlen(edit(str1, 2));
-
-        if (!k) {
-          printLongLine(cat("Statement \"",
-              g_Statement[g_showStatement].labelName,
-              "\" is not referenced in the proof of any statement.", NULL),
-              "", " ");
-        } else {
-          if (recursiveFlag) {
-            let(&str2, "\" directly or indirectly affects");
-          } else {
-            let(&str2, "\" is directly referenced in");
-          }
-          if (k == 1) {
-            printLongLine(cat("Statement \"",
-                g_Statement[g_showStatement].labelName,
-                str2, " the proof of ",
-                str((double)k), " statement:", NULL), "", " ");
-          } else {
-            printLongLine(cat("Statement \"",
-                g_Statement[g_showStatement].labelName,
-                str2, " the proofs of ",
-                str((double)k), " statements:", NULL), "", " ");
-          }
-        }
-
-        if (k) {
-          let(&str1, cat(" ", str1, NULL));
-        } else {
-          let(&str1, "  (None)");
-        }
-
-        /@ Print the output @/
-        printLongLine(str1, "  ", " ");
-        */
-        /********* 18-Jul-2015 nm End of deleted code ****************/
-
-
-        /************* 18-Jul-2015 nm Start of new code ************/
-        /* 18-Jul-2015 nm */
         /* str1[0] will be 'Y' or 'N' depending on whether there are any
            statements.  str1[i] will be 'Y' or 'N' depending on whether
            g_Statement[i] uses g_showStatement. */
@@ -3986,9 +3540,6 @@ void command(int argc, char *argv[])
         } else {
           print2("  (None)\n");
         } /* if (k != 0) */
-        /********* 18-Jul-2015 nm End of new code ****************/
-
-
       } /* next i (statement matching wildcard list) */
 
       if (g_showStatement == 0) {
@@ -4010,7 +3561,6 @@ void command(int argc, char *argv[])
         continue;
       }
 
-      /* 3-May-2016 nm */
       if (cmdMatches("SAVE NEW_PROOF")
           && getMarkupFlag(g_proveStatement, PROOF_DISCOURAGED)) {
         if (switchPos("/ OVERRIDE") == 0 && g_globalDiscouragement == 1) {
@@ -4040,13 +3590,11 @@ void command(int argc, char *argv[])
         saveFlag = 1; /* The command is SAVE PROOF */
       }
 
-      /* 16-Aug-2016 nm */
       printTime = 0;
       if (switchPos("/ TIME") != 0) {  /* / TIME legal in SAVE mode only */
         printTime = 1;
       }
 
-      /* 27-Dec-2013 nm */
       i = switchPos("/ OLD_COMPRESSION");
       if (i) {
         if (!switchPos("/ COMPRESSED")) {
@@ -4055,7 +3603,6 @@ void command(int argc, char *argv[])
         }
       }
 
-      /* 2-Mar-2016 nm */
       i = switchPos("/ FAST");
       if (i) {
         if (!switchPos("/ COMPRESSED") && !switchPos("/ PACKED")) {
@@ -4067,7 +3614,6 @@ void command(int argc, char *argv[])
         fastFlag = 0;
       }
 
-      /* 2-Mar-2016 nm */
       if (switchPos("/ EXPLICIT")) {
         if (switchPos("/ COMPRESSED")) {
           print2("?/ COMPRESSED and / EXPLICIT may not be used together.\n");
@@ -4088,10 +3634,8 @@ void command(int argc, char *argv[])
       /* Establish defaults for omitted qualifiers */
       startStep = 0;
       endStep = 0;
-      /* startIndent = 0; */ /* Not used */
       endIndent = 0;
-      /*essentialFlag = 0;*/
-      essentialFlag = 1; /* 10/9/99 - friendlier default */
+      essentialFlag = 1;
       renumberFlag = 0;
       unknownFlag = 0;
       notUnifiedFlag = 0;
@@ -4099,7 +3643,7 @@ void command(int argc, char *argv[])
       detailStep = 0;
       noIndentFlag = 0;
       splitColumn = DEFAULT_COLUMN;
-      skipRepeatedSteps = 0; /* 28-Jun-2013 nm */
+      skipRepeatedSteps = 0;
       texFlag = 0;
 
       i = switchPos("/ FROM_STEP");
@@ -4108,12 +3652,6 @@ void command(int argc, char *argv[])
       if (i) endStep = (long)val(g_fullArg[i + 1]);
       i = switchPos("/ DEPTH");
       if (i) endIndent = (long)val(g_fullArg[i + 1]);
-      /* 10/9/99 - ESSENTIAL is retained for downwards compatibility, but is
-         now the default, so we ignore it. */
-      /*
-      i = switchPos("/ ESSENTIAL");
-      if (i) essentialFlag = 1;
-      */
       i = switchPos("/ ALL");
       if (i) essentialFlag = 0;
       if (i && switchPos("/ ESSENTIAL")) {
@@ -4132,10 +3670,9 @@ void command(int argc, char *argv[])
       if (i) noIndentFlag = 1;
       i = switchPos("/ START_COLUMN");
       if (i) splitColumn = (long)val(g_fullArg[i + 1]);
-      i = switchPos("/ NO_REPEATED_STEPS"); /* 28-Jun-2013 nm */
-      if (i) skipRepeatedSteps = 1;         /* 28-Jun-2013 nm */
+      i = switchPos("/ NO_REPEATED_STEPS");
+      if (i) skipRepeatedSteps = 1;
 
-      /* 8-Dec-2018 nm */
       /* If NO_REPEATED_STEPS is specified, indentation (tree) mode will be
          misleading because a hypothesis assignment will be suppressed if the
          same assignment occurred earlier, i.e. it is no longer a "tree". */
@@ -4145,15 +3682,13 @@ void command(int argc, char *argv[])
       }
 
       i = switchPos("/ TEX") || switchPos("/ HTML")
-          /* 14-Sep-2010 nm Added OLDE_TEX */
           || switchPos("/ OLD_TEX");
       if (i) texFlag = 1;
 
-      /* 14-Sep-2010 nm Added OLD_TEX */
       g_oldTexFlag = 0;
       if (switchPos("/ OLD_TEX")) g_oldTexFlag = 1;
 
-      if (cmdMatches("MIDI")) { /* 8/28/00 */
+      if (cmdMatches("MIDI")) {
         g_midiFlag = 1;
         pipFlag = 0;
         saveFlag = 0;
@@ -4178,10 +3713,6 @@ void command(int argc, char *argv[])
               g_htmlFlag ? "HTML" : "TEX");
           continue;
         }
-        /**** this is now done after outputting
-        print2("The %s source was written to \"%s\".\n",
-            g_htmlFlag ? "HTML" : "LaTeX", g_texFileName);
-        */
       }
 
       i = switchPos("/ DETAILED_STEP"); /* non-pip mode only */
@@ -4193,7 +3724,6 @@ void command(int argc, char *argv[])
 
 /*??? Need better warnings for switch combinations that don't make sense */
 
-      /* 2-Jan-2017 nm */
       /* Print a single message for "/compressed/fast" */
       if (switchPos("/ COMPRESSED") && fastFlag
           && !strcmp("*", labelMatch)) {
@@ -4210,7 +3740,6 @@ void command(int argc, char *argv[])
         /* If !pipFlag, get the next statement: */
         if (!pipFlag) {
           if (g_Statement[stmt].type != (char)p_) continue; /* Not $p */
-          /* 30-Jan-06 nm Added single-character-match wildcard argument */
           if (!matchesList(g_Statement[stmt].labelName, labelMatch, '*', '?'))
             continue;
           g_showStatement = stmt;
@@ -4230,7 +3759,6 @@ void command(int argc, char *argv[])
           continue;
         }
 
-        /* 21-Jun-2014 */
         if (switchPos("/ SIZE")) { /* non-pip mode only */
           /* Just print the size of the stored proof and continue */
           let(&str1, space(g_Statement[g_showStatement].proofSectionLen));
@@ -4254,7 +3782,6 @@ void command(int argc, char *argv[])
             switchPos("/ COMPRESSED") || switchPos("/ EXPLICIT") || saveFlag) {
           /*??? Add error msg if other switches were specified. (Ignore them.)*/
 
-          /* 16-Aug-2016 nm */
           if (saveFlag) {
             if (printTime == 1) {
               getRunTime(&timeIncr);  /* This call just resets the time */
@@ -4274,16 +3801,14 @@ void command(int argc, char *argv[])
 
           if (!pipFlag) {
             parseProof(g_showStatement);  /* Prints message if severe error */
-            if (g_WrkProof.errorSeverity > 1) {  /* 21-Aug-04 nm */
-                              /* Prevent bugtrap in nmbrSquishProof -> */
-                              /* nmbrGetSubProofLen if proof corrupted */
+            if (g_WrkProof.errorSeverity > 1) {
+              /* Prevent bugtrap in nmbrSquishProof -> nmbrGetSubProofLen
+                 if proof corrupted */
               print2(
           "?The proof has a severe error and cannot be displayed or saved.\n");
               continue;
             }
-            /* verifyProof(g_showStatement); */ /* Not necessary */
-            if (fastFlag) { /* 2-Mar-2016 nm */
-              /* 2-Mar-2016 nm */
+            if (fastFlag) {
               /* Use the proof as is */
               nmbrLet(&nmbrSaveProof, g_WrkProof.proofString);
             } else {
@@ -4294,7 +3819,7 @@ void command(int argc, char *argv[])
             nmbrLet(&nmbrSaveProof, g_ProofInProgress.proof);
           }
           if (switchPos("/ PACKED")  || switchPos("/ COMPRESSED")) {
-            if (!fastFlag) { /* 2-Mar-2016 nm */
+            if (!fastFlag) {
               nmbrLet(&nmbrSaveProof, nmbrSquishProof(nmbrSaveProof));
             }
           }
@@ -4302,12 +3827,10 @@ void command(int argc, char *argv[])
           if (switchPos("/ COMPRESSED")) {
             let(&str1, compressProof(nmbrSaveProof,
                 outStatement, /* g_showStatement or g_proveStatement based on pipFlag */
-                (switchPos("/ OLD_COMPRESSION")) ? 1 : 0  /* 27-Dec-2013 nm */
-                ));
+                (switchPos("/ OLD_COMPRESSION")) ? 1 : 0));
           } else {
             let(&str1, nmbrCvtRToVString(nmbrSaveProof,
-                /* 25-Jan-2016 nm */
-                explicitTargets, /*explicitTargets*/
+                explicitTargets,
                 outStatement /*statemNum, used only if explicitTargets*/));
           }
 
@@ -4326,9 +3849,6 @@ void command(int argc, char *argv[])
               break; /* Break for speedup if user quit */
             print2(
 "---------Clip out the proof below this line to put it in the source file:\n");
-            /* 19-Apr-2015 so */
-            /* 24-Apr-2015 nm Reverted */
-            /*print2("\n");*/ /* Add a blank line to make clipping easier */
           }
           if (switchPos("/ COMPRESSED")) {
             printLongLine(cat(space(indentation), str1, " $.", NULL),
@@ -4339,26 +3859,17 @@ void command(int argc, char *argv[])
               space(indentation), " ");
           }
 
-          /* 24-Apr-2015 nm */
           l = (long)(strlen(str1)); /* Save length for printout below */
 
-          /* 3-May-2017 nm Rewrote the if block below */
-          /* 12-Jun-2011 nm Removed pipFlag condition so that a date
-             stamp will always be created if it doesn't exist */
-          if /*(pipFlag)*/ (1  /* Add the date proof was created */
-              /* 19-Apr-2015 so */
-              /* SOREAR Only generate date if the proof looks complete.
-                 This is not intended as a grading mechanism, just trying
-                 to avoid premature output */
-              && !nmbrElementIn(1, nmbrSaveProof, -(long)'?')) {
-
-            /* 3-May-2017 nm */
+          /* SOREAR Only generate date if the proof looks complete.
+            This is not intended as a grading mechanism, just trying
+            to avoid premature output */
+          if (!nmbrElementIn(1, nmbrSaveProof, -(long)'?')) {
             /* Add a "(Contributed by...)" date if it isn't there */
             let(&str2, "");
             str2 = getContrib(outStatement, CONTRIBUTOR);
             if (str2[0] == 0) { /* The is no contributor, so add one */
 
-              /* 14-May-2017 nm */
               /* See if there is a date below the proof (for converting old
                  .mm files).  Someday this will be obsolete, with str3 and
                  str4 always returned as "". */
@@ -4374,9 +3885,8 @@ void command(int argc, char *argv[])
               /* If there is no date below proof, use today's date */
               if (str3[0] == 0) let(&str3, date());
               let(&str4, cat("\n", space(indentation + 1),
-                  /*"(Contributed by ?who?, ", date(), ".) ", NULL));*/
                   "(Contributed by ", g_contributorName,
-                      ", ", str3, ".) ", NULL)); /* 14-May-2017 nm */
+                      ", ", str3, ".) ", NULL));
               /* If there is a 2nd date below proof, add a "(Revised by..."
                  tag */
               if (str5[0] != 0) {
@@ -4387,7 +3897,7 @@ void command(int argc, char *argv[])
                    a reviser. */
                 let(&str4, cat(str4, "\n", space(indentation + 1),
                     "(Revised by ", DEFAULT_CONTRIBUTOR,
-                        ", ", str5, ".) ", NULL)); /* 15-May-2017 nm */
+                        ", ", str5, ".) ", NULL));
               }
 
               let(&str3, space(g_Statement[outStatement].labelSectionLen));
@@ -4421,77 +3931,7 @@ void command(int argc, char *argv[])
                 str3 = getContrib(outStatement, GC_RESET_STMT);
               } /* if i != 0 */
             } /* if str2[0] == 0 */
-
-            /* At this point, str4 contains the "$( [date] $)" comment
-               if it would have been added to the saved proof, for use
-               by "show proof" */
-
-
-            /********* deleted 3-May-2017 - date below proof is obsolete
-            /@ 12-Jun-2011 nm Removed pipFlag condition so that a date
-               stamp will always be created if it doesn't exist @/
-            if ( /@ pipFlag && @/ !instr(1, str2, "$([")
-                /@ 7-Sep-04 Allow both "$([<date>])$" and "$( [<date>] )$" @/
-                /@ 19-Apr-2015 so @/
-                /@ SOREAR Only generate date if the proof looks complete.
-                   This is not intended as a grading mechanism, just trying
-                   to avoid premature output @/
-                && !nmbrElementIn(1, nmbrSaveProof, -(long)'?')
-                && !instr(1, str2, "$( [")) {
-            /@ 6/13/98 end @/
-              /@ No date stamp existed before.  Create one for today's
-                 date.  Note that the characters after "$." at the end of
-                 the proof normally go in the labelSection of the next
-                 statement, but a special mode in outputStatement() (in
-                 mmpars.c) will output the date stamp characters for a saved
-                 proof. @/
-              /@ print2("%s$([%s]$)\n", space(indentation), date()); @/
-              /@ 4/23/04 nm Initialize with a "?" date followed by today's
-                 date.  The "?" date can be edited by the user when the
-                 proof is becomes "official." @/
-              /@print2("%s$([?]$) $([%s]$)\n", space(indentation), date());@/
-              /@ 7-Sep-04 Put space around "[<date>]" @/
-              /@print2("%s$( [?] $) $( [%s] $)\n", space(indentation), date());@/
-              /@ 30-Nov-2013 remove the unknown date placeholder @/
-              print2("%s$( [%s] $)\n", space(indentation), date());
-            } else {
-              if (saveFlag && (instr(1, str2, "$([")
-                  /@ 7-Sep-04 Allow both "$([<date>])$" and "$( [<date>] )$" @/
-                  || instr(1, str2, "$( ["))) {
-                /@ An old date stamp existed, and we're saving the proof to
-                   the output file.  Make sure the indentation of the old
-                   date stamp (which exists in the labelSection of the
-                   next statement) matches the indentation of the saved
-                   proof.  To do this, we "delete" the indentation spaces
-                   on the old date in the labelSection of the next statement,
-                   and we put the actual required indentation spaces at
-                   the end of the saved proof.  This is done because the
-                   labelSectionPtr of the next statement does not point to
-                   an isolated string that can be allocated/deallocated but
-                   rather to a place in the input source buffer. @/
-                /@ Correct the indentation on old date @/
-                while ((g_Statement[outStatement + 1].labelSectionPtr)[0] !=
-                    '$') {
-                  /@ "Delete" spaces before old date (by moving source
-                     buffer pointer forward), and also "delete"
-                     the \n that comes before those spaces @/
-                  /@ If the proof is saved a 2nd time, this loop will
-                     not be entered because the pointer will already be
-                     at the "$". @/
-                  (g_Statement[outStatement + 1].labelSectionPtr)++;
-                  (g_Statement[outStatement + 1].labelSectionLen)--;
-                }
-                if (!g_outputToString) bug(1115);
-                /@ The final \n will not appear in final output (done in
-                   outputStatement() in mmpars.c) because the proofSectionLen
-                   below is adjusted to omit it.  This will allow the
-                   space(indentation) to appear before the old date without an
-                   intervening \n. @/
-                print2("%s\n", space(indentation));
-              }
-            }
-            ******** end of deletion 3-May-2017 ******/
-          } /* if / *(pipFlag)* / (1) */
+          } /* if (!nmbrElementIn(1, nmbrSaveProof, -(long)'?')) */
 
           if (saveFlag) {
             g_sourceChanged = 1;
@@ -4501,26 +3941,6 @@ void command(int argc, char *argv[])
               proofSavedFlag = 1; /* UNDO stack empty no longer reliably
                              indicates that proof hasn't changed */
             }
-
-            /******** deleted 3-May-2017 nm (before proofSectionChanged added)
-            /@ ASCII 1 is a flag that string was allocated and not part of
-               original source file text buffer @/
-            let(&g_printString, cat(chr(1), "\n", g_printString, NULL));
-            if (g_Statement[outStatement].proofSectionPtr[-1] == 1) {
-              /@ Deallocate old proof if not original source @/
-              let(&str1, ""); /@ Deallocate any previous str1 content @/
-              str1 = g_Statement[outStatement].proofSectionPtr - 1;
-              let(&str1, ""); /@ Deallocate the proof section @/
-            }
-            g_Statement[outStatement].proofSectionPtr = g_printString + 1;
-            /@ Subtr 1 char for ASCII 1 at beg, 1 char for "\n" at the end
-               (which is the first char of next statement's labelSection) @/
-            g_Statement[outStatement].proofSectionLen
-                = (long)strlen(g_printString) - 2;
-            /@ Reset g_printString without deallocating @/
-            g_printString = "";
-            g_outputToString = 0;
-            **********/
 
             /* 3-May-2017 nm */
             /* Add an initial \n which will go after the "$=" and the
@@ -4570,7 +3990,6 @@ void command(int argc, char *argv[])
                   NULL), "", " ");
             }
 
-            /* 16-Aug-2016 nm */
             if (printTime == 1) {
               getRunTime(&timeIncr);
               print2("SAVE PROOF run time = %6.2f sec for \"%s\"\n", timeIncr,
@@ -4578,8 +3997,6 @@ void command(int argc, char *argv[])
             }
 
           } else {
-            /* 19-Apr-2015 so */
-            /* 24-Apr-2015 nm Reverted */
             /*print2("\n");*/ /* Add a blank line to make clipping easier */
             print2(cat(
                 "---------The proof of \"", g_Statement[outStatement].labelName,
@@ -4619,25 +4036,8 @@ void command(int argc, char *argv[])
             }
           } else { /* g_htmlFlag */
             bug(1118);
-            /*???? The code below is obsolete - now down in show statement*/
-            /*
-            print2("<CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR=%s>\n",
-                MINT_BACKGROUND_COLOR);
-            print2("<CAPTION><B>Proof of Theorem <FONT\n");
-            printLongLine(cat("   COLOR=", GREEN_TITLE_COLOR, ">",
-                asciiToTt(g_Statement[outStatement].labelName),
-                "</FONT></B></CAPTION>", NULL), "", "\"");
-            print2(
-                "<TR><TD><B>Step</B></TD><TD><B>Hyp</B></TD><TD><B>Ref</B>\n");
-            print2("</TD><TD><B>Expression</B></TD></TR>\n");
-            */
           }
           g_outputToString = 0;
-          /* 8/26/99: Obsolete: */
-          /* printTexLongMath in typeProof will do this
-          fprintf(g_texFilePtr, "%s", g_printString);
-          let(&g_printString, "");
-          */
           /* 8/26/99: printTeXLongMath now clears g_printString in LaTeX
              mode before starting its output, so we must put out the
              g_printString ourselves here */
@@ -4646,7 +4046,6 @@ void command(int argc, char *argv[])
         } else { /* !texFlag */
           /* Terminal output - display the statement if wildcard is used */
           if (!pipFlag) {
-            /* 30-Jan-06 nm Added single-character-match wildcard argument */
             if (instr(1, labelMatch, "*") || instr(1, labelMatch, "?")) {
               if (!print2("Proof of \"%s\":\n", g_Statement[outStatement].labelName))
                 break; /* Break for speedup if user quit */
@@ -4665,7 +4064,6 @@ void command(int argc, char *argv[])
             endIndent,
             essentialFlag,
 
-            /* 1-May-2017 nm */
             /* In SHOW PROOF xxx /TEX, we use renumber steps mode so that
                the first step is step 1.  The step number is checked for
                step 1 in mmwtex.c to prevent a spurious \\ (newline) at the
@@ -4673,27 +4071,23 @@ void command(int argc, char *argv[])
                SHOW PROOF is not available in HTML mode, so texFlag will
                always mean LaTeX mode here. */
             (texFlag ? 1 : renumberFlag),
-            /*was: renumberFlag,*/
 
             unknownFlag,
             notUnifiedFlag,
             reverseFlag,
 
-            /* 1-May-2017 nm */
             /* In SHOW PROOF xxx /TEX, we use Lemmon mode so that the
                hypothesis reference list will be available.  Note that
                SHOW PROOF is not available in HTML mode, so texFlag will
                always mean LaTeX mode here. */
             (texFlag ? 1 : noIndentFlag),
-            /*was: noIndentFlag,*/
 
             splitColumn,
-            skipRepeatedSteps, /* 28-Jun-2013 nm */
+            skipRepeatedSteps,
             texFlag,
             g_htmlFlag);
         if (texFlag) {
           if (!g_htmlFlag) {
-            /* 14-Sep-2010 nm */
             if (!g_oldTexFlag) {
               g_outputToString = 1;
               print2("\\end{align}\n");
@@ -4713,26 +4107,20 @@ void command(int argc, char *argv[])
           }
         }
 
-        /*???CLEAN UP */
-        /*nmbrLet(&g_WrkProof.proofString, nmbrSaveProof);*/
-
         /*E*/ if (0) { /* for debugging: */
           printLongLine(nmbrCvtRToVString(g_WrkProof.proofString,
-                /* 25-Jan-2016 nm */
                 0, /*explicitTargets*/
                 0 /*statemNum, used only if explicitTargets*/)," "," ");
           print2("\n");
 
           nmbrLet(&nmbrSaveProof, nmbrSquishProof(g_WrkProof.proofString));
           printLongLine(nmbrCvtRToVString(nmbrSaveProof,
-                /* 25-Jan-2016 nm */
                 0, /*explicitTargets*/
                 0 /*statemNum, used only if explicitTargets*/)," "," ");
           print2("\n");
 
           nmbrLet(&nmbrTmp, nmbrUnsquishProof(nmbrSaveProof));
           printLongLine(nmbrCvtRToVString(nmbrTmp,
-                /* 25-Jan-2016 nm */
                 0, /*explicitTargets*/
                 0 /*statemNum, used only if explicitTargets*/)," "," ");
 
@@ -4759,7 +4147,6 @@ void command(int argc, char *argv[])
         }
         if (texFlag) {
           print2("The LaTeX source was written to \"%s\".\n", g_texFileName);
-         /* 14-Sep-2010 nm Added OLD_TEX */
          g_oldTexFlag = 0;
         }
       }
@@ -4781,7 +4168,6 @@ void command(int argc, char *argv[])
       }
 
       print2("Result:  %s\n", nmbrCvtRToVString(nmbrTmpPtr,
-                /* 25-Jan-2016 nm */
                 0, /*explicitTargets*/
                 0 /*statemNum, used only if explicitTargets*/));
       nmbrLet(&nmbrTmpPtr, NULL_NMBRSTRING);
@@ -4792,7 +4178,6 @@ void command(int argc, char *argv[])
 
     if (cmdMatches("PROVE")) {
 
-      /* 14-Sep-2012 nm */
       /* Get the unique statement matching the g_fullArg[1] pattern */
       i = getStatementNum(g_fullArg[1],
           1/*startStmt*/,
@@ -4809,54 +4194,22 @@ void command(int argc, char *argv[])
       g_proveStatement = i;
 
 
-      /* 10-May-2016 nm */
       /* 1 means to override usage locks */
       overrideFlag = ( (switchPos("/ OVERRIDE")) ? 1 : 0)
          || g_globalDiscouragement == 0;
       if (getMarkupFlag(g_proveStatement, PROOF_DISCOURAGED)) {
         if (overrideFlag == 0) {
           /* print2("\n"); */ /* Enable for more emphasis */
-          print2(
- ">>> ?Error: Modification of this statement's proof is discouraged.\n"
-              );
-          print2(
- ">>> You must use PROVE ... / OVERRIDE to work on it.\n");
+          print2(">>> ?Error: "
+            "Modification of this statement's proof is discouraged.\n");
+          print2(">>> You must use PROVE ... / OVERRIDE to work on it.\n");
           /* print2("\n"); */ /* Enable for more emphasis */
           continue;
         }
       }
 
-
-      /*********** 14-Sep-2012 replaced by getStatementNum()
-      /@??? Make sure only $p statements are allowed. @/
-      for (i = 1; i <= g_statements; i++) {
-        if (!strcmp(g_fullArg[1],g_Statement[i].labelName)) break;
-      }
-      if (i > g_statements) {
-        printLongLine(cat("?There is no statement with label \"",
-            g_fullArg[1], "\".  ",
-            "Use SHOW LABELS for a list of valid labels.", NULL), "", " ");
-        g_proveStatement = 0;
-        continue;
-      }
-      g_proveStatement = i;
-      if (g_Statement[g_proveStatement].type != (char)p_) {
-        printLongLine(cat("?Statement \"", g_fullArg[1],
-            "\" is not a $p statement.", NULL), "", " ");
-        g_proveStatement = 0;
-        continue;
-      }
-      ************** end of 14-Sep-2012 deletion ************/
-
-      print2(
-"Entering the Proof Assistant.  HELP PROOF_ASSISTANT for help, EXIT to exit.\n");
-
-      /* Obsolete:
-      print2("You will be working on the proof of statement %s:\n",
-          g_Statement[g_proveStatement].labelName);
-      printLongLine(cat("  $p ", nmbrCvtMToVString(
-          g_Statement[g_proveStatement].mathString), NULL), "    ", " ");
-      */
+      print2("Entering the Proof Assistant.  "
+        "HELP PROOF_ASSISTANT for help, EXIT to exit.\n");
 
       g_PFASmode = 1; /* Set mode for commands here and in mmcmdl.c */
       /* Note:  Proof Assistant mode can equivalently be determined by:
@@ -4874,45 +4227,9 @@ void command(int argc, char *argv[])
       }
       cleanWrkProof(); /* Deallocate verifyProof storage */
 
-      /* 11-Sep-2016 nm */
       /* Initialize the structure needed for the Proof Assistant */
       initProofStruct(&g_ProofInProgress, nmbrSaveProof, g_proveStatement);
 
-      /****** 11-Sep-2016 nm Replaced by initProofStruct()
-      /@ Right now, only non-packed proofs are handled. @/
-      nmbrLet(&nmbrSaveProof, nmbrUnsquishProof(nmbrSaveProof));
-
-      /@ Assign initial proof structure @/
-      if (nmbrLen(g_ProofInProgress.proof)) bug(1113); /@ Should've been deall.@/
-      nmbrLet(&g_ProofInProgress.proof, nmbrSaveProof);
-      i = nmbrLen(g_ProofInProgress.proof);
-      pntrLet(&g_ProofInProgress.target, pntrNSpace(i));
-      pntrLet(&g_ProofInProgress.source, pntrNSpace(i));
-      pntrLet(&g_ProofInProgress.user, pntrNSpace(i));
-      nmbrLet((nmbrString @@)(&((g_ProofInProgress.target)[i - 1])),
-          g_Statement[g_proveStatement].mathString);
-      g_pipDummyVars = 0;
-
-      /@ Assign known subproofs @/
-      assignKnownSubProofs();
-
-      /@ Initialize remaining steps @/
-      for (j = 0; j < i/@proof length@/; j++) {
-        if (!nmbrLen((g_ProofInProgress.source)[j])) {
-          initStep(j);
-        }
-      }
-
-      /@ Unify whatever can be unified @/
-      autoUnify(0); /@ 0 means no "congrats" message @/
-      **** end of 11-Sep-2016 deletion ************/
-
-/*
-      print2(
-"Periodically save your work with SAVE NEW_PROOF and WRITE SOURCE.\n");
-      print2(
-"There is no UNDO command yet.  You can OPEN LOG to track what you've done.\n");
-*/
       /* Show the user the statement to be proved */
       print2("You will be working on statement (from \"SHOW STATEMENT %s\"):\n",
           g_Statement[g_proveStatement].labelName);
@@ -4943,22 +4260,16 @@ void command(int argc, char *argv[])
             0 /*reverseFlag*/,
             0 /*noIndentFlag*/,
             0 /*splitColumn*/,
-            0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
+            0 /*skipRepeatedSteps*/,
             0 /*texFlag*/,
             0 /*g_htmlFlag*/);
-        /* 6/14/98 end */
       }
 
-      /* 3-May-2016 nm */
       if (getMarkupFlag(g_proveStatement, PROOF_DISCOURAGED)) {
         /* print2("\n"); */ /* Enable for more emphasis */
         print2(
 ">>> ?Warning: Modification of this statement's proof is discouraged.\n"
             );
-        /*
-        print2(
-">>> You must use SAVE NEW_PROOF ... / OVERRIDE to save it.\n");
-        */
         /* print2("\n"); */ /* Enable for more emphasis */
       }
 
@@ -4970,7 +4281,6 @@ void command(int argc, char *argv[])
     }
 
 
-    /* 1-Nov-2013 nm Added UNDO */
     if (cmdMatches("UNDO")) {
       processUndoStack(&g_ProofInProgress, PUS_UNDO, "", 0);
       g_proofChanged = 1; /* Maybe make this more intelligent some day */
@@ -4991,11 +4301,9 @@ void command(int argc, char *argv[])
           0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
           0 /*texFlag*/,
           0 /*g_htmlFlag*/);
-      /* 6/14/98 end */
       continue;
     }
 
-    /* 1-Nov-2013 nm Added REDO */
     if (cmdMatches("REDO")) {
       processUndoStack(&g_ProofInProgress, PUS_REDO, "", 0);
       g_proofChanged = 1; /* Maybe make this more intelligent some day */
@@ -5013,7 +4321,7 @@ void command(int argc, char *argv[])
           0 /*reverseFlag*/,
           0 /*noIndentFlag*/,
           0 /*splitColumn*/,
-          0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
+          0 /*skipRepeatedSteps*/,
           0 /*texFlag*/,
           0 /*g_htmlFlag*/);
       /* 6/14/98 end */
@@ -5101,10 +4409,9 @@ void command(int argc, char *argv[])
           0 /*reverseFlag*/,
           0 /*noIndentFlag*/,
           0 /*splitColumn*/,
-          0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
+          0 /*skipRepeatedSteps*/,
           0 /*texFlag*/,
           0 /*g_htmlFlag*/);
-      /* 6/14/98 end */
       continue;
     }
 
@@ -5227,65 +4534,9 @@ void command(int argc, char *argv[])
 
       if (cmdMatches("LET STEP")) {
 
-        /* 14-Sep-2012 nm */
         s = getStepNum(g_fullArg[2], g_ProofInProgress.proof,
             0 /* ALL not allowed */);
         if (s == -1) continue;  /* Error; message was provided already */
-
-        /************** 14-Sep-2012 replaced by getStepNum()
-        s = (long)val(g_fullArg[2]); /@ Step number @/
-
-        /@ 16-Apr-06 nm Added LET STEP n where n <= 0: 0 = last,
-           -1 = penultimate, etc. _unknown_ step @/
-        /@ Unlike ASSIGN LAST/FIRST and IMPROVE LAST/FIRST, it probably
-           doesn't make sense to add LAST/FIRST to LET STEP since known
-           steps can also be LET.  The main purpose of LET STEP n, n<=0, is
-           to use with scripting for mmj2 imports. @/
-        offset = 0;
-        if (s <= 0) {
-          offset = - s + 1;
-          s = 1; /@ Temp. until we figure out which step @/
-        }
-        /@ End of 16-Apr-06 @/
-
-        m = nmbrLen(g_ProofInProgress.proof); /@ Original proof length @/
-        if (s > m || s < 1) {
-          print2("?The step must be in the range from 1 to %ld.\n", m);
-          continue;
-        }
-
-        /@ 16-Apr-06 nm Added LET STEP n where n <= 0: 0 = last,
-           1 = penultimate, etc. _unknown_ step @/
-        if (offset > 0) {  /@ step <= 0 @/
-          /@ Get the essential step flags @/
-          s = 0; /@ Use as flag that step was found @/
-          nmbrLet(&essentialFlags, nmbrGetEssential(g_ProofInProgress.proof));
-          /@ Scan proof backwards until last essential unknown step found @/
-          /@ 16-Apr-06 - count back 'offset' unknown steps @/
-          j = offset;
-          for (i = m; i >= 1; i--) {
-            if (essentialFlags[i - 1]
-                && (g_ProofInProgress.proof)[i - 1] == -(long)'?') {
-              j--;
-              if (j == 0) {
-                /@ Found it @/
-                s = i;
-                break;
-              }
-            }
-          } /@ Next i @/
-          if (s == 0) {
-            if (offset == 1) {
-              print2("?There are no unknown essential steps.\n");
-            } else {
-              print2("?There are not at least %ld unknown essential steps.\n",
-                offset);
-            }
-            continue;
-          }
-        } /@ if offset > 0 @/
-        /@ End of 16-Apr-06 @/
-        ******************** end 14-Sep-2012 deletion ********/
 
         /* Check to see if the statement selected is allowed */
         if (!checkMStringMatch(nmbrTmp, s - 1)) {
@@ -5319,53 +4570,19 @@ void command(int argc, char *argv[])
           0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
           0 /*texFlag*/,
           0 /*g_htmlFlag*/);
-      /* 6/14/98 end */
       continue;
     }
 
 
     if (cmdMatches("ASSIGN")) {
-
-      /* 10/4/99 - Added LAST - this means the last unknown step shown
-         with SHOW NEW_PROOF/ESSENTIAL/UNKNOWN */
-      /* 11-Dec-05 nm - Added FIRST - this means the first unknown step shown
-         with SHOW NEW_PROOF/ESSENTIAL/UNKNOWN */
-      /* 16-Apr-06 nm - Handle nonpositive step number: 0 = last,
-         -1 = penultimate, etc.*/
-      /* 14-Sep-2012 nm All the above now done by getStepNum() */
       s = getStepNum(g_fullArg[1], g_ProofInProgress.proof,
           0 /* ALL not allowed */);
       if (s == -1) continue;  /* Error; message was provided already */
 
-      /* 3-May-2016 nm */
       /* 1 means to override usage locks */
       overrideFlag = ( (switchPos("/ OVERRIDE")) ? 1 : 0)
          || g_globalDiscouragement == 0;
 
-      /****** replaced by getStepNum()  nm 14-Sep-2012
-      offset = 0; /@ 16-Apr-06 @/
-      let(&str1, g_fullArg[1]); /@ To avoid void pointer problems with g_fullArg @/
-      if (toupper((unsigned char)(str1[0])) == 'L'
-          || toupper((unsigned char)(str1[0])) == 'F') {
-                                          /@ "ASSIGN LAST" or "ASSIGN FIRST" @/
-                                          /@ 11-Dec-05 nm @/
-        s = 1; /@ Temporary until we figure out which step @/
-        offset = 1;          /@ 16-Apr-06 @/
-      } else {
-        s = (long)val(g_fullArg[1]); /@ Step number @/
-        if (strcmp(g_fullArg[1], str((double)s))) {
-          print2("?Expected either a number or FIRST or LAST after ASSIGN.\n");
-                                                             /@ 11-Dec-05 nm @/
-          continue;
-        }
-        if (s <= 0) {         /@ 16-Apr-06 @/
-          offset = - s + 1;   /@ 16-Apr-06 @/
-          s = 1; /@ Temporary until we figure out which step @/ /@ 16-Apr-06 @/
-        }                     /@ 16-Apr-06 @/
-      }
-      ******************** end 14-Sep-2012 deletion ********/
-
-      /* 14-Sep-2012 nm */
       /* Get the unique statement matching the g_fullArg[2] pattern */
       k = getStatementNum(g_fullArg[2],
           1/*startStmt*/,
@@ -5380,37 +4597,6 @@ void command(int argc, char *argv[])
         continue; /* Error msg was provided if not unique */
       }
 
-      /*********** 14-Sep-2012 replaced by getStatementNum()
-      for (i = 1; i <= g_statements; i++) {
-        if (!strcmp(g_fullArg[2], g_Statement[i].labelName)) {
-          /@ If a $e or $f, it must be a hypothesis of the statement
-             being proved @/
-          if (g_Statement[i].type == (char)e_ || g_Statement[i].type == (char)f_){
-            if (!nmbrElementIn(1, g_Statement[g_proveStatement].reqHypList, i) &&
-                !nmbrElementIn(1, g_Statement[g_proveStatement].optHypList, i))
-                continue;
-          }
-          break;
-        }
-      }
-      if (i > g_statements) {
-        printLongLine(cat("?The statement with label \"",
-            g_fullArg[2],
-            "\" was not found or is not a hypothesis of the statement ",
-            "being proved.  ",
-            "Use SHOW LABELS for a list of valid labels.", NULL), "", " ");
-        continue;
-      }
-      k = i;
-
-      if (k >= g_proveStatement) {
-        print2(
-   "?You must specify a statement that occurs earlier the one being proved.\n");
-        continue;
-      }
-      ***************** end of 14-Sep-2012 deletion ************/
-
-      /* 3-May-2016 nm */
       if (getMarkupFlag(k, USAGE_DISCOURAGED)) {
         if (overrideFlag == 0) {
           /* print2("\n"); */ /* Enable for more emphasis */
@@ -5429,61 +4615,6 @@ void command(int argc, char *argv[])
       }
 
       m = nmbrLen(g_ProofInProgress.proof); /* Original proof length */
-
-
-      /****** replaced by getStepNum()  nm 14-Sep-2012
-      if (s > m || s < 1) {
-        print2("?The step must be in the range from 1 to %ld.\n", m);
-        continue;
-      }
-
-      /@ 10/4/99 - For ASSIGN FIRST/LAST command, figure out the last unknown
-         essential step @/                      /@ 11-Dec-05 nm - Added LAST @/
-      /@if (toupper(str1[0]) == 'L' || toupper(str1[0]) == 'F') {@/
-                                /@ "ASSIGN LAST or FIRST" @/ /@ 11-Dec-05 nm @/
-      if (offset > 0) {  /@ LAST, FIRST, or step <= 0 @/ /@ 16-Apr-06 @/
-        /@ Get the essential step flags @/
-        s = 0; /@ Use as flag that step was found @/
-        nmbrLet(&essentialFlags, nmbrGetEssential(g_ProofInProgress.proof));
-        /@ if (toupper((unsigned char)(str1[0])) == 'L') { @/
-        if (toupper((unsigned char)(str1[0])) != 'F') {   /@ 16-Apr-06 @/
-          /@ Scan proof backwards until last essential unknown step is found @/
-          /@ 16-Apr-06 - count back 'offset' unknown steps @/
-          j = offset;      /@ 16-Apr-06 @/
-          for (i = m; i >= 1; i--) {
-            if (essentialFlags[i - 1]
-                && (g_ProofInProgress.proof)[i - 1] == -(long)'?') {
-              j--;          /@ 16-Apr-06 @/
-              if (j == 0) {  /@ 16-Apr-06 @/
-                /@ Found it @/
-                s = i;
-                break;
-              }             /@ 16-Apr-06 @/
-            }
-          } /@ Next i @/
-        } else {
-          /@ 11-Dec-05 nm Added ASSIGN FIRST @/
-          /@ Scan proof forwards until first essential unknown step is found @/
-          for (i = 1; i <= m; i++) {
-            if (essentialFlags[i - 1]
-                && (g_ProofInProgress.proof)[i - 1] == -(long)'?') {
-              /@ Found it @/
-              s = i;
-              break;
-            }
-          } /@ Next i @/
-        }
-        if (s == 0) {
-          if (offset == 1) {                                /@ 16-Apr-06 @/
-            print2("?There are no unknown essential steps.\n");
-          } else {                                          /@ 16-Apr-06 @/
-            print2("?There are not at least %ld unknown essential steps.\n",
-              offset);                                      /@ 16-Apr-06 @/
-          }                                                 /@ 16-Apr-06 @/
-          continue;
-        }
-      }
-      ******************** end 14-Sep-2012 deletion ********/
 
       /* Check to see that the step is an unknown step */
       if ((g_ProofInProgress.proof)[s - 1] != -(long)'?') {
@@ -5515,36 +4646,6 @@ void command(int argc, char *argv[])
                                                  already unified */
       } /* if NO_UNIFY flag not set */
 
-      /******* 8-Apr-05 nm Commented out:
-      if (m == n) {
-        print2("Step %ld was assigned statement %s.\n",
-          s, g_Statement[k].labelName);
-      } else {
-        if (s != m) {
-          printLongLine(cat("Step ", str((double)s),
-              " was assigned statement ", g_Statement[k].labelName,
-              ".  Steps ", str((double)s), ":",
-              str((double)m), " are now ", str((double)(s - m + n)), ":", str((double)n), ".",
-              NULL),
-              "", " ");
-        } else {
-          printLongLine(cat("Step ", str((double)s),
-              " was assigned statement ", g_Statement[k].labelName,
-              ".  Step ", str((double)m), " is now step ", str((double)n), ".",
-              NULL),
-              "", " ");
-        }
-      }
-      *********/
-      /* 8-Apr-05 nm Added: */
-      /* 1-Nov-2013 nm No longer needed because of UNDO
-      printLongLine(cat("To undo the assignment, DELETE STEP ",
-              str((double)(s - m + n)), " and if needed INITIALIZE, UNIFY.",
-              NULL),
-              "", " ");
-      */
-
-      /* 5-Aug-2020 nm */
       /* See if it's in another mathbox; if so, let user know */
       assignMathboxInfo();
       if (k > g_mathboxStmt && g_proveStatement > g_mathboxStmt) {
@@ -5574,8 +4675,6 @@ void command(int argc, char *argv[])
           0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
           0 /*texFlag*/,
           0 /*g_htmlFlag*/);
-      /* 6/14/98 end */
-
 
       g_proofChangedFlag = 1; /* Flag to push 'undo' stack (future) */
       g_proofChanged = 1; /* Cumulative flag */
@@ -5586,29 +4685,14 @@ void command(int argc, char *argv[])
 
 
     if (cmdMatches("REPLACE")) {
-
-      /* s = (long)val(g_fullArg[1]);  obsolete */ /* Step number */
-
-      /* 3-May-2016 nm */
       /* 1 means to override usage locks */
       overrideFlag = ( (switchPos("/ OVERRIDE")) ? 1 : 0)
          || g_globalDiscouragement == 0;
 
-      /* 14-Sep-2012 nm */
       step = getStepNum(g_fullArg[1], g_ProofInProgress.proof,
           0 /* ALL not allowed */);
       if (step == -1) continue;  /* Error; message was provided already */
 
-      /* This limitation is due to the assignKnownSteps call below which
-         does not tolerate unknown steps. */
-      /******* 10/20/02  Limitation removed
-      if (nmbrElementIn(1, g_ProofInProgress.proof, -(long)'?')) {
-        print2("?The proof must be complete before you can use REPLACE.\n");
-        continue;
-      }
-      *******/
-
-      /* 14-Sep-2012 nm */
       /* Get the unique statement matching the g_fullArg[2] pattern */
       stmt = getStatementNum(g_fullArg[2],
           1/*startStmt*/,
@@ -5623,37 +4707,6 @@ void command(int argc, char *argv[])
         continue; /* Error msg was provided if not unique */
       }
 
-      /*********** 14-Sep-2012 replaced by getStatementNum()
-      for (i = 1; i <= g_statements; i++) {
-        if (!strcmp(g_fullArg[2], g_Statement[i].labelName)) {
-          /@ If a $e or $f, it must be a hypothesis of the statement
-             being proved @/
-          if (g_Statement[i].type == (char)e_ || g_Statement[i].type == (char)f_){
-            if (!nmbrElementIn(1, g_Statement[g_proveStatement].reqHypList, i) &&
-                !nmbrElementIn(1, g_Statement[g_proveStatement].optHypList, i))
-                continue;
-          }
-          break;
-        }
-      }
-      if (i > g_statements) {
-        printLongLine(cat("?The statement with label \"",
-            g_fullArg[2],
-            "\" was not found or is not a hypothesis of the statement ",
-            "being proved.  ",
-            "Use SHOW LABELS for a list of valid labels.", NULL), "", " ");
-        continue;
-      }
-      k = i;
-
-      if (k >= g_proveStatement) {
-        print2(
-   "?You must specify a statement that occurs earlier the one being proved.\n");
-        continue;
-      }
-      ****************************** end of 14-Sep-2012 deletion *********/
-
-      /* 3-May-2016 nm */
       if (getMarkupFlag(stmt, USAGE_DISCOURAGED)) {
         if (overrideFlag == 0) {
           /* print2("\n"); */ /* Enable for more emphasis */
@@ -5673,24 +4726,6 @@ void command(int argc, char *argv[])
 
       m = nmbrLen(g_ProofInProgress.proof); /* Original proof length */
 
-      /************** 14-Sep-2012 replaced by getStepNum()
-      if (s > m || s < 1) {
-        print2("?The step must be in the range from 1 to %ld.\n", m);
-        continue;
-      }
-      ************* end of 14-Sep-2012 deletion **************/
-
-      /* Check to see that the step is a known step */
-      /* 22-Aug-2012 nm This check was deleted because it is unnecessary  */
-      /*
-      if ((g_ProofInProgress.proof)[s - 1] == -(long)'?') {
-        print2(
-        "?Step %ld is unknown.  You can only replace known steps.\n"
-            , s);
-        continue;
-      }
-      */
-
       /* 10/20/02  Set a flag that proof has unknown steps (for autoUnify()
          call below) */
       if (nmbrElementIn(1, g_ProofInProgress.proof, -(long)'?')) {
@@ -5706,7 +4741,6 @@ void command(int argc, char *argv[])
         continue;
       }
 
-      /* 16-Sep-2012 nm */
       /* Check dummy variable status of step */
       /* For use in message later */
       dummyVarIsoFlag = checkDummyVarIsolation(step - 1);
@@ -5720,11 +4754,10 @@ void command(int argc, char *argv[])
           0/*noDistinct*/,
           1/* try to prove $e's */,
           1/*improveDepth*/,
-          overrideFlag,   /* 3-May-2016 nm */
+          overrideFlag,
           /* Currently REPLACE (not often used) allows other mathboxes
              silently; TODO: we may want to notify user like for ASSIGN */
-          1/*mathboxFlag*/ /* 5-Aug-2020 nm */
-          );
+          1/*mathboxFlag*/);
       if (!nmbrLen(nmbrTmpPtr)) {
         print2(
            "?Hypotheses of statement \"%s\" do not match known proof steps.\n",
@@ -5737,9 +4770,6 @@ void command(int argc, char *argv[])
       deleteSubProof(step - 1);
       addSubProof(nmbrTmpPtr, step - q);
 
-      /* 10/20/02 Replaced "assignKnownSteps" with code from entry of PROVE
-         command so REPLACE can be done in partial proofs */
-      /*assignKnownSteps(s - q, nmbrLen(nmbrTmpPtr));*/  /* old code */
       /* Assign known subproofs */
       assignKnownSubProofs();
       /* Initialize remaining steps */
@@ -5753,7 +4783,6 @@ void command(int argc, char *argv[])
       /* If proof wasn't complete before (p = 1), but is now, print congrats
          for user */
       autoUnify((char)p); /* 0 means no "congrats" message */
-      /* end 10/20/02 */
 
       nmbrLet(&nmbrTmpPtr, NULL_NMBRSTRING); /* Deallocate memory */
 
@@ -5781,36 +4810,11 @@ void command(int argc, char *argv[])
           }
         }
       }
-      /*autoUnify(1);*/
-
-      /************ delete 19-Sep-2012 nm - not needed for REPLACE *******
-      /@ Automatically interact with user if step not unified @/
-      /@ ???We might want to add a setting to defeat this if user doesn't
-         like it @/
-      if (1 /@ ???Future setting flag @/) {
-        interactiveUnifyStep(step - m + n - 1, 2); /@ 2nd arg. means print
-                                         msg if already unified @/
-      }
-      *************** end 19-Sep-2012 deletion ********************/
 
       g_proofChangedFlag = 1; /* Flag to push 'undo' stack */
       g_proofChanged = 1; /* Cumulative flag */
       processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
 
-      /* 16-Sep-2012 nm */
-      /*
-      if (dummyVarIsoFlag == 2 && g_proofChangedFlag) {
-        printLongLine(cat(
-     "Assignments to shared working variables ($nn) are guesses.  If "
-     "incorrect, to undo DELETE STEP ",
-              str((double)(step - m + n)),
-      ", INITIALIZE, UNIFY, then assign them manually with LET ",
-      "and try REPLACE again.",
-              NULL),
-              "", " ");
-      }
-      */
-      /* 25-Feb-2014 nm */
       if (dummyVarIsoFlag == 2 && g_proofChangedFlag) {
         printLongLine(cat(
      "Assignments to shared working variables ($nn) are guesses.  If "
@@ -5839,8 +4843,6 @@ void command(int argc, char *argv[])
             0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
             0 /*texFlag*/,
             0 /*g_htmlFlag*/);
-      /* 14-Sep-2012 end */
-
 
       continue;
 
@@ -5854,17 +4856,14 @@ void command(int argc, char *argv[])
       if (i) improveDepth = (long)val(g_fullArg[i + 1]);
       if (switchPos("/ NO_DISTINCT")) p = 1; else p = 0;
                         /* p = 1 means don't try to use statements with $d's */
-      /* 22-Aug-2012 nm Added */
       searchAlg = 1; /* Default */
       if (switchPos("/ 1")) searchAlg = 1;
       if (switchPos("/ 2")) searchAlg = 2;
       if (switchPos("/ 3")) searchAlg = 3;
-      /* 4-Sep-2012 nm Added */
       searchUnkSubproofs = 0;
       if (switchPos("/ SUBPROOFS")) searchUnkSubproofs = 1;
 
       mathboxFlag = (switchPos("/ INCLUDE_MATHBOXES") != 0); /* 5-Aug-2020 */
-      /* 5-Aug-2020 nm */
       assignMathboxInfo(); /* In case it hasn't been assigned yet */
       if (g_proveStatement > g_mathboxStmt) {
         /* We're in a mathbox */
@@ -5875,132 +4874,16 @@ void command(int argc, char *argv[])
         thisMathboxStartStmt = g_mathboxStmt;
       }
 
-      /* 3-May-2016 nm */
       /* 1 means to override usage locks */
       overrideFlag = ( (switchPos("/ OVERRIDE")) ? 1 : 0)
          || g_globalDiscouragement == 0;
 
-      /* 14-Sep-2012 nm */
       s = getStepNum(g_fullArg[1], g_ProofInProgress.proof,
           1 /* 1 = "ALL" is permissible; returns 0 */);
       if (s == -1) continue;  /* Error; message was provided already */
 
       if (s != 0) {  /* s=0 means ALL */
-
-      /**************** 14-Sep-2012 nm replaced with getStepNum()
-      /@ 26-Aug-2006 nm Changed 'IMPROVE STEP <step>' to 'IMPROVE <step>' @/
-      let(&str1, g_fullArg[1]); /@ To avoid void pointer problems with g_fullArg @/
-      if (toupper((unsigned char)(str1[0])) != 'A') {
-        /@ 16-Apr-06 nm - Handle nonpositive step number: 0 = last,
-           -1 = penultimate, etc.@/
-        offset = 0; /@ 16-Apr-06 @/
-        /@ 10/4/99 - Added LAST - this means the last unknown step shown
-           with SHOW NEW_PROOF/ESSENTIAL/UNKNOWN @/
-        if (toupper((unsigned char)(str1[0])) == 'L'
-            || toupper((unsigned char)(str1[0])) == 'F') {
-                                        /@ 'IMPROVE LAST' or 'IMPROVE FIRST' @/
-          s = 1; /@ Temporary until we figure out which step @/
-          offset = 1;          /@ 16-Apr-06 @/
-        } else {
-          if (toupper((unsigned char)(str1[0])) == 'S') {
-            print2(
-           "?\"IMPROVE STEP <step>\" is obsolete.  Use \"IMPROVE <step>\".\n");
-            continue;
-          }
-          s = (long)val(g_fullArg[1]); /@ Step number @/
-          if (strcmp(g_fullArg[1], str((double)s))) {
-            print2(
-                "?Expected a number or FIRST or LAST or ALL after IMPROVE.\n");
-            continue;
-          }
-          if (s <= 0) {         /@ 16-Apr-06 @/
-            offset = - s + 1;   /@ 16-Apr-06 @/
-            s = 1; /@ Temporary until we figure out step @/ /@ 16-Apr-06 @/
-          }                     /@ 16-Apr-06 @/
-        }
-        /@ End of 26-Aug-2006 change @/
-
-      /@ ------- Old code before 26-Aug-2006 -------
-      if (cmdMatches("IMPROVE STEP") || cmdMatches("IMPROVE LAST") ||
-          cmdMatches("IMPROVE FIRST")) {                     /# 11-Dec-05 nm #/
-
-        /# 16-Apr-06 nm - Handle nonpositive step number: 0 = last,
-           -1 = penultimate, etc.#/
-        offset = 0; /# 16-Apr-06 #/
-        /# 10/4/99 - Added LAST - this means the last unknown step shown
-           with SHOW NEW_PROOF/ESSENTIAL/UNKNOWN #/
-        if (cmdMatches("IMPROVE LAST") || cmdMatches("IMPROVE FIRST")) {
-                               /# "IMPROVE LAST or FIRST" #/ /# 11-Dec-05 nm #/
-          s = 1; /# Temporary until we figure out which step #/
-          offset = 1;          /# 16-Apr-06 #/
-        } else {
-          s = val(g_fullArg[2]); /# Step number #/
-          if (s <= 0) {         /# 16-Apr-06 #/
-            offset = - s + 1;   /# 16-Apr-06 #/
-            s = 1; /# Temp. until we figure out which step #/ /# 16-Apr-06 #/
-          }                     /# 16-Apr-06 #/
-        }
-        ------- End of old code ------- @/
-        **************** end of 14-Sep-2012 nm ************/
-
         m = nmbrLen(g_ProofInProgress.proof); /* Original proof length */
-
-
-        /**************** 14-Sep-2012 nm replaced with getStepNum()
-        if (s > m || s < 1) {
-          print2("?The step must be in the range from 1 to %ld.\n", m);
-          continue;
-        }
-
-
-        /@ 10/4/99 - For IMPROVE FIRST/LAST command, figure out the last
-           unknown essential step @/           /@ 11-Dec-05 nm - Added FIRST @/
-        /@if (cmdMatches("IMPROVE LAST") || cmdMatches("IMPROVE FIRST")) {@/
-                               /@ IMPROVE LAST or FIRST @/ /@ 11-Dec-05 nm @/
-        if (offset > 0) {  /@ LAST, FIRST, or step <= 0 @/ /@ 16-Apr-06 @/
-          /@ Get the essential step flags @/
-          s = 0; /@ Use as flag that step was found @/
-          nmbrLet(&essentialFlags, nmbrGetEssential(g_ProofInProgress.proof));
-          /@if (cmdMatches("IMPROVE LAST")) {@/
-          /@if (!cmdMatches("IMPROVE FIRST")) {@/   /@ 16-Apr-06 @/
-          if (toupper((unsigned char)(str1[0])) != 'F') { /@ 26-Aug-2006 @/
-            /@ Scan proof backwards until last essential unknown step found @/
-            /@ 16-Apr-06 - count back 'offset' unknown steps @/
-            j = offset;      /@ 16-Apr-06 @/
-            for (i = m; i >= 1; i--) {
-              if (essentialFlags[i - 1]
-                  && (g_ProofInProgress.proof)[i - 1] == -(long)'?') {
-                j--;           /@ 16-Apr-06 @/
-                if (j == 0) {  /@ 16-Apr-06 @/
-                  /@ Found it @/
-                  s = i;
-                  break;
-                }              /@ 16-Apr-06 @/
-              }
-            } /@ Next i @/
-          } else {
-            /@ 11-Dec-05 nm Added IMPROVE FIRST @/
-            /@ Scan proof forwards until first essential unknown step found @/
-            for (i = 1; i <= m; i++) {
-              if (essentialFlags[i - 1]
-                  && (g_ProofInProgress.proof)[i - 1] == -(long)'?') {
-                /@ Found it @/
-                s = i;
-                break;
-              }
-            } /@ Next i @/
-          }
-          if (s == 0) {
-            if (offset == 1) {                                /@ 16-Apr-06 @/
-              print2("?There are no unknown essential steps.\n");
-            } else {                                          /@ 16-Apr-06 @/
-              print2("?There are not at least %ld unknown essential steps.\n",
-                offset);                                      /@ 16-Apr-06 @/
-            }                                                 /@ 16-Apr-06 @/
-            continue;
-          }
-        } /@ if offset > 0 @/
-        **************** end of 14-Sep-2012 nm ************/
 
         /* Get the subproof at step s */
         q = subproofLen(g_ProofInProgress.proof, s - 1);
@@ -6015,7 +4898,6 @@ void command(int argc, char *argv[])
           continue;
         }
 
-        /* 25-Aug-2012 nm */
         /* Check dummy variable status of step */
         dummyVarIsoFlag = checkDummyVarIsolation(s - 1);
               /* 0=no dummy vars, 1=isolated dummy vars, 2=not isolated*/
@@ -6026,47 +4908,28 @@ void command(int argc, char *argv[])
                                  dummy variables that aren't isolated */
         }
 
-        /********* Deleted old code 25-Aug-2012 nm
-        /@ Check to see that the step has no dummy variables. @/
-        j = 0; /@ Break flag @/
-        for (i = 0; i < nmbrLen((g_ProofInProgress.target)[s - 1]); i++) {
-          if (((nmbrString @)((g_ProofInProgress.target)[s - 1]))[i] > mathTokens) {
-            j = 1;
-            break;
-          }
-        }
-        if (j) {
-          print2(
-   "?Step %ld target has dummy variables and cannot be improved.\n", s);
-          continue;
-        }
-        ********/
-
-
-        if (dummyVarIsoFlag == 0) { /* No dummy vars */ /* 25-Aug-2012 nm */
+        if (dummyVarIsoFlag == 0) { /* No dummy vars */
           /* Only use proveFloating if no dummy vars */
           nmbrTmpPtr = proveFloating((g_ProofInProgress.target)[s - 1],
               g_proveStatement, improveDepth, s - 1, (char)p/*NO_DISTINCT*/,
-              overrideFlag,  /* 3-May-2016 nm */
-              mathboxFlag /* 5-Aug-2020 nm */
-              );
+              overrideFlag,
+              mathboxFlag);
         } else {
-          nmbrTmpPtr = NULL_NMBRSTRING; /* Initialize */ /* 25-Aug-2012 nm */
+          nmbrTmpPtr = NULL_NMBRSTRING; /* Initialize */
         }
         if (!nmbrLen(nmbrTmpPtr)) {
           /* A proof for the step was not found with proveFloating(). */
 
-          /* 22-Aug-2012 nm Next, try REPLACE algorithm */
+          /* Next, try REPLACE algorithm */
           if (searchAlg == 2 || searchAlg == 3) {
             nmbrTmpPtr = proveByReplacement(g_proveStatement,
               s - 1/*prfStep*/, /* 0 means step 1 */
               (char)p/*NO_DISTINCT*/, /* 1 means don't try stmts with $d's */
               dummyVarIsoFlag,
               (char)(searchAlg - 2), /*0=proveFloat for $fs, 1=$e's also */
-              improveDepth, /* 4-Sep-2012 */
-              overrideFlag,  /* 3-May-2016 nm */
-              mathboxFlag /* 5-Aug-2020 nm */
-              );
+              improveDepth,
+              overrideFlag,
+              mathboxFlag);
           }
           if (!nmbrLen(nmbrTmpPtr)) {
             print2("A proof for step %ld was not found.\n", s);
@@ -6108,11 +4971,9 @@ void command(int argc, char *argv[])
         g_proofChanged = 1; /* Cumulative flag */
         processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
 
-        /* End if s != 0 i.e. not IMPROVE ALL */   /* 14-Sep-2012 nm */
+        /* End if s != 0 i.e. not IMPROVE ALL */
       } else {
-        /* Here, getStepNum() returned 0, meaning ALL */  /* 14-Sep-2012 nm */
-
-        /*if (cmdMatches("IMPROVE ALL")) {*/  /* obsolete */
+        /* Here, getStepNum() returned 0, meaning ALL */
 
         if (!nmbrElementIn(1, g_ProofInProgress.proof, -(long)'?')) {
           print2("The proof is already complete.\n");
@@ -6158,11 +5019,11 @@ void command(int argc, char *argv[])
           for (s = m; s > 0; s--) {
 
             proofStepUnk = ((g_ProofInProgress.proof)[s - 1] == -(long)'?')
-                ? 1 : 0;   /* 25-Aug-2012 nm Added for clearer code */
+                ? 1 : 0;
 
             /* 22-Aug-2012 nm I think this is really too conservative, even
                with the old algorithm, but keep it to imitate the old one */
-            if (improveAllIter == 1 || searchAlg == 1) { /* 22-Aug-2012 nm */
+            if (improveAllIter == 1 || searchAlg == 1) {
               /* If the step is known and unified, don't do it, since nothing
                  would be accomplished. */
               if (!proofStepUnk) {
@@ -6173,9 +5034,7 @@ void command(int argc, char *argv[])
 
             /* Get the subproof at step s */
             q = subproofLen(g_ProofInProgress.proof, s - 1);
-            if (proofStepUnk && q != 1) {
-              bug(1120); /* 25-Aug-2012 nm Consistency check */
-            }
+            if (proofStepUnk && q != 1) bug(1120); /* Consistency check */
             nmbrLet(&nmbrTmp, nmbrSeg(g_ProofInProgress.proof, s - q + 1, s));
 
             /* Improve only subproofs with unknown steps */
@@ -6183,48 +5042,29 @@ void command(int argc, char *argv[])
 
             nmbrLet(&nmbrTmp, NULL_NMBRSTRING); /* No longer needed - dealloc */
 
-            /* 25-Aug-2012 nm */
             /* Check dummy variable status of step */
             dummyVarIsoFlag = checkDummyVarIsolation(s - 1);
                   /* 0=no dummy vars, 1=isolated dummy vars, 2=not isolated*/
             if (dummyVarIsoFlag == 2) continue; /* Don't try to improve
                                      dummy variables that aren't isolated */
 
-            /********* Deleted old code now done by checkDummyVarIsolation()
-                       25-Aug-2012 nm
-            /@ Check to see that the step has no dummy variables. @/
-            j = 0; /@ Break flag @/
-            for (i = 0; i < nmbrLen((g_ProofInProgress.target)[s - 1]); i++) {
-              if (((nmbrString @)((g_ProofInProgress.target)[s - 1]))[i] >
-                  mathTokens) {
-                j = 1;
-                break;
-              }
-            }
-            if (j) {
-              /@ Step has dummy variables and cannot be improved. @/
-              continue;
-            }
-            ********/
-
             if (dummyVarIsoFlag == 0
                 && (improveAllIter == 1
                   || improveAllIter == 4)) {
-                /* No dummy vars */ /* 25-Aug-2012 nm */
+                /* No dummy vars */
               /* Only use proveFloating if no dummy vars */
               nmbrTmpPtr = proveFloating((g_ProofInProgress.target)[s - 1],
                   g_proveStatement, improveDepth, s - 1,
                   (char)p/*NO_DISTINCT*/,
-                  overrideFlag,  /* 3-May-2016 nm */
-                  mathboxFlag /* 5-Aug-2020 nm */
-                  );
+                  overrideFlag,
+                  mathboxFlag);
             } else {
-              nmbrTmpPtr = NULL_NMBRSTRING; /* Init */ /* 25-Aug-2012 nm */
+              nmbrTmpPtr = NULL_NMBRSTRING; /* Init */
             }
             if (!nmbrLen(nmbrTmpPtr)) {
               /* A proof for the step was not found with proveFloating(). */
 
-              /* 22-Aug-2012 nm Next, try REPLACE algorithm */
+              /* Next, try REPLACE algorithm */
               if ((searchAlg == 2 || searchAlg == 3)
                   && ((improveAllIter == 2 && proofStepUnk)
                     || (improveAllIter == 3 && !proofStepUnk)
@@ -6234,10 +5074,9 @@ void command(int argc, char *argv[])
                   (char)p/*NO_DISTINCT*/, /* 1 means don't try stmts w/ $d's */
                   dummyVarIsoFlag,
                   (char)(searchAlg - 2),/*searchMethod: 0 or 1*/
-                  improveDepth,                        /* 4-Sep-2012 */
-                  overrideFlag,   /* 3-May-2016 nm */
-                  mathboxFlag /* 5-Aug-2020 nm */
-                  );
+                  improveDepth,
+                  overrideFlag,
+                  mathboxFlag);
 
               }
               if (!nmbrLen(nmbrTmpPtr)) {
@@ -6315,10 +5154,9 @@ void command(int argc, char *argv[])
             0 /*reverseFlag*/,
             0 /*noIndentFlag*/,
             0 /*splitColumn*/,
-            0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
+            0 /*skipRepeatedSteps*/,
             0 /*texFlag*/,
             0 /*g_htmlFlag*/);
-      /* 6/14/98 end */
 
       continue;
 
@@ -6327,7 +5165,6 @@ void command(int argc, char *argv[])
 
     if (cmdMatches("MINIMIZE_WITH")) {
 
-      /* 16-Aug-2016 nm */
       printTime = 0;
       if (switchPos("/ TIME") != 0) {
         printTime = 1;
@@ -6336,30 +5173,20 @@ void command(int argc, char *argv[])
         getRunTime(&timeIncr);  /* This call just resets the time */
       }
 
-      /* q = 0; */ /* Line length */  /* 25-Jun-2014 deleted */
       prntStatus = 0; /* Status flag to help determine messages
                          0 = no statement was matched during scan (mainly for
                              error message if user typo in label field)
                          1 = a statement was matched but no shorter proof
                          2 = shorter proof found */
-      /* verboseMode = (switchPos("/ BRIEF") == 0); */ /* Non-verbose mode */
-      /* 4-Feb-2013 nm VERBOSE is now default */
       verboseMode = (switchPos("/ VERBOSE") != 0); /* Verbose mode */
-      /* 30-Jan-06 nm Added single-character-match wildcard argument */
       if (!(instr(1, g_fullArg[1], "*") || instr(1, g_fullArg[1], "?"))) i = 1;
           /* 16-Feb-05 If no wildcard was used, switch to non-verbose mode
              since there is no point to it and an annoying extra blank line
              results */
       mayGrowFlag = (switchPos("/ MAY_GROW") != 0);
                   /* Mode to replace even if it doesn't reduce proof length */
-      /* 25-Jun-2014 nm /NO_DISTINCT is obsolete
-      noDistinctFlag = (switchPos("/ NO_DISTINCT") != 0);
-      */
-                                          /* Skip trying statements with $d */
       exceptPos = switchPos("/ EXCEPT"); /* Statement match to skip */
-                                                               /* 7-Jan-06 */
 
-      /* 4-Aug-2019 nm */
       allowNewAxiomsMatchPos = switchPos("/ ALLOW_NEW_AXIOMS");
       if (allowNewAxiomsMatchPos != 0) {
         let(&allowNewAxiomsMatchList, g_fullArg[allowNewAxiomsMatchPos + 1]);
@@ -6367,7 +5194,6 @@ void command(int argc, char *argv[])
         let(&allowNewAxiomsMatchList, "");
       }
 
-      /* 20-May-2013 nm */
       noNewAxiomsMatchPos = switchPos("/ NO_NEW_AXIOMS_FROM");
       if (noNewAxiomsMatchPos != 0) {
         let(&noNewAxiomsMatchList, g_fullArg[noNewAxiomsMatchPos + 1]);
@@ -6375,7 +5201,6 @@ void command(int argc, char *argv[])
         let(&noNewAxiomsMatchList, "");
       }
 
-      /* 20-May-2013 nm */
       forbidMatchPos = switchPos("/ FORBID");
       if (forbidMatchPos != 0) {
         let(&forbidMatchList, g_fullArg[forbidMatchPos + 1]);
@@ -6383,30 +5208,15 @@ void command(int argc, char *argv[])
         let(&forbidMatchList, "");
       }
 
-      mathboxFlag = (switchPos("/ INCLUDE_MATHBOXES") != 0); /* 28-Jun-2011 */
-      /* 25-Jun-2014 nm /REVERSE is obsolete
-      forwFlag = (switchPos("/ REVERSE") != 0); /@ 10-Nov-2011 nm @/
-      */
-      /****** 5-Aug-2020 nm Replaced w/ assignMathboxInfo() below
-      if (g_mathboxStmt == 0) { /@ Look up "mathbox" label if it hasn't been @/
-        g_mathboxStmt = lookupLabel("mathbox");
-        if (g_mathboxStmt == -1)
-          g_mathboxStmt = g_statements + 1;  /@ Default beyond db end if none @/
-      }
-      *******/
+      mathboxFlag = (switchPos("/ INCLUDE_MATHBOXES") != 0);
 
-      /* 3-May-2016 nm */
       /* Flag to override any "usage locks" placed in the comment markup */
       overrideFlag = (switchPos("/ OVERRIDE") != 0)
            || g_globalDiscouragement == 0;
 
-      /* 25-Jun-2014 nm */
       /* If a single statement is specified, don't bother to do certain
          actions or print some of the messages */
-      /* 18-Jul-2020 nm New code*/
       hasWildCard = 0;
-      /* (Note strpbrk warning in mmpars.c) */
-      /*if (strpbrk(g_fullArg[1], "*?=~%#@,") != NULL) {*/
       /* Set hasWildCard only when there are potentially > 1 matches */
       if (strpbrk(g_fullArg[1], "*?~%,") != NULL) {
         /* (See matches() function for processing of these)
@@ -6420,21 +5230,12 @@ void command(int argc, char *argv[])
            "," Comma-separated fields */
         hasWildCard = 1;
       }
-      /****** 18-Jul-2020 nm Deleted old code:
-      hasWildCard = (instr(1, g_fullArg[1], "*")
-          || instr(1, g_fullArg[1], "?")
-          || instr(1, g_fullArg[1], ",")
-          || instr(1, g_fullArg[1], "~") /@ 3-May-2014 nm label~label range @/
-          );
-      ********/
 
       g_proofChangedFlag = 0;
 
-      /* Added 14-Aug-2012 nm */
       /* Always scan statements in current mathbox, even if
          "/ INCLUDE_MATHBOXES" is omitted */
 
-      /* 5-Aug-2020 nm */
       assignMathboxInfo(); /* In case it hasn't been assigned yet */
       if (g_proveStatement > g_mathboxStmt) {
         /* We're in a mathbox */
@@ -6444,25 +5245,7 @@ void command(int argc, char *argv[])
       } else {
         thisMathboxStartStmt = g_mathboxStmt;
       }
-      /****** 5-Aug-2020 deleted old code
-      thisMathboxStartStmt = g_mathboxStmt;
-                /@ Will become start of current (g_proveStatement's) mathbox @/
-      if (g_proveStatement > g_mathboxStmt) {
-        /@ We're in a mathbox @/
-        for (k = g_proveStatement; k >= g_mathboxStmt; k--) {
-          let(&str1, left(g_Statement[k].labelSectionPtr,
-              g_Statement[k].labelSectionLen));
-          /@ Heuristic to match beginning of mathbox @/
-          if (instr(1, str1, "Mathbox for") != 0) {
-             /@ Found beginning of current mathbox @/
-             thisMathboxStartStmt = k;
-             break;
-          }
-        }
-      }
-      **************/
 
-      /* 25-Jun-2014 nm */
       copyProofStruct(&saveOrigProof, g_ProofInProgress);
 
       /* 12-Sep-2016 nm TODO replace this w/ compressedProofSize */
@@ -6477,14 +5260,12 @@ void command(int argc, char *argv[])
           0 /* Normal (not "fast") compression */
           ));
       origCompressedLength = (long)strlen(str1);
-      print2(
-"Bytes refer to compressed proof size, steps to uncompressed length.\n");
+      print2("Bytes refer to compressed proof size, "
+        "steps to uncompressed length.\n");
 
-      /* 25-Jun-2014 nm forwRevPass outer loop added */
       /* Scan forward, then reverse, then pick best result */
       for (forwRevPass = 1; forwRevPass <= 2; forwRevPass++) {
 
-        /* 25-Jun-2014 nm */
         if (forwRevPass == 1) {
           if (hasWildCard) print2("Scanning forward through statements...\n");
           forwFlag = 1;
@@ -6505,63 +5286,31 @@ void command(int argc, char *argv[])
           copyProofStruct(&g_ProofInProgress, saveOrigProof);
         }
 
-        /* 20-May-2013 nm */
-        /*
-        if (forbidMatchList[0]) { /@ User provided a /FORBID list @/
-          /@ Save the proof structure in case we have to revert a
-             forbidden match. @/
-          copyProofStruct(&saveProofForReverting, g_ProofInProgress);
-        }
-        */
-        /* 25-Jun-2014 nm */
         copyProofStruct(&saveProofForReverting, g_ProofInProgress);
 
         oldCompressedLength = origCompressedLength;
 
-        /* for (k = 1; k < g_proveStatement; k++) { */
-        /* 10-Nov-2011 nm */
         /* If forwFlag is 0, scan from g_proveStatement-1 to 1
            If forwFlag is 1, scan from 1 to g_proveStatement-1 */
         for (k = forwFlag ? 1 : (g_proveStatement - 1);
              k * (forwFlag ? 1 : -1) < (forwFlag ? g_proveStatement : 0);
              k = k + (forwFlag ? 1 : -1)) {
-          /* 28-Jun-2011 */
-          /* Scan mathbox statements only if INCLUDE_MATHBOXES specified */
-          /*if (!mathboxFlag && k >= g_mathboxStmt) continue;*/
-          /* 14-Aug-2012 nm */
           if (!mathboxFlag && k >= g_mathboxStmt && k < thisMathboxStartStmt) {
             continue;
           }
 
           if (g_Statement[k].type != (char)p_ && g_Statement[k].type != (char)a_)
             continue;
-          /* 30-Jan-06 nm Added single-character-match wildcard argument */
           if (!matchesList(g_Statement[k].labelName, g_fullArg[1], '*', '?'))
             continue;
-          /* 25-Jun-2014 nm /NO_DISTINCT is obsolete
-          if (noDistinctFlag) {
-            /@ Skip the statement if it has a $d requirement.  This option
-               prevents illegal minimizations that would violate $d requirements
-               since MINIMIZE_WITH does not check for $d violations. @/
-            if (nmbrLen(g_Statement[k].reqDisjVarsA)) {
-              /@ 30-Jan-06 nm Added single-character-match wildcard argument @/
-              if (!(instr(1, g_fullArg[1], "@") || instr(1, g_fullArg[1], "?")))
-                print2("?\"%s\" has a $d requirement\n", g_fullArg[1]);
-              continue;
-            }
-          }
-          */
 
-          /* 7-Jan-06 nm - Added EXCEPT switch */
           if (exceptPos != 0) {
             /* Skip any match to the EXCEPT argument */
-            /* 30-Jan-06 nm Added single-character-match wildcard argument */
             if (matchesList(g_Statement[k].labelName, g_fullArg[exceptPos + 1],
                 '*', '?'))
               continue;
           }
 
-          /* 20-May-2013 nm */
           if (forbidMatchList[0]) { /* User provided a /FORBID list */
             /* First, we check to make sure we're not trying a statement
                in the forbidMatchList directly (traceProof() won't find
@@ -6570,7 +5319,6 @@ void command(int argc, char *argv[])
               continue;
           }
 
-          /* 3-May-2016 nm */
           /* Check to see if statement comment specified a usage
              restriction */
           if (!overrideFlag) {
@@ -6581,16 +5329,6 @@ void command(int argc, char *argv[])
 
           /* Print individual labels */
           if (prntStatus == 0) prntStatus = 1; /* Matched at least one */
-          /* 25-Jun-2014 nm Don't list matched statements anymore
-          if (verboseMode) {
-            q = q + (long)strlen(g_Statement[k].labelName) + 1;
-            if (q > 72) {
-              q = (long)strlen(g_Statement[k].labelName) + 1;
-              print2("\n");
-            }
-            print2("%s ",g_Statement[k].labelName);
-          }
-          */
 
           m = nmbrLen(g_ProofInProgress.proof); /* Original proof length */
           nmbrLet(&nmbrTmp, g_ProofInProgress.proof);
@@ -6616,7 +5354,7 @@ void command(int argc, char *argv[])
                     0, /*essentialFlag*/
                     0, /*axiomFlag*/
                     forbidMatchList,
-                    "", /*traceToList*/ /* 18-Jul-2015 nm */
+                    "", /*traceToList*/
                     1 /* testOnlyFlag */)) {
                   /* Yes, a forbidden statement occurred in traceProof() */
                   /* Revert the proof to before minimization */
@@ -6633,22 +5371,17 @@ void command(int argc, char *argv[])
                relatively rare case where a minimization occurred.  If the
                NO_NEW_AXIOMS_FROM condition applies, we then need to revert
                back to the original proof. */
-            /* 4-Aug-2019 nm */
             if (n == n + 0) {  /* By default, no new axioms are permitted */
             /*if (noNewAxiomsMatchList[0]) {*/ /* User provided /NO_NEW_AXIOMS_FROM */
               /* If we haven't called trace yet for the theorem being proved,
                  do it now. */
               if (traceProofFlags[0] == 0) {
 
-                /******** start of 29-Nov-2019 nm ************/
                 /* traceProofWork() was written to use the SAVEd proof and
                    not the proof in progress.  In order to use the proof in
                    progress, we temporarily put the proof in progress into the
                    (SAVEd) statement structure to trick traceProofWork() into using
                    the proof in progress instead of the SAVEd proof */
-                /* Bad code line between 4-Aug-2019 and 12-Feb-2020: */
-                /*nmbrLet(&nmbrSaveProof, nmbrSquishProof(g_ProofInProgress.proof));*/ /* Bad! */
-                /* 12-Feb-2020 nm */
                 /* Use the version of the proof in progress that existed *before* the
                    MINIMIZE_WITH command was invoked */
                 nmbrLet(&nmbrSaveProof, nmbrSquishProof(saveProofForReverting.proof));
@@ -6675,30 +5408,26 @@ void command(int argc, char *argv[])
                 /* We don't deallocate previous proofSectionPtr content because
                    we will recover it after the verifyProof() */
                 g_Statement[g_proveStatement].proofSectionPtr = str1;
-                /******** end of 29-Nov-2019 nm ************/
 
                 traceProofWork(g_proveStatement,
                     1 /*essentialFlag*/,
-                    "", /*traceToList*/ /* 18-Jul-2015 nm */
+                    "", /*traceToList*/
                     &traceProofFlags, /* y/n list of flags */
                     &nmbrTmp /* unproved list - ignored */);
                 nmbrLet(&nmbrTmp, NULL_NMBRSTRING); /* Discard */
 
-                /******** start of 29-Nov-2019 nm ************/
                 /* Restore the SAVEd proof */
                 g_Statement[g_proveStatement].proofSectionPtr
                     = saveZappedProofSectionPtr;
                 g_Statement[g_proveStatement].proofSectionLen
                     = saveZappedProofSectionLen;
                 g_Statement[g_proveStatement].proofSectionChanged
-                    = saveZappedProofSectionChanged; /* 16-Jun-2017 nm */
-                /******** end of 29-Nov-2019 nm ************/
-
+                    = saveZappedProofSectionChanged;
               }
               let(&traceTrialFlags, "");
               traceProofWork(k, /* The trial statement */
                   1 /*essentialFlag*/,
-                  "", /*traceToList*/ /* 18-Jul-2015 nm */
+                  "", /*traceToList*/
                   &traceTrialFlags, /* Y/N list of flags */
                   &nmbrTmp /* unproved list - ignored */);
               nmbrLet(&nmbrTmp, NULL_NMBRSTRING); /* Discard */
@@ -6712,20 +5441,12 @@ void command(int argc, char *argv[])
                     '*', '?') == 1
                       &&
                     matchesList(g_Statement[i].labelName, noNewAxiomsMatchList,
-                    '*', '?') != 1) { /* 4-Aug-2019 nm */
+                    '*', '?') != 1) {
                   /* If the axiom is in the list to allow and not in the list
                      to disallow, we don't care if the trial statement depends
                      on it */
                   continue;
                 }
-                /*
-                if (matchesList(g_Statement[i].labelName, noNewAxiomsMatchList,
-                    '@', '?') != 1) {
-                  /@ If the axiom isn't in the list to avoid, we don't
-                     care if the trial statement depends on it @/
-                  continue;
-                }
-                */
                 if (traceTrialFlags[i] == 'Y') {
                   /* The trial statement uses an axiom that the current
                      proof should avoid, so we abort it */
@@ -6774,7 +5495,6 @@ void command(int argc, char *argv[])
               }
             } /* if (nmbrLen(g_Statement[k].reqDisjVarsA) || !mayGrowFlag) */
 
-            /* 25-Jun-2014 nm */
             /* Make sure there are no $d violations, otherwise revert */
             /* This requires the str1 from above */
             if (nmbrLen(g_Statement[k].reqDisjVarsA)) {
@@ -6789,16 +5509,6 @@ void command(int argc, char *argv[])
               saveZappedProofSectionLen
                   = g_Statement[g_proveStatement].proofSectionLen;
 
-              /****** Obsolete due to 3-May-2017 update
-              /@ (search for "chr(1)" above for explanation) @/
-              let(&str1, cat(chr(1), "\n", str1, " $.\n", NULL));
-              g_Statement[g_proveStatement].proofSectionPtr = str1 + 1; /@ Compressed
-                                                     proof generated above @/
-              g_Statement[g_proveStatement].proofSectionLen =
-                  newCompressedLength + 4;
-              *******/
-
-              /******** start of 16-Jun-2017 nm ************/
               saveZappedProofSectionChanged
                   = g_Statement[g_proveStatement].proofSectionChanged;
               /* Set flag that this is not the original source */
@@ -6813,13 +5523,8 @@ void command(int argc, char *argv[])
               /* We don't deallocate previous proofSectionPtr content because
                  we will recover it after the verifyProof() */
               g_Statement[g_proveStatement].proofSectionPtr = str1;
-              /******** end of 16-Jun-2017 nm ************/
 
               g_outputToString = 1; /* Suppress error messages */
-              /* i = parseProof(g_proveStatement); */
-              /* if (i != 0) bug(1121); */
-              /* i = verifyProof(g_proveStatement); */
-              /* if (i != 0) bug(1122); */
               /* 15-Apr-2015 nm parseProof, verifyProof, cleanWkrProof must be
                  called in sequence to assign the g_WrkProof structure, verify
                  the proof, and deallocate the g_WrkProof structure.  Either none
@@ -6844,7 +5549,7 @@ void command(int argc, char *argv[])
               g_Statement[g_proveStatement].proofSectionLen
                   = saveZappedProofSectionLen;
               g_Statement[g_proveStatement].proofSectionChanged
-                  = saveZappedProofSectionChanged; /* 16-Jun-2017 nm */
+                  = saveZappedProofSectionChanged;
               if (i != 0 || j != 0) {
                 /* There was a verify proof error (j!=0) or $d violation (i!=0)
                    so don't used minimized proof */
@@ -6855,16 +5560,6 @@ void command(int argc, char *argv[])
               }
             } /* if (nmbrLen(g_Statement[k].reqDisjVarsA)) */
 
-            /* 25-Jun-2014 nm - not needed since trials now suppressed */
-            /*
-            if (verboseMode) {
-              print2("\n");
-            }
-            */
-
-            /*if (nmbrLen(g_Statement[k].reqDisjVarsA) || !mayGrowFlag) {*/
-
-            /* 3-May-2016 nm */
             /* Warn user if a discouraged statement is overridden */
             if (getMarkupFlag(k, USAGE_DISCOURAGED)) {
               if (!overrideFlag) bug(1126);
@@ -6916,18 +5611,7 @@ void command(int argc, char *argv[])
                 "Proof of \"%s\" remained at %ld steps using \"%s\".\n",
                 g_Statement[g_proveStatement].labelName,
                 m, g_Statement[k].labelName);
-            /* Distinct variable warning (obsolete) */
-            /*
-            if (nmbrLen(g_Statement[k].reqDisjVarsA)) {
-              printLongLine(cat("Note: \"", g_Statement[k].labelName,
-                  "\" has $d constraints.",
-                  "  SAVE NEW_PROOF then VERIFY PROOF to check them.",
-                  NULL), "", " ");
-            }
-            */
-            /* q = 0; */ /* Line length for label list */ /* 25-Jun-2014 del */
 
-            /* 8-Aug-2020 nm */
             /* See if it's in another mathbox; if so, let user know */
             assignMathboxInfo();
             if (k > g_mathboxStmt && g_proveStatement > g_mathboxStmt) {
@@ -6943,15 +5627,6 @@ void command(int argc, char *argv[])
             prntStatus = 2; /* Found one */
             g_proofChangedFlag = 1;
 
-            /* deleted 25-Jun-2014:
-            /@ 20-May-2012 nm @/
-            if (forbidMatchList[0]) { /@ User provided a /FORBID list @/
-              /@ Save the changed proof in case we have to restore
-                 it later @/
-              copyProofStruct(&saveProofForReverting, g_ProofInProgress);
-            }
-            */
-            /* 25-Jun-2014 nm */
             /* Save the changed proof in case we have to restore
                it later */
             copyProofStruct(&saveProofForReverting, g_ProofInProgress);
@@ -6959,15 +5634,8 @@ void command(int argc, char *argv[])
           }
 
         } /* Next k (statement) */
-        /* 25-Jun-2014 nm - not needed since trials now suppressed */
-        /*
-        if (verboseMode) {
-          if (prntStatus) print2("\n");
-        }
-        */
 
         if (g_proofChangedFlag && forwRevPass == 2) {
-          /* 25-Jun-2014 nm */
           /* Check whether the reverse pass found a better proof than the
              forward pass */
           if (verboseMode) {
@@ -6999,55 +5667,38 @@ void command(int argc, char *argv[])
         print2("?No earlier %s$p or $a label matches \"%s\".\n",
             (overrideFlag ? "" : "(allowed) "),  /* 3-May-2016 nm */
             g_fullArg[1]);
-      /* 25-Jun-2014 nm /NO_DISTINCT is obsolete
-      if (!prntStatus && noDistinctFlag) {
-        /@ 30-Jan-06 nm Added single-character-match wildcard argument @/
-        if (instr(1, g_fullArg[1], "@") || instr(1, g_fullArg[1], "?"))
-          print2("?No earlier $p or $a label (without $d) matches \"%s\".\n",
-              g_fullArg[1]);
-      }
-      */
-      /* 28-Jun-2011 nm */
       if (!mathboxFlag && g_proveStatement >= g_mathboxStmt) {
         print2(
   "(Other mathboxes were not checked.  Use / INCLUDE_MATHBOXES to include them.)\n");
       }
 
-      /* 16-Aug-2016 nm */
       if (printTime == 1) {
         getRunTime(&timeIncr);
         print2("MINIMIZE_WITH run time = %7.2f sec for \"%s\"\n", timeIncr,
             g_Statement[g_proveStatement].labelName);
       }
 
-      /* 23-Nov-2019 nm */
       let(&str1, ""); /* Deallocate memory */
       nmbrLet(&nmbrSaveProof, NULL_NMBRSTRING); /* Deallocate memory */
 
-      /* 23-Nov-2019 nm */
       /* Clear these Y/N trace strings unconditionally since new axioms are no
         longer  allowed by default, so they may become set regardless of
         qualifiers */
       let(&traceProofFlags, ""); /* Deallocate memory */
       let(&traceTrialFlags, ""); /* Deallocate memory */
 
-      /* 4-Aug-2019 nm */
       if (allowNewAxiomsMatchList[0]) { /* User provided /NO_NEW_AXIOMS_FROM list */
         let(&allowNewAxiomsMatchList, ""); /* Deallocate memory */
       }
 
-      /* 22-Nov-2014 nm */
       if (noNewAxiomsMatchList[0]) { /* User provided /ALLOW_NEW_AXIOMS list */
         let(&noNewAxiomsMatchList, ""); /* Deallocate memory */
       }
 
-      /* 20-May-2013 nm */
       if (forbidMatchList[0]) { /* User provided a /FORBID list */
-        /*deallocProofStruct(&saveProofForReverting);*/ /* Deallocate memory */
         let(&forbidMatchList, ""); /* Deallocate memory */
       }
 
-      /* 25-Jun-2014 nm */
       deallocProofStruct(&saveProofForReverting); /* Deallocate memory */
       deallocProofStruct(&saveOrigProof); /* Deallocate memory */
       deallocProofStruct(&save1stPassProof); /* Deallocate memory */
@@ -7061,7 +5712,6 @@ void command(int argc, char *argv[])
     } /* End if MINIMIZE_WITH */
 
 
-    /* 11-Sep-2016 nm Added EXPAND command */
     if (cmdMatches("EXPAND")) {
 
       g_proofChangedFlag = 0;
@@ -7070,14 +5720,12 @@ void command(int argc, char *argv[])
 
       for (i = g_proveStatement - 1; i >= 1; i--) {
         if (g_Statement[i].type != (char)p_) continue; /* Not a $p */
-        /* 30-Jan-06 nm Added single-character-match wildcard argument */
         if (!matchesList(g_Statement[i].labelName, g_fullArg[1], '*', '?')) {
           continue;
         }
         sourceStatement = i;
 
-        nmbrTmp = expandProof(nmbrSaveProof,
-            sourceStatement /*, g_proveStatement*/);
+        nmbrTmp = expandProof(nmbrSaveProof, sourceStatement);
 
         if (!nmbrEq(nmbrTmp, nmbrSaveProof)) {
           g_proofChangedFlag = 1;
@@ -7160,10 +5808,9 @@ void command(int argc, char *argv[])
           0 /*reverseFlag*/,
           0 /*noIndentFlag*/,
           0 /*splitColumn*/,
-          0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
+          0 /*skipRepeatedSteps*/,
           0 /*texFlag*/,
           0 /*g_htmlFlag*/);
-      /* 6/14/98 end */
 
       g_proofChanged = 1; /* Cumulative flag */
       processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
@@ -7219,10 +5866,9 @@ void command(int argc, char *argv[])
             0 /*reverseFlag*/,
             0 /*noIndentFlag*/,
             0 /*splitColumn*/,
-            0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
+            0 /*skipRepeatedSteps*/,
             0 /*texFlag*/,
             0 /*g_htmlFlag*/);
-        /* 6/14/98 end */
 
         g_proofChanged = 1; /* Cumulative flag */
         processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
@@ -7256,7 +5902,6 @@ void command(int argc, char *argv[])
         continue;
       }
 
-        /* Added 16-Apr-06 nm */
       if (cmdMatches("INITIALIZE USER")) {
         i = nmbrLen(g_ProofInProgress.proof);
         /* Delete all LET STEP assignments */
@@ -7270,9 +5915,7 @@ void command(int argc, char *argv[])
         processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
         continue;
       }
-      /* End 16-Apr-06 */
 
-      /* cmdMatches("INITIALIZE STEP") */
       s = (long)val(g_fullArg[2]); /* Step number */
       if (s > nmbrLen(g_ProofInProgress.proof) || s < 1) {
         print2("?The step must be in the range from 1 to %ld.\n",
@@ -7282,13 +5925,11 @@ void command(int argc, char *argv[])
 
       initStep(s - 1);
 
-      /* Also delete LET STEPs, per HELP INITIALIZE */          /* 16-Apr-06 */
-      nmbrLet((nmbrString **)(&((g_ProofInProgress.user)[s - 1])),  /* 16-Apr-06 */
-              NULL_NMBRSTRING);                                 /* 16-Apr-06 */
+      /* Also delete LET STEPs, per HELP INITIALIZE */
+      nmbrLet((nmbrString **)(&((g_ProofInProgress.user)[s - 1])),
+              NULL_NMBRSTRING);
 
-      print2(
-          "Step %ld and its hypotheses have been initialized.\n",
-          s);
+      print2("Step %ld and its hypotheses have been initialized.\n", s);
 
       g_proofChanged = 1; /* Cumulative flag */
       processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
@@ -7355,7 +5996,6 @@ void command(int argc, char *argv[])
           if (!p) break;
           let(&str1, cat(left(str1, p - 1), chr(3), right(str1, p + 1), NULL));
         }
-        /* End of 30-Jan-06 addition */
 
         /* Change wildcard to ASCII 2 (to be different from printable chars) */
         /* 1/3/02 (Why are we matching with and without space? I'm not sure.)*/
@@ -7381,8 +6021,6 @@ void command(int argc, char *argv[])
         while (1) {
           p = instr(1, str1, " $ ");
           if (!p) break;
-          /* 30-Jan-06 nm Bug fix - changed "2" to "3" below in order to
-             properly match 0 tokens */
           let(&str1, cat(left(str1, p - 1), chr(2), right(str1, p + 3), NULL));
         }
         while (1) {
@@ -7403,7 +6041,6 @@ void command(int argc, char *argv[])
             g_Statement[i].type != (char)a_) {
           continue; /* No /ALL switch */
         }
-        /* 30-Jan-06 nm Added single-character-match wildcard argument */
         if (!matchesList(g_Statement[i].labelName, g_fullArg[1], '*', '?'))
           continue;
         if (n) { /* COMMENTS switch */
@@ -7418,7 +6055,8 @@ void command(int argc, char *argv[])
           /* Strip linefeeds and reduce spaces */
           let(&str2, edit(str2, 4 + 8 + 16 + 128));
           j = j + ((long)strlen(str1) / 2); /* Center of match location */
-          p = g_screenWidth - 7 - (long)strlen(str((double)i)) - (long)strlen(g_Statement[i].labelName);
+          p = g_screenWidth - 7 - (long)strlen(str((double)i)) -
+            (long)strlen(g_Statement[i].labelName);
                         /* Longest comment portion that will fit in one line */
           q = (long)strlen(str2); /* Length of comment */
           if (q <= p) { /* Use entire comment */
@@ -7441,7 +6079,6 @@ void command(int argc, char *argv[])
         } else { /* No COMMENTS switch */
           let(&str2,nmbrCvtMToVString(g_Statement[i].mathString));
 
-          /* 14-Apr-2008 nm JOIN flag */
           tmpFlag = 0; /* Flag that $p or $a is already in string */
           if (joinFlag && (g_Statement[i].type == (char)p_ ||
               g_Statement[i].type == (char)a_)) {
@@ -7473,7 +6110,6 @@ void command(int argc, char *argv[])
           let(&str2, left(str3, q + s));
 
           let(&str2, cat(" ", str2, " ", NULL));
-          /* 30-Jan-06 nm Added single-character-match wildcard argument */
           /* We should use matches() and not matchesList() here, because
              commas can be legal token characters in math symbols */
           if (!matches(str2, str1, 2/* ascii 2 0-or-more-token match char*/,
@@ -7495,7 +6131,6 @@ void command(int argc, char *argv[])
     if (cmdMatches("SET ECHO")) {
       if (cmdMatches("SET ECHO ON")) {
         g_commandEcho = 1;
-        /* 15-Jun-2009 nm Added "!" (see 15-Jun-2009 note above) */
         print2("!SET ECHO ON\n");
         print2("Command line echoing is now turned on.\n");
       } else {
@@ -7558,20 +6193,9 @@ void command(int argc, char *argv[])
       continue;
     }
 
-    if (cmdMatches("SET WIDTH")) { /* 18-Nov-85 nm Was SCREEN_WIDTH */
+    if (cmdMatches("SET WIDTH")) {
       s = (long)val(g_fullArg[2]); /* Screen width value */
 
-      /************ 19-Jun-2020 nm printBuffer is now dynamically allocated
-      if (s >= PRINTBUFFERSIZE - 1) {
-        print2(
-"?Maximum screen width is %ld.  Recompile with larger PRINTBUFFERSIZE in\n",
-            (long)(PRINTBUFFERSIZE - 2));
-        print2("mminou.h if you need more.\n");
-        continue;
-      }
-      *************/
-
-      /* 26-Sep-2017 nm */
       /* TODO: figure out why s=2 crashes program! */
       if (s < 3) s = 3; /* Less than 3 may cause a segmentation fault */
       i = g_screenWidth;
@@ -7582,7 +6206,7 @@ void command(int argc, char *argv[])
     }
 
 
-    if (cmdMatches("SET HEIGHT")) {  /* 18-Nov-05 nm Added */
+    if (cmdMatches("SET HEIGHT")) {
       s = (long)val(g_fullArg[2]); /* Screen height value */
       if (s < 2) s = 2;  /* Less than 2 makes no sense */
       i = g_screenHeight;
@@ -7595,7 +6219,6 @@ void command(int argc, char *argv[])
     }
 
 
-    /* 10-Jul-2016 nm */
     if (cmdMatches("SET DISCOURAGEMENT")) {
       if (!strcmp(g_fullArg[2], "ON")) {
         g_globalDiscouragement = 1;
@@ -7617,7 +6240,6 @@ void command(int argc, char *argv[])
     }
 
 
-    /* 14-May-2017 nm */
     if (cmdMatches("SET CONTRIBUTOR")) {
       print2("\"Contributed by...\" name was changed from \"%s\" to \"%s\"\n",
           g_contributorName, g_fullArg[2]);
@@ -7626,7 +6248,6 @@ void command(int argc, char *argv[])
     }
 
 
-    /* 31-Dec-2017 nm */
     if (cmdMatches("SET ROOT_DIRECTORY")) {
       let(&str1, g_rootDirectory); /* Save previous one */
       let(&g_rootDirectory, edit(g_fullArg[2], 2/*discard spaces,tabs*/));
@@ -7646,7 +6267,7 @@ void command(int argc, char *argv[])
           }
         }
       }
-      if (strcmp(str1, g_rootDirectory)){
+      if (strcmp(str1, g_rootDirectory)) {
         print2("Root directory was changed from \"%s\" to \"%s\"\n",
             str1, g_rootDirectory);
       }
@@ -7655,7 +6276,6 @@ void command(int argc, char *argv[])
     }
 
 
-    /* 1-Nov-2013 nm Added UNDO */
     if (cmdMatches("SET UNDO")) {
       s = (long)val(g_fullArg[2]); /* Maximum UNDOs */
       if (s < 0) s = 0;  /* Less than 0 UNDOs makes no sense */
@@ -7712,21 +6332,7 @@ void command(int argc, char *argv[])
     }
 
     if (cmdMatches("OPEN TEX")) {
-    /* 2-Oct-2017 nm OPEN HTML is very obsolete, no need to warn anymore
-    if (cmdMatches("OPEN TEX") || cmdMatches("OPEN HTML") ) {
-      if (cmdMatches("OPEN HTML")) {
-        print2("?OPEN HTML is obsolete - use SHOW STATEMENT * / HTML\n");
-        continue;
-      }
-    */
-
-      /* 17-Nov-2015 TODO: clean up mixed LaTeX/HTML attempts (check
-         g_texFileOpenFlag when switching to HTML & close LaTeX file) */
-
       if (g_texDefsRead) {
-        /* Current limitation - can only read .def once */
-        /* 2-Oct-2017 nm OPEN HTML is obsolete */
-        /*if (cmdMatches("OPEN HTML") != g_htmlFlag) {*/
         if (g_htmlFlag) {
           /* Actually it isn't clear to me this is still the case, but
              to be safe I left it in */
@@ -7755,7 +6361,6 @@ void command(int argc, char *argv[])
       g_texFilePtr = fSafeOpen(g_texFileName, "w", 0/*noVersioningFlag*/);
       if (!g_texFilePtr) continue; /* Couldn't open it (err msg was provided) */
       g_texFileOpenFlag = 1;
-      /* 2-Oct-2017 nm OPEN HTML is obsolete */
       print2("Created %s output file \"%s\".\n",
           g_htmlFlag ? "HTML" : "LaTeX", g_texFileName);
       printTexHeader(texHeaderFlag);
@@ -7763,28 +6368,6 @@ void command(int argc, char *argv[])
       continue;
     }
 
-    /* 2-Oct-2017 nm CLOSE HTML is obsolete */
-    /******
-    if (cmdMatches("CLOSE TEX") || cmdMatches("CLOSE HTML")) {
-      if (cmdMatches("CLOSE HTML")) {
-        print2("?CLOSE HTML is obsolete - use SHOW STATEMENT @ / HTML\n");
-        continue;
-      }
-      /@ Close the TeX file @/
-      if (!g_texFileOpenFlag) {
-        print2("?Sorry, there is no %s file currently open.\n",
-            g_htmlFlag ? "HTML" : "LaTeX");
-      } else {
-        print2("The %s output file \"%s\" has been closed.\n",
-            g_htmlFlag ? "HTML" : "LaTeX", g_texFileName);
-        printTexTrailer(texHeaderFlag);
-        fclose(g_texFilePtr);
-        g_texFileOpenFlag = 0;
-      }
-      let(&g_texFileName,"");
-      continue;
-    }
-    *****/
     if (cmdMatches("CLOSE TEX")) {
       /* Close the TeX file */
       if (!g_texFileOpenFlag) {
@@ -7930,7 +6513,7 @@ void command(int argc, char *argv[])
         g_sourceChanged = 0;
       }
       eraseSource();
-      g_sourceHasBeenRead = 0; /* Global variable */ /* 31-Dec-2017 nm */
+      g_sourceHasBeenRead = 0; /* Global variable */
       g_showStatement = 0;
       g_proveStatement = 0;
       print2("Metamath has been reset to the starting state.\n");
@@ -7946,9 +6529,6 @@ void command(int argc, char *argv[])
       continue;
     }
 
-    /* 7-Nov-2015 nm New */  /* 17-Nov-2015 nm Updated */
-    /* 25-Jun-2020 nm Added UNDERSCORE_SKIP */
-    /* 17-Jul-2020 nm Added MATHBOX_SKIP */
     if (cmdMatches("VERIFY MARKUP")) {
       i = (switchPos("/ DATE_SKIP") != 0) ? 1 : 0;
       j = (switchPos("/ TOP_DATE_SKIP") != 0) ? 1 : 0;
@@ -7967,7 +6547,7 @@ void command(int argc, char *argv[])
           (flag)k, /* 1 = skip checking external files GIF, mmset.html,... */
           (flag)l, /* 1 = skip checking labels for underscores */
           (flag)m, /* 1 = skip checking mathbox cross-references */
-          (flag)n); /* 1 = verbose mode */  /* 26-Dec-2016 nm */
+          (flag)n); /* 1 = verbose mode */
       continue;
     }
 

--- a/metamath.c
+++ b/metamath.c
@@ -3652,6 +3652,12 @@ void command(int argc, char *argv[])
       if (i) endStep = (long)val(g_fullArg[i + 1]);
       i = switchPos("/ DEPTH");
       if (i) endIndent = (long)val(g_fullArg[i + 1]);
+      /* ESSENTIAL is retained for downwards compatibility, but is
+         now the default, so we ignore it. */
+      /*
+      i = switchPos("/ ESSENTIAL");
+      if (i) essentialFlag = 1;
+      */
       i = switchPos("/ ALL");
       if (i) essentialFlag = 0;
       if (i && switchPos("/ ESSENTIAL")) {
@@ -6577,3 +6583,5 @@ void command(int argc, char *argv[])
 
   }
 } /* command */
+
+

--- a/metamath.c
+++ b/metamath.c
@@ -687,7 +687,6 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>
-/* #include <time.h> */ /* 21-Jun-2014 nm For ELAPSED_TIME */
 #include "mmvstr.h"
 #include "mmdata.h"
 #include "mmcmdl.h"
@@ -704,8 +703,7 @@
 
 void command(int argc, char *argv[]);
 
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
 
 /* argc is the number of arguments; argv points to an array containing them */
 
@@ -727,12 +725,11 @@ int main(int argc, char *argv[])
     /*print2("Metamath - Version %s\n", MVERSION);*/
     print2("Metamath - Version %s%s", MVERSION, space(27 - (long)strlen(MVERSION)));
   }
-  /* if (argc < 2) */ print2("Type HELP for help, EXIT to exit.\n");
+  print2("Type HELP for help, EXIT to exit.\n");
 
   /* Allocate big arrays */
   initBigArrays();
 
-  /* 14-May-2017 nm */
   /* Set the default contributor */
   let(&g_contributorName, DEFAULT_CONTRIBUTOR);
 
@@ -751,8 +748,7 @@ int main(int argc, char *argv[])
 
 
 
-void command(int argc, char *argv[])
-{
+void command(int argc, char *argv[]) {
   /* Command line user interface -- this is an infinite loop; it fetches and
      processes a command; returns only if the command is 'EXIT' or 'QUIT' and
      never returns otherwise. */
@@ -772,7 +768,7 @@ void command(int argc, char *argv[])
   pntrString *expandedProof = NULL_PNTRSTRING;
   flag tmpFlag;
 
-  /* 1-Nov-2013 nm proofSavedFlag tells us there was at least one
+  /* proofSavedFlag tells us there was at least one
      SAVE NEW_PROOF during the MM-PA session while the UNDO stack wasn't
      empty, meaning that "UNDO stack empty" is no longer a reliable indication
      that the proof wasn't changed.  It is cleared upon entering MM-PA, and
@@ -794,19 +790,19 @@ void command(int argc, char *argv[])
   long detailStep;
   flag noIndentFlag; /* Flag to use non-indented display */
   long splitColumn; /* Column at which formula starts in nonindented display */
-  flag skipRepeatedSteps; /* NO_REPEATED_STEPS qualifier */ /* 28-Jun-2013 nm */
+  flag skipRepeatedSteps; /* NO_REPEATED_STEPS qualifier */
   flag texFlag; /* Flag for TeX */
   flag saveFlag; /* Flag to save in source */
-  flag fastFlag; /* Flag for SAVE PROOF.../FAST */ /* 2-Jan-2017 nm */
+  flag fastFlag; /* Flag for SAVE PROOF.../FAST */
   long indentation; /* Number of spaces to indent proof */
   vstring labelMatch = ""; /* SHOW PROOF <label> argument */
 
   flag axiomFlag; /* For SHOW TRACE_BACK */
-  flag treeFlag; /* For SHOW TRACE_BACK */ /* 19-May-2013 nm */
-  flag countStepsFlag; /* For SHOW TRACE_BACK */ /* 19-May-2013 nm */
-  flag matchFlag; /* For SHOW TRACE_BACK */ /* 19-May-2013 nm */
-  vstring matchList = "";  /* For SHOW TRACE_BACK */ /* 19-May-2013 nm */
-  vstring traceToList = ""; /* For SHOW TRACE_BACK */ /* 18-Jul-2015 nm */
+  flag treeFlag; /* For SHOW TRACE_BACK */
+  flag countStepsFlag; /* For SHOW TRACE_BACK */
+  flag matchFlag; /* For SHOW TRACE_BACK */
+  vstring matchList = "";  /* For SHOW TRACE_BACK */
+  vstring traceToList = ""; /* For SHOW TRACE_BACK */
   flag recursiveFlag; /* For SHOW USAGE */
   long fromLine, toLine; /* For TYPE, SEARCH */
   flag joinFlag; /* For SEARCH */
@@ -816,61 +812,60 @@ void command(int argc, char *argv[])
   nmbrString *essentialFlags = NULL_NMBRSTRING;
                                             /* For ASSIGN/IMPROVE FIRST/LAST */
   long improveDepth; /* For IMPROVE */
-  flag searchAlg; /* For IMPROVE */ /* 22-Aug-2012 nm */
-  flag searchUnkSubproofs;  /* For IMPROVE */ /* 4-Sep-2012 nm */
-  flag dummyVarIsoFlag; /* For IMPROVE */ /* 25-Aug-2012 nm */
-  long improveAllIter; /* For IMPROVE ALL */ /* 25-Aug-2012 nm */
-  flag proofStepUnk; /* For IMPROVE ALL */ /* 25-Aug-2012 nm */
+  flag searchAlg; /* For IMPROVE */
+  flag searchUnkSubproofs;  /* For IMPROVE */
+  flag dummyVarIsoFlag; /* For IMPROVE */
+  long improveAllIter; /* For IMPROVE ALL */
+  flag proofStepUnk; /* For IMPROVE ALL */
 
   flag texHeaderFlag; /* For OPEN TEX, CLOSE TEX */
   flag commentOnlyFlag; /* For SHOW STATEMENT */
   flag briefFlag; /* For SHOW STATEMENT */
   flag linearFlag; /* For SHOW LABELS */
   vstring bgcolor = ""; /* For SHOW STATEMENT definition list */
-                                                            /* 8-Aug-2008 nm */
 
   flag verboseMode, mayGrowFlag /*, noDistinctFlag*/; /* For MINIMIZE_WITH */
   long prntStatus; /* For MINIMIZE_WITH */
   flag hasWildCard; /* For MINIMIZE_WITH */
   long exceptPos; /* For MINIMIZE_WITH */
-  flag mathboxFlag; /* For MINIMIZE_WITH */ /* 28-Jun-2011 nm */
-  long thisMathboxStartStmt; /* For MINIMIZE_WITH */ /* 14-Aug-2012 nm */
-  flag forwFlag; /* For MINIMIZE_WITH */ /* 11-Nov-2011 nm */
-  long forbidMatchPos;  /* For MINIMIZE_WITH */ /* 20-May-2013 nm */
-  vstring forbidMatchList = "";  /* For MINIMIZE_WITH */ /* 20-May-2013 nm */
-  long noNewAxiomsMatchPos;  /* For NO_NEW_AXIOMS_FROM */ /* 22-Nov-2014 nm */
-  vstring noNewAxiomsMatchList = "";  /* For NO_NEW_AXIOMS_FROM */ /* 22-Nov-2014 */
-  long allowNewAxiomsMatchPos;  /* For NO_NEW_AXIOMS_FROM */ /* 4-Aug-2019 nm */
-  vstring allowNewAxiomsMatchList = "";  /* For NO_NEW_AXIOMS_FROM */ /* 4-Aug-2019 */
-  vstring traceProofFlags = ""; /* For NO_NEW_AXIOMS_FROM */ /* 22-Nov-2014 nm */
-  vstring traceTrialFlags = ""; /* For NO_NEW_AXIOMS_FROM */ /* 22-Nov-2014 nm */
-  flag overrideFlag; /* For discouraged statement /OVERRIDE */ /* 3-May-2016 nm */
+  flag mathboxFlag; /* For MINIMIZE_WITH */
+  long thisMathboxStartStmt; /* For MINIMIZE_WITH */
+  flag forwFlag; /* For MINIMIZE_WITH */
+  long forbidMatchPos;  /* For MINIMIZE_WITH */
+  vstring forbidMatchList = "";  /* For MINIMIZE_WITH */
+  long noNewAxiomsMatchPos;  /* For NO_NEW_AXIOMS_FROM */
+  vstring noNewAxiomsMatchList = "";  /* For NO_NEW_AXIOMS_FROM */
+  long allowNewAxiomsMatchPos;  /* For NO_NEW_AXIOMS_FROM */
+  vstring allowNewAxiomsMatchList = "";  /* For NO_NEW_AXIOMS_FROM */
+  vstring traceProofFlags = ""; /* For NO_NEW_AXIOMS_FROM */
+  vstring traceTrialFlags = ""; /* For NO_NEW_AXIOMS_FROM */
+  flag overrideFlag; /* For discouraged statement /OVERRIDE */
 
   struct pip_struct saveProofForReverting = {
        NULL_NMBRSTRING, NULL_PNTRSTRING, NULL_PNTRSTRING, NULL_PNTRSTRING };
-                                   /* For MINIMIZE_WITH */ /* 20-May-2013 nm */
-  long origCompressedLength; /* For MINIMIZE_WITH */ /* 25-Jun-2014 nm */
-  long oldCompressedLength = 0; /* For MINIMIZE_WITH */ /* 25-Jun-2014 nm */
-  long newCompressedLength = 0; /* For MINIMIZE_WITH */ /* 25-Jun-2014 nm */
-  long forwardCompressedLength = 0; /* For MINIMIZE_WITH */ /* 25-Jun-2014 nm */
-  long forwardLength = 0; /* For MINIMIZE_WITH */ /* 25-Jun-2014 nm */
+                                   /* For MINIMIZE_WITH */
+  long origCompressedLength; /* For MINIMIZE_WITH */
+  long oldCompressedLength = 0; /* For MINIMIZE_WITH */
+  long newCompressedLength = 0; /* For MINIMIZE_WITH */
+  long forwardCompressedLength = 0; /* For MINIMIZE_WITH */
+  long forwardLength = 0; /* For MINIMIZE_WITH */
   vstring saveZappedProofSectionPtr; /* Pointer only */ /* For MINIMIZE_WITH */
-  long saveZappedProofSectionLen; /* For MINIMIZE_WITH */ /* 25-Jun-2014 nm */
-  flag saveZappedProofSectionChanged; /* For MINIMIZE_WITH */ /* 16-Jun-2017 nm */
+  long saveZappedProofSectionLen; /* For MINIMIZE_WITH */
+  flag saveZappedProofSectionChanged; /* For MINIMIZE_WITH */
 
   struct pip_struct saveOrigProof = {
        NULL_NMBRSTRING, NULL_PNTRSTRING, NULL_PNTRSTRING, NULL_PNTRSTRING };
-                                   /* For MINIMIZE_WITH */ /* 25-Jun-2014 nm */
+                                   /* For MINIMIZE_WITH */
   struct pip_struct save1stPassProof = {
        NULL_NMBRSTRING, NULL_PNTRSTRING, NULL_PNTRSTRING, NULL_PNTRSTRING };
-                                   /* For MINIMIZE_WITH */ /* 25-Jun-2014 nm */
-  long forwRevPass; /* 1 = forward pass */ /* 25-Jun-2014 nm */
+                                   /* For MINIMIZE_WITH */
+  long forwRevPass; /* 1 = forward pass */
 
-  long sourceStatement; /* For EXPAND */ /* 11-Sep-2016 nm */
+  long sourceStatement; /* For EXPAND */
 
-  flag showLemmas; /* For WRITE THEOREM_LIST */ /* 10-Oct-2012 nm */
-  flag noVersioning; /* For WRITE THEOREM_LIST & others */ /* 17-Jul-2019 nm */
-  long theoremsPerPage; /* For WRITE THEOREM_LIST */ /* 17-Jul-2019 nm */
+  flag showLemmas; /* For WRITE THEOREM_LIST */
+  flag noVersioning; /* For WRITE THEOREM_LIST & others */
+  long theoremsPerPage; /* For WRITE THEOREM_LIST */
 
   /* g_toolsMode-specific variables */
   flag commandProcessedFlag = 0; /* Set when the first command line processed;
@@ -886,23 +881,17 @@ void command(int argc, char *argv[])
   flag cmdMode, changedFlag, outMsgFlag;
   double sum;
   vstring bufferedLine = "";
-  vstring tagStartMatch = "";  /* 2-Jul-2011 nm For TAG command */
-  long tagStartCount = 0;      /* 2-Jul-2011 nm For TAG command */
-  vstring tagEndMatch = "";    /* 2-Jul-2011 nm For TAG command */
-  long tagEndCount = 0;        /* 2-Jul-2011 nm For TAG command */
-  long tagStartCounter = 0;    /* 2-Jul-2011 nm For TAG command */
-  long tagEndCounter = 0;      /* 2-Jul-2011 nm For TAG command */
+  vstring tagStartMatch = "";  /* For TAG command */
+  long tagStartCount = 0;      /* For TAG command */
+  vstring tagEndMatch = "";    /* For TAG command */
+  long tagEndCount = 0;        /* For TAG command */
+  long tagStartCounter = 0;    /* For TAG command */
+  long tagEndCounter = 0;      /* For TAG command */
 
-  /* 21-Jun-2014 */
-  /* 16-Aug-2016 nm Now in getElapasedTime() */
-  /* clock_t timePrevious = 0; */  /* For SHOW ELAPSED_TIME command */
-  /* clock_t timeNow = 0; */       /* For SHOW ELAPSED_TIME command */
-  /* 16-Aug-2016 nm */
   double timeTotal = 0;
   double timeIncr = 0;
   flag printTime;  /* Set by "/ TIME" in SAVE PROOF and others */
 
-  /* 14-Aug-2018 nm */
   flag defaultScrollMode = 1; /* Default to prompted mode */
 
   /* Initialization to avoid compiler warning (should not be theoretically
@@ -912,10 +901,10 @@ void command(int argc, char *argv[])
   s = 0;
   texHeaderFlag = 0;
   firstChangedLine = 0;
-  tagStartCount = 0;           /* 2-Jul-2011 nm For TAG command */
-  tagEndCount = 0;             /* 2-Jul-2011 nm For TAG command */
-  tagStartCounter = 0;         /* 2-Jul-2011 nm For TAG command */
-  tagEndCounter = 0;           /* 2-Jul-2011 nm For TAG command */
+  tagStartCount = 0;           /* For TAG command */
+  tagEndCount = 0;             /* For TAG command */
+  tagStartCounter = 0;         /* For TAG command */
+  tagEndCounter = 0;           /* For TAG command */
 
   while (1) {
 
@@ -966,7 +955,7 @@ void command(int argc, char *argv[])
     let(&labelMatch, "");
     /* (End of space deallocation) */
 
-    g_midiFlag = 0; /* 8/28/00 Initialize here in case SHOW PROOF exits early */
+    g_midiFlag = 0; /* Initialize here in case SHOW PROOF exits early */
 
     if (g_memoryStatus) {
       /*??? Change to user-friendly message */
@@ -993,7 +982,6 @@ void command(int argc, char *argv[])
 
     if (!commandProcessedFlag && argc > 1 && argsProcessed < argc - 1
         && g_commandFileNestingLevel == 0) {
-      /* if (g_toolsMode) { */  /* 10-Oct-2006 nm Fix bug: changed to g_listMode */
       if (g_listMode) {
         /* If program was compiled in TOOLS mode, the command-line argument
            is assumed to be a single TOOLS command; build the equivalent
@@ -1034,39 +1022,6 @@ void command(int argc, char *argv[])
             /* Put quotes so / won't be interpreted as qualifier separator */
             let(&g_commandLine, cat("READ \"", g_commandLine, "\"", NULL));
           }
-
-          /***** 3-Jan-2017 nm  This is now done with SET ROOT_DIRECTORY
-          /@ 31-Dec-2017 nm @/
-          /@ This block of code can be removed without side effects @/
-          /@ "Hidden" hack for NM's convenience. :)  If there is an =, change
-             it to space.  This lets users invoke with "metamath set.mm/h=test"
-             or "metamath mbox/aa.mm/home=test" to specify an implicit read with
-             /ROOT_DIRECTORY without having a space in the argument (a space
-             means don't assume a read command). @/
-          i = instr(1, g_commandLine, "=");
-          if (i != 0) {
-            /@ Change 'READ "set.mm/h=test"' to 'READ "set.mm" / "h" "test"' @/
-            let(&g_commandLine, cat(left(g_commandLine, i - 1), "\" \"",
-                right(g_commandLine, i + 1), NULL));
-            while (i > 0) {
-              if (g_commandLine[i - 1] == '/') {
-                let(&g_commandLine, cat(left(g_commandLine, i - 1),
-                    "\" / \"", right(g_commandLine, i + 1), NULL));
-                break;
-              }
-              i--;
-            }
-            /@ Change ' to " to prevent mismatched quotes @/
-            i = (long)strlen(g_commandLine);
-            while (i > 0) {
-              if (g_commandLine[i - 1] == '\'') {
-                g_commandLine[i - 1] = '"';
-              }
-              i--;
-            }
-          } /@ if i != 0 (end of 31-Dec-2017 NM hack) @/
-          */
-
         }
       }
       print2("%s\n", cat(g_commandPrompt, g_commandLine, NULL));
@@ -1145,7 +1100,6 @@ void command(int argc, char *argv[])
         fprintf(g_listFile_fp, "%s\n", str1);  /* Print to list command file */
       }
       if (g_commandEcho) {
-        /* 15-Jun-2009 nm Added code line below */
         /* Put special character "!" before line for easier extraction to
            build SUBMIT files; see also SET ECHO ON output below */
         let(&str1, cat("!", str1, NULL));
@@ -1176,7 +1130,7 @@ void command(int argc, char *argv[])
       } else {
         help1(str1);
         help2(str1);
-        help3(str1); /* 18-Jul-2015 nm */
+        help3(str1);
       }
       continue;
     }
@@ -1195,13 +1149,9 @@ void command(int argc, char *argv[])
       continue;
     }
 
-    if (cmdMatches("EXIT") || cmdMatches("QUIT")
-        || cmdMatches("_EXIT_PA")) { /* 9-Jun-2016 - for MM-PA> exit
-            in scripts, so it will error out in MM> (if for some reason
-            MM-PA wasn't entered) instead of exiting metamath */
-    /*???        || !strcmp(cmd,"^Z")) { */
-
-      /* 9-Jun-2016 */
+    if (cmdMatches("EXIT") || cmdMatches("QUIT") || cmdMatches("_EXIT_PA")) {
+      /* for MM-PA> exit in scripts, so it will error out in MM> (if for some reason
+        MM-PA wasn't entered) instead of exiting metamath */
       if (cmdMatches("_EXIT_PA")) {
         if (!g_PFASmode || (g_toolsMode && !g_listMode)) bug(1127);
                  /* mmcmdl.c should have caught this */
@@ -1233,8 +1183,7 @@ void command(int argc, char *argv[])
                  || proofSavedFlag)) {
           print2(
               "Warning:  You have not saved changes to the proof of \"%s\".\n",
-              g_Statement[g_proveStatement].labelName); /* 21-Jan-06 nm */
-          /* 17-Aug-04 nm Added / FORCE qualifier */
+              g_Statement[g_proveStatement].labelName);
           if (switchPos("/ FORCE") == 0) {
             str1 = cmdInput1("Do you want to EXIT anyway (Y, N) <N>? ");
             if (str1[0] != 'y' && str1[0] != 'Y') {
@@ -1251,34 +1200,16 @@ void command(int argc, char *argv[])
         processUndoStack(NULL, PUS_INIT, "", 0);
         proofSavedFlag = 0; /* Will become 1 if proof is ever saved */
 
-        print2(
- "Exiting the Proof Assistant.  Type EXIT again to exit Metamath.\n");
+        print2("Exiting the Proof Assistant.  Type EXIT again to exit Metamath.\n");
 
         /* Deallocate proof structure */
-        deallocProofStruct(&g_ProofInProgress); /* 20-May-2013 nm */
-
-        /**** old deallocation before 20-May-2013
-        i = nmbrLen(g_ProofInProgress.proof);
-        nmbrLet(&g_ProofInProgress.proof, NULL_NMBRSTRING);
-        for (j = 0; j < i; j++) {
-          nmbrLet((nmbrString **)(&((g_ProofInProgress.target)[j])),
-              NULL_NMBRSTRING);
-          nmbrLet((nmbrString **)(&((g_ProofInProgress.source)[j])),
-              NULL_NMBRSTRING);
-          nmbrLet((nmbrString **)(&((g_ProofInProgress.user)[j])),
-              NULL_NMBRSTRING);
-        }
-        pntrLet(&g_ProofInProgress.target, NULL_PNTRSTRING);
-        pntrLet(&g_ProofInProgress.source, NULL_PNTRSTRING);
-        pntrLet(&g_ProofInProgress.user, NULL_PNTRSTRING);
-        *** end of old code before 20-May-2013 */
+        deallocProofStruct(&g_ProofInProgress);
 
         g_PFASmode = 0;
         continue;
       } else {
         if (g_sourceChanged) {
           print2("Warning:  You have not saved changes to the source.\n");
-          /* 17-Aug-04 nm Added / FORCE qualifier */
           if (switchPos("/ FORCE") == 0) {
             str1 = cmdInput1("Do you want to EXIT anyway (Y, N) <N>? ");
             if (str1[0] != 'y' && str1[0] != 'Y') {
@@ -1306,7 +1237,6 @@ void command(int argc, char *argv[])
           g_logFileOpenFlag = 0;
         }
 
-        /* 4-May-2017 Ari Ferrera */
         /* Free remaining allocations before exiting */
         freeCommandLine();
         freeInOu();
@@ -1316,7 +1246,7 @@ void command(int argc, char *argv[])
         let(&g_commandPrompt,"");
         let(&g_commandLine,"");
         let(&g_input_fn,"");
-        let(&g_contributorName, ""); /* 14-May-2017 nm */
+        let(&g_contributorName, "");
 
         return; /* Exit from program */
       }
@@ -1335,7 +1265,6 @@ void command(int argc, char *argv[])
       g_commandFileName[g_commandFileNestingLevel] = ""; /* Initialize if nec. */
       let(&g_commandFileName[g_commandFileNestingLevel], g_fullArg[1]);
 
-      /* 23-Oct-2006 nm Added / SILENT */
       g_commandFileSilent[g_commandFileNestingLevel] = 0;
       if (switchPos("/ SILENT")
           || g_commandFileSilentFlag /* Propagate silence from outer level */) {
@@ -1363,7 +1292,7 @@ void command(int argc, char *argv[])
 #define BUILD_MODE 8
 #define MATCH_MODE 9
 #define RIGHT_MODE 10
-#define TAG_MODE 11  /* 2-Jul-2011 nm Added TAG command */
+#define TAG_MODE 11  /* Added TAG command */
       cmdMode = 0;
       if (cmdMatches("ADD")) cmdMode = ADD_MODE;
       else if (cmdMatches("DELETE")) cmdMode = DELETE_MODE;
@@ -1405,7 +1334,7 @@ void command(int argc, char *argv[])
         switch (cmdMode) {
           case ADD_MODE:
             break;
-          case TAG_MODE:  /* 2-Jul-2011 nm Added TAG command */
+          case TAG_MODE:
             let(&tagStartMatch, g_fullArg[4]);
             tagStartCount = (long)val(g_fullArg[5]);
             if (tagStartCount == 0) tagStartCount = 1; /* Default */
@@ -1486,7 +1415,7 @@ void command(int argc, char *argv[])
               let(&str2, cat(g_fullArg[2], str1, g_fullArg[3], NULL));
               if (strcmp(str1, str2)) changedLines++;
               break;
-            case TAG_MODE:   /* 2-Jul-2011 nm Added TAG command */
+            case TAG_MODE:
               if (tagStartCounter < tagStartCount) {
                 if (instr(1, str1, tagStartMatch)) tagStartCounter++;
               }
@@ -1561,7 +1490,7 @@ void command(int argc, char *argv[])
                     lines++;
                     changedLines++;
                   }
-                  /* 14-Sep-2010 nm Continue the search after the replacement
+                  /* Continue the search after the replacement
                      string, so that "SUBST 1.tmp abbb ab a ''" will change
                      "abbbab" to "abba" rather than "aa" */
                   p1 = p1 + (long)strlen(newstr) - 1;
@@ -1604,7 +1533,7 @@ void command(int argc, char *argv[])
                   /* Even though space is always a separator, it can be used
                      to suppress all default tokens.  Go past 2nd space to prevent
                      infinite loop in that case. */
-                  p += 2; /* 3-Jul-2020 nm */
+                  p += 2;
                 }
               }
               let(&str2, edit(str2, 8 + 16 + 128)); /* Reduce & trim spaces */
@@ -1684,7 +1613,7 @@ void command(int argc, char *argv[])
         p = instr(1, str3, "\n");
         if (p) let(&str3, left(str3, p - 1));
         if (!outMsgFlag) {
-          /* 18-Aug-2011 nm Make message depend on line counts */
+          /* Make message depend on line counts */
           if (!changedFlag) {
             if (!lines) {
               print2("The file %s has no lines.\n", g_fullArg[1]);
@@ -1722,8 +1651,8 @@ void command(int argc, char *argv[])
         fclose(list2_fp);
         fSafeRename(list2_ftmpname, list2_fname);
         /* Deallocate string memory */
-        let(&tagStartMatch, "");  /* 2-Jul-2011 nm Added TAG command */
-        let(&tagEndMatch, "");  /* 2-Jul-2011 nm Added TAG command */
+        let(&tagStartMatch, "");
+        let(&tagEndMatch, "");
         continue;
       } /* end if cmdMode for ADD, etc. */
 
@@ -1984,8 +1913,7 @@ void command(int argc, char *argv[])
 "The first longest line (out of %ld) is line %ld and has %ld characters:\n",
             j, i, q);
         printLongLine(str4, "    "/*startNextLine*/, ""/*breakMatch*/);
-            /* breakMatch empty means break line anywhere */  /* 6-Dec-03 */
- /* print2("If each line were a number, their sum would be %s\n", str((double)sum)); */
+            /* breakMatch empty means break line anywhere */
         printLongLine(cat(
             "Stripping all but digits, \".\", and \"-\", the sum of lines is ",
             str((double)sum), NULL), "    ", " ");
@@ -2083,51 +2011,19 @@ void command(int argc, char *argv[])
     }
 
     if (cmdMatches("READ")) {
-      /*if (g_statements) {*/
-      /* 31-Dec-2017 nm */
       /* We can't use 'statements > 0' for the test since the source
          could be just a comment */
       if (g_sourceHasBeenRead == 1) {
         printLongLine(cat(
             "?Sorry, reading of more than one source file is not allowed.  ",
             "The file \"", g_input_fn, "\" has already been READ in.  ",
-                                                             /* 11-Dec-05 nm */
             "You may type ERASE to start over.  Note that additional source ",
-        "files may be included in the source file with \"$[ <filename> $]\".",
-                                                             /* 11-Dec-05 nm */
+            "files may be included in the source file with \"$[ <filename> $]\".",
             NULL),"  "," ");
         continue;
       }
 
       let(&g_input_fn, g_fullArg[1]);
-
-      /***** 3-Jan-2017 nm  This is now done with SET ROOT_DIRECTORY
-      /@ 31-Dec-2017 nm - Added ROOT_DIRECTORY switch @/
-      /@ TODO - remove this and just use SET ROOT_DIRECTORY instead @/
-      i = switchPos("/ ROOT_DIRECTORY"); /@ Statement match to skip @/
-      if (i != 0) {
-        let(&g_rootDirectory, edit(g_fullArg[i + 1], 2/@discard spaces,tabs@/));
-        if (g_rootDirectory[0] != 0) {  /@ Not an empty directory path @/
-          /@ Add trailing "/" to g_rootDirectory if missing @/
-          if (instr(1, g_rootDirectory, "\\") != 0
-              || instr(1, g_input_fn, "\\") != 0 ) {
-            /@ Using Windows-style path (not really supported, but at least
-               make full path consistent) @/
-            if (g_rootDirectory[strlen(g_rootDirectory) - 1] != '\\') {
-              let(&g_rootDirectory, cat(g_rootDirectory, "\\", NULL));
-            }
-          } else {
-            if (g_rootDirectory[strlen(g_rootDirectory) - 1] != '/') {
-              let(&g_rootDirectory, cat(g_rootDirectory, "/", NULL));
-            }
-          }
-        }
-      /@
-      } else {
-        let(&g_rootDirectory, "");
-      @/
-      }
-      */
 
       let(&str1, cat(g_rootDirectory, g_input_fn, NULL));
       g_input_fp = fSafeOpen(str1, "r", 0/*noVersioningFlag*/);
@@ -2136,7 +2032,6 @@ void command(int argc, char *argv[])
       fclose(g_input_fp);
 
       readInput();
-      /*g_sourceHasBeenRead = 1;*/ /* Global variable - set in readInput() */
 
       if (switchPos("/ VERIFY")) {
         verifyProofs("*",1); /* Parse and verify */
@@ -2144,50 +2039,7 @@ void command(int argc, char *argv[])
         /* verifyProofs("*",0); */ /* Parse only (for gross error checking) */
       }
 
-      /* 13-Dec-2016 nm Moved to verifyMarkup in mmcmds.c */
-      /*
-      /@ 10/21/02 - detect Microsoft bugs reported by several users, when the
-         HTML output files are named "con.html" etc. @/
-      /@ If we want a standard error message underlining token, this could go
-         in mmpars.c @/
-      /@ From Microsoft's site:
-         "The following reserved words cannot be used as the name of a file:
-         CON, PRN, AUX, CLOCK$, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7,
-         COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.
-         Also, reserved words followed by an extension - for example,
-         NUL.tx7 - are invalid file names." @/
-      /@ Check for labels that will lead to illegal Microsoft file names for
-         Windows users.  Don't bother checking CLOCK$ since $ is already
-         illegal @/
-      let(&str1, cat(
-         ",CON,PRN,AUX,NUL,COM1,COM2,COM3,COM4,COM5,COM6,COM7,",
-         "COM8,COM9,LPT1,LPT2,LPT3,LPT4,LPT5,LPT6,LPT7,LPT8,LPT9,", NULL));
-      for (i = 1; i <= g_statements; i++) {
-        let(&str2, cat(",", edit(g_Statement[i].labelName, 32/@uppercase@/), ",",
-            NULL));
-        if (instr(1, str1, str2) ||
-            /@ 5-Jan-04 mm@.html is reserved for mmtheorems.html, etc. @/
-            !strcmp(",MM", left(str2, 3))) {
-          print2("\n");
-          assignStmtFileAndLineNum(j); /@ 9-Jan-2018 nm @/
-          printLongLine(cat("?Warning in statement \"",
-              g_Statement[i].labelName, "\" at line ",
-              str((double)(g_Statement[i].lineNum)),
-              " in file \"", g_Statement[i].fileName,
-              "\".  To workaround a Microsoft operating system limitation, the",
-              " the following reserved words cannot be used for label names:",
-              " CON, PRN, AUX, CLOCK$, NUL, COM1, COM2, COM3, COM4, COM5,",
-              " COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6,",
-              " LPT7, LPT8, and LPT9.  Also, \"mm@.html\" is reserved for",
-              " Metamath file names.  Use another name for this label.", NULL),
-              "", " ");
-          g_errorCount++;
-        }
-      }
-      /@ 10/21/02 end @/
-      */
-
-      if (g_sourceHasBeenRead == 1) {  /* 9-Jan-2018 nm */
+      if (g_sourceHasBeenRead == 1) {
         if (!g_errorCount) {
           let(&str1, "No errors were found.");
           if (!switchPos("/ VERIFY")) {
@@ -2249,7 +2101,7 @@ void command(int argc, char *argv[])
 
 
     if (cmdMatches("WRITE THEOREM_LIST")) {
-      /* 4-Dec-03 - Write out an HTML summary of the theorems to
+      /* Write out an HTML summary of the theorems to
          mmtheorems.html, mmtheorems1.html,... */
       /* THEOREMS_PER_PAGE is the default number of proof descriptions to output. */
 #define THEOREMS_PER_PAGE 100
@@ -2283,8 +2135,7 @@ void command(int argc, char *argv[])
       }
 
       /* Output the theorem list */
-      writeTheoremList(theoremsPerPage, showLemmas,
-          noVersioning); /* (located in mmwtex.c) */
+      writeTheoremList(theoremsPerPage, showLemmas, noVersioning);
       continue;
     }  /* End of "WRITE THEOREM_LIST" */
 
@@ -2367,12 +2218,10 @@ void command(int argc, char *argv[])
           tmpFlag = 1; /* Error flag to recover input file */
           break;
         }
-        /* 13-May-04 nm Put in "last updated" stamp */
         if (!strcmp(left(str1, 21), "<!-- last updated -->")) {
           let(&str1, cat(left(str1, 21), " <I>Last updated on ", date(),
-          /* ??Future: make "EDT"/"EST" or other automatic */
-          /*  " at ", time_(), " EST.</I>", NULL)); */
-          /* 10-Nov-04 nm Just make it "ET" for "Eastern Time" */
+          /* ??Future: use timezones properly */
+          /* Just make it "ET" for "Eastern Time" */
             " at ", time_(), " ET.</I>", NULL));
         }
         fprintf(list2_fp, "%s\n", str1);
@@ -2381,7 +2230,7 @@ void command(int argc, char *argv[])
       if (tmpFlag) goto wrrecent_error;
 
       /* Get and parse today's date */
-      parseDate(date(), &k /*dd*/, &l /*mmm*/, &m /*yyyy*/); /* 4-Nov-2015 */
+      parseDate(date(), &k /*dd*/, &l /*mmm*/, &m /*yyyy*/);
 
 #define START_YEAR 93 /* Earliest 19xx year in set.mm database */
       n = 0; /* Count of how many output so far */
@@ -2477,14 +2326,14 @@ void command(int argc, char *argv[])
 
             if (n >= i /*RECENT_COUNT*/) break; /* We're done */
 
-            /* 27-Oct-03 nm Put separator row if not last theorem */
+            /* Put separator row if not last theorem */
             g_outputToString = 1;
             printLongLine(cat("<TR BGCOLOR=white><TD COLSPAN=3>",
                 "<FONT SIZE=-3>&nbsp;</FONT></TD></TR>", NULL),
                 " ",  /* Start continuation line with space */
                 "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
 
-            /* 29-Jul-04 nm Put the previous, current, and next statement
+            /* Put the previous, current, and next statement
                labels in HTML comments so a script can use them to update
                web site incrementally.  This would be done by searching
                for "For script" and gather label between = and --> then
@@ -2518,7 +2367,6 @@ void command(int argc, char *argv[])
             }
             if (j) print2("<!-- For script: next = %s -->\n",
                 g_Statement[j].labelName);
-            /* End of 29-Jul-04 section */
 
             g_outputToString = 0;
             fprintf(list2_fp, "%s", g_printString);
@@ -2613,7 +2461,6 @@ void command(int argc, char *argv[])
           continue;
         }
 
-        /* 2-Oct-2015 nm */
         let(&str1, cat(str((double)i), " ",
             g_Statement[i].labelName, " $", chr(g_Statement[i].type),
             NULL));
@@ -2805,7 +2652,7 @@ void command(int argc, char *argv[])
         g_texFileOpenFlag = 1;
         printTexHeader((s > 0) ? 1 : 0 /*texHeaderFlag*/);
         if (!g_texDefsRead) {
-          /* 9/6/03 If there was an error reading the $t xx.mm statement,
+          /* If there was an error reading the $t xx.mm statement,
              g_texDefsRead won't be set, and we should close out file and skip
              further processing.  Otherwise we will be attempting to process
              uninitialized htmldef arrays and such. */
@@ -2850,7 +2697,7 @@ void command(int argc, char *argv[])
               break;
             case 0:
               printLongLine(cat(
-                  /* 2/9/02 (in case |- suppressed) */
+                  /* (in case |- suppressed) */
                   "<CAPTION><B>List of Syntax, ",
                   "Axioms (<FONT COLOR=", GREEN_TITLE_COLOR, ">ax-</FONT>) and",
                   " Definitions (<FONT COLOR=", GREEN_TITLE_COLOR,
@@ -2917,8 +2764,7 @@ void command(int argc, char *argv[])
                     let(&str2, "");
                     str2 = tokenToTex(g_MathToken[(g_Statement[i].mathString)[j]
                         ].tokenName, i/*stmt# for error msgs*/);
-                    /* 2/9/02  Skip any tokens (such as |- in QL Explorer) that
-                       may be suppressed */
+                    /* Skip any tokens (such as |- in QL Explorer) that may be suppressed */
                     if (!str2[0]) continue;
                     /* Convert special characters to HTML entities */
                     for (k = 0; k < (signed)(strlen(str1)); k++) {
@@ -2942,7 +2788,7 @@ void command(int argc, char *argv[])
                         (g_altHtmlFlag ? cat("<SPAN ", g_htmlFont, ">", NULL) : ""),
                         str2,
                         (g_altHtmlFlag ? "</SPAN>" : ""),
-                        "&nbsp;", /* 10-Jan-2016 nm This will prevent a
+                        "&nbsp;", /* This will prevent a
                                      -4px shifted image from overlapping the
                                      lower border of the table cell */
                         "</TD><TD><TT>",
@@ -2959,9 +2805,8 @@ void command(int argc, char *argv[])
                 let(&str1, "");
                 if (s == 0 || g_briefHtmlFlag) {
                   let(&str1, "");
-                  /* 18-Sep-03 Get HTML hypotheses => assertion */
+                  /* Get HTML hypotheses => assertion */
                   str1 = getTexOrHtmlHypAndAssertion(i);
-                                                /* In mmwtex.c */
                   let(&str1, cat(str1, "</TD></TR>", NULL));
                 }
 
@@ -2983,7 +2828,7 @@ void command(int argc, char *argv[])
                   /* Get little pink (or rainbow-colored) number */
                   let(&str4, "");
                   str4 = pinkHTML(i);
-                  let(&str2, cat("<TR BGCOLOR=", bgcolor, /* 8-Aug-2008 nm */
+                  let(&str2, cat("<TR BGCOLOR=", bgcolor,
                       " ALIGN=LEFT><TD><A HREF=\"",
                       g_Statement[i].labelName,
                       ".html\">", g_Statement[i].labelName,
@@ -3296,7 +3141,7 @@ void command(int argc, char *argv[])
         print2(
           "(SET EMPTY_SUBSTITUTION...) EMPTY_SUBSTITUTION is allowed (ON).\n");
       }
-      if (g_hentyFilter) { /* 18-Nov-05 nm Added to the SHOW listing */
+      if (g_hentyFilter) {
         print2(
               "(SET JEREMY_HENTY_FILTER...) The Henty filter is turned ON.\n");
       } else {
@@ -3425,9 +3270,9 @@ void command(int argc, char *argv[])
             traceProof(g_showStatement,
                 essentialFlag,
                 axiomFlag,
-                matchList, /* 19-May-2013 nm */
-                traceToList, /* 18-Jul-2015 nm */
-                0 /* testOnlyFlag */ /* 20-May-2013 nm */);
+                matchList,
+                traceToList,
+                0 /* testOnlyFlag */);
           }
         }
 
@@ -3948,7 +3793,6 @@ void command(int argc, char *argv[])
                              indicates that proof hasn't changed */
             }
 
-            /* 3-May-2017 nm */
             /* Add an initial \n which will go after the "$=" and the
                beginning of the proof */
             let(&g_printString, cat("\n", g_printString, NULL));
@@ -4007,7 +3851,6 @@ void command(int argc, char *argv[])
             print2(cat(
                 "---------The proof of \"", g_Statement[outStatement].labelName,
                 /* "\" to clip out ends above this line.\n",NULL)); */
-                /* 24-Apr-2015 nm */
                 "\" (", str((double)l), " bytes) ends above this line.\n", NULL));
           } /* End if saveFlag */
           nmbrLet(&nmbrSaveProof, NULL_NMBRSTRING);
@@ -4027,7 +3870,6 @@ void command(int argc, char *argv[])
           g_outputToString = 1; /* Flag for print2 to add to g_printString */
           if (!g_htmlFlag) {
             if (!g_oldTexFlag) {
-              /* 14-Sep-2010 nm */
               print2("\\begin{proof}\n");
               print2("\\begin{align}\n");
             } else {
@@ -4044,7 +3886,7 @@ void command(int argc, char *argv[])
             bug(1118);
           }
           g_outputToString = 0;
-          /* 8/26/99: printTeXLongMath now clears g_printString in LaTeX
+          /* printTeXLongMath clears g_printString in LaTeX
              mode before starting its output, so we must put out the
              g_printString ourselves here */
           fprintf(g_texFilePtr, "%s", g_printString);
@@ -4252,8 +4094,8 @@ void command(int argc, char *argv[])
 
         print2(
      "Unknown step summary (from \"SHOW NEW_PROOF / UNKNOWN\"):\n");
-        /* 6/14/98 - Automatically display new unknown steps
-         ???Future - add switch to enable/defeat this */
+        /* Automatically display new unknown steps
+           ???Future - add switch to enable/defeat this */
         typeProof(g_proveStatement,
             1 /*pipFlag*/,
             0 /*startStep*/,
@@ -4290,30 +4132,7 @@ void command(int argc, char *argv[])
     if (cmdMatches("UNDO")) {
       processUndoStack(&g_ProofInProgress, PUS_UNDO, "", 0);
       g_proofChanged = 1; /* Maybe make this more intelligent some day */
-      /* 6/14/98 - Automatically display new unknown steps
-         ???Future - add switch to enable/defeat this */
-      typeProof(g_proveStatement,
-          1 /*pipFlag*/,
-          0 /*startStep*/,
-          0 /*endStep*/,
-          0 /*endIndent*/,
-          1 /*essentialFlag*/,
-          0 /*renumberFlag*/,
-          1 /*unknownFlag*/,
-          0 /*notUnifiedFlag*/,
-          0 /*reverseFlag*/,
-          0 /*noIndentFlag*/,
-          0 /*splitColumn*/,
-          0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
-          0 /*texFlag*/,
-          0 /*g_htmlFlag*/);
-      continue;
-    }
-
-    if (cmdMatches("REDO")) {
-      processUndoStack(&g_ProofInProgress, PUS_REDO, "", 0);
-      g_proofChanged = 1; /* Maybe make this more intelligent some day */
-      /* 6/14/98 - Automatically display new unknown steps
+      /* Automatically display new unknown steps
          ???Future - add switch to enable/defeat this */
       typeProof(g_proveStatement,
           1 /*pipFlag*/,
@@ -4330,7 +4149,29 @@ void command(int argc, char *argv[])
           0 /*skipRepeatedSteps*/,
           0 /*texFlag*/,
           0 /*g_htmlFlag*/);
-      /* 6/14/98 end */
+      continue;
+    }
+
+    if (cmdMatches("REDO")) {
+      processUndoStack(&g_ProofInProgress, PUS_REDO, "", 0);
+      g_proofChanged = 1; /* Maybe make this more intelligent some day */
+      /* Automatically display new unknown steps
+         ???Future - add switch to enable/defeat this */
+      typeProof(g_proveStatement,
+          1 /*pipFlag*/,
+          0 /*startStep*/,
+          0 /*endStep*/,
+          0 /*endIndent*/,
+          1 /*essentialFlag*/,
+          0 /*renumberFlag*/,
+          1 /*unknownFlag*/,
+          0 /*notUnifiedFlag*/,
+          0 /*reverseFlag*/,
+          0 /*noIndentFlag*/,
+          0 /*splitColumn*/,
+          0 /*skipRepeatedSteps*/,
+          0 /*texFlag*/,
+          0 /*g_htmlFlag*/);
       continue;
     }
 
@@ -4401,7 +4242,7 @@ void command(int argc, char *argv[])
           }
         } /* End while (1) */
       }
-      /* 6/14/98 - Automatically display new unknown steps
+      /* Automatically display new unknown steps
          ???Future - add switch to enable/defeat this */
       typeProof(g_proveStatement,
           1 /*pipFlag*/,
@@ -4559,7 +4400,7 @@ void command(int argc, char *argv[])
         g_proofChanged = 1; /* Cumulative flag */
         processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
       }
-      /* 6/14/98 - Automatically display new unknown steps
+      /* Automatically display new unknown steps
          ???Future - add switch to enable/defeat this */
       typeProof(g_proveStatement,
           1 /*pipFlag*/,
@@ -4573,7 +4414,7 @@ void command(int argc, char *argv[])
           0 /*reverseFlag*/,
           0 /*noIndentFlag*/,
           0 /*splitColumn*/,
-          0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
+          0 /*skipRepeatedSteps*/,
           0 /*texFlag*/,
           0 /*g_htmlFlag*/);
       continue;
@@ -4645,7 +4486,7 @@ void command(int argc, char *argv[])
       /* Automatically interact with user if step not unified */
       /* ???We might want to add a setting to defeat this if user doesn't
          like it */
-      /* 8-Apr-05 nm Since ASSIGN LAST is often run from a commmand file, don't
+      /* Since ASSIGN LAST is often run from a commmand file, don't
          interact if / NO_UNIFY is specified, so response is predictable */
       if (switchPos("/ NO_UNIFY") == 0) {
         interactiveUnifyStep(s - m + n - 1, 2); /* 2nd arg. means print msg if
@@ -4664,7 +4505,7 @@ void command(int argc, char *argv[])
         }
       }
 
-      /* 6/14/98 - Automatically display new unknown steps
+      /* Automatically display new unknown steps
          ???Future - add switch to enable/defeat this */
       typeProof(g_proveStatement,
           1 /*pipFlag*/,
@@ -4678,7 +4519,7 @@ void command(int argc, char *argv[])
           0 /*reverseFlag*/,
           0 /*noIndentFlag*/,
           0 /*splitColumn*/,
-          0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
+          0 /*skipRepeatedSteps*/,
           0 /*texFlag*/,
           0 /*g_htmlFlag*/);
 
@@ -4732,8 +4573,7 @@ void command(int argc, char *argv[])
 
       m = nmbrLen(g_ProofInProgress.proof); /* Original proof length */
 
-      /* 10/20/02  Set a flag that proof has unknown steps (for autoUnify()
-         call below) */
+      /* Set a flag that proof has unknown steps (for autoUnify() call below) */
       if (nmbrElementIn(1, g_ProofInProgress.proof, -(long)'?')) {
         p = 1;
       } else {
@@ -4831,7 +4671,7 @@ void command(int argc, char *argv[])
       }
 
 
-      /* 14-Sep-2012 nm - Automatically display new unknown steps
+      /* Automatically display new unknown steps
          ???Future - add switch to enable/defeat this */
       if (g_proofChangedFlag)
         typeProof(g_proveStatement,
@@ -4846,7 +4686,7 @@ void command(int argc, char *argv[])
             0 /*reverseFlag*/,
             0 /*noIndentFlag*/,
             0 /*splitColumn*/,
-            0 /*skipRepeatedSteps*/, /* 28-Jun-2013 nm */
+            0 /*skipRepeatedSteps*/,
             0 /*texFlag*/,
             0 /*g_htmlFlag*/);
 
@@ -4869,7 +4709,7 @@ void command(int argc, char *argv[])
       searchUnkSubproofs = 0;
       if (switchPos("/ SUBPROOFS")) searchUnkSubproofs = 1;
 
-      mathboxFlag = (switchPos("/ INCLUDE_MATHBOXES") != 0); /* 5-Aug-2020 */
+      mathboxFlag = (switchPos("/ INCLUDE_MATHBOXES") != 0);
       assignMathboxInfo(); /* In case it hasn't been assigned yet */
       if (g_proveStatement > g_mathboxStmt) {
         /* We're in a mathbox */
@@ -4991,7 +4831,6 @@ void command(int argc, char *argv[])
         g_proofChangedFlag = 0;
 
         for (improveAllIter = 1; improveAllIter <= 4; improveAllIter++) {
-                                                           /* 25-Aug-2012 nm */
           if (improveAllIter == 1 && (searchAlg == 2 || searchAlg == 3))
             print2("Pass 1:  Trying to match cut-free statements...\n");
           if (improveAllIter == 2) {
@@ -5027,7 +4866,7 @@ void command(int argc, char *argv[])
             proofStepUnk = ((g_ProofInProgress.proof)[s - 1] == -(long)'?')
                 ? 1 : 0;
 
-            /* 22-Aug-2012 nm I think this is really too conservative, even
+            /* I think this is really too conservative, even
                with the old algorithm, but keep it to imitate the old one */
             if (improveAllIter == 1 || searchAlg == 1) {
               /* If the step is known and unified, don't do it, since nothing
@@ -5145,7 +4984,7 @@ void command(int argc, char *argv[])
 
       } /* End if IMPROVE ALL */
 
-      /* 6/14/98 - Automatically display new unknown steps
+      /* Automatically display new unknown steps
          ???Future - add switch to enable/defeat this */
       if (g_proofChangedFlag)
         typeProof(g_proveStatement,
@@ -5185,10 +5024,12 @@ void command(int argc, char *argv[])
                          1 = a statement was matched but no shorter proof
                          2 = shorter proof found */
       verboseMode = (switchPos("/ VERBOSE") != 0); /* Verbose mode */
+
+      /* If no wildcard was used, switch to non-verbose mode
+        since there is no point to it and an annoying extra blank line
+        results */
       if (!(instr(1, g_fullArg[1], "*") || instr(1, g_fullArg[1], "?"))) i = 1;
-          /* 16-Feb-05 If no wildcard was used, switch to non-verbose mode
-             since there is no point to it and an annoying extra blank line
-             results */
+
       mayGrowFlag = (switchPos("/ MAY_GROW") != 0);
                   /* Mode to replace even if it doesn't reduce proof length */
       exceptPos = switchPos("/ EXCEPT"); /* Statement match to skip */
@@ -5255,7 +5096,7 @@ void command(int argc, char *argv[])
       copyProofStruct(&saveOrigProof, g_ProofInProgress);
 
       /* 12-Sep-2016 nm TODO replace this w/ compressedProofSize */
-      /* 25-Jun-2014 nm Get the current (original) compressed proof length
+      /* Get the current (original) compressed proof length
          to compare it when a shorter non-compressed proof is found, to see
          if the compressed proof also decreased in size */
       nmbrLet(&nmbrSaveProof, g_ProofInProgress.proof);   /* Redundant? */
@@ -5346,7 +5187,7 @@ void command(int argc, char *argv[])
           if (!nmbrEq(nmbrTmp, g_ProofInProgress.proof)) {
             /* The proof got shorter (or it changed if MAY_GROW) */
 
-            /* 20-May-2013 nm Because of the slow speed of traceBack(),
+            /* Because of the slow speed of traceBack(),
                we only want to check the /FORBID list in the relatively
                rare case where a minimization occurred.  If the FORBID
                list is matched, we then need to revert back to the
@@ -5372,7 +5213,7 @@ void command(int argc, char *argv[])
             }
 
 
-            /* 22-Nov-2014 nm Because of the slow speed of traceBack(),
+            /* Because of the slow speed of traceBack(),
                we only want to check the /NO_NEW_AXIOMS_FROM list in the
                relatively rare case where a minimization occurred.  If the
                NO_NEW_AXIOMS_FROM condition applies, we then need to revert
@@ -5470,7 +5311,7 @@ void command(int argc, char *argv[])
             } /* end if (true) */
 
 
-            /* 25-Jun-2014 nm Make sure the compressed proof length
+            /* Make sure the compressed proof length
                decreased, otherwise revert.  Also, we will use the
                compressed proof for the $d check next */
             if (nmbrLen(g_Statement[k].reqDisjVarsA) || !mayGrowFlag) {
@@ -5531,7 +5372,7 @@ void command(int argc, char *argv[])
               g_Statement[g_proveStatement].proofSectionPtr = str1;
 
               g_outputToString = 1; /* Suppress error messages */
-              /* 15-Apr-2015 nm parseProof, verifyProof, cleanWkrProof must be
+              /* parseProof, verifyProof, cleanWkrProof must be
                  called in sequence to assign the g_WrkProof structure, verify
                  the proof, and deallocate the g_WrkProof structure.  Either none
                  of them or all of them must be called. */
@@ -5539,7 +5380,7 @@ void command(int argc, char *argv[])
               verifyProof(g_proveStatement); /* Must be called even if error
                                   occurred in parseProof, to init RPN stack
                                   for cleanWrkProof() */
-              /* 15-Apr-2015 nm - don't change proof if there is an error
+              /* don't change proof if there is an error
                  (which could be pre-existing). */
               i = (g_WrkProof.errorSeverity > 1);
               /**** Here we look at the screen output sent to a string.
@@ -5671,7 +5512,7 @@ void command(int argc, char *argv[])
         print2("The proof was not changed.\n");
       if (!prntStatus /* && !noDistinctFlag */)
         print2("?No earlier %s$p or $a label matches \"%s\".\n",
-            (overrideFlag ? "" : "(allowed) "),  /* 3-May-2016 nm */
+            (overrideFlag ? "" : "(allowed) "),
             g_fullArg[1]);
       if (!mathboxFlag && g_proveStatement >= g_mathboxStmt) {
         print2(
@@ -5800,7 +5641,7 @@ void command(int argc, char *argv[])
         }
       }
 
-      /* 6/14/98 - Automatically display new unknown steps
+      /* Automatically display new unknown steps
          ???Future - add switch to enable/defeat this */
       typeProof(g_proveStatement,
           1 /*pipFlag*/,
@@ -5858,7 +5699,7 @@ void command(int argc, char *argv[])
           print2("Steps %ld and above have been renumbered.\n", n);
         }
 
-        /* 6/14/98 - Automatically display new unknown steps
+        /* Automatically display new unknown steps
            ???Future - add switch to enable/defeat this */
         typeProof(g_proveStatement,
             1 /*pipFlag*/,
@@ -5951,7 +5792,6 @@ void command(int argc, char *argv[])
         m = 0;  /* Show $a, $p only */
       }
 
-      /* 14-Apr-2008 nm added */
       if (switchPos("/ JOIN")) {
         joinFlag = 1;  /* Join $e's to $a,$p for matching */
       } else {
@@ -5987,7 +5827,7 @@ void command(int argc, char *argv[])
         }
         let(&str1, left(str3, q + s));
 
-        /* 30-Jan-06 nm Added single-character-match wildcard argument "$?"
+        /* Find single-character-match wildcard argument "$?"
            (or "?" for convenience).  Use ASCII 3 for the exactly-1-char
            wildcard character.  This is a single-character
            match, not a single-token match:  we need "??" to match "ph". */
@@ -6004,7 +5844,7 @@ void command(int argc, char *argv[])
         }
 
         /* Change wildcard to ASCII 2 (to be different from printable chars) */
-        /* 1/3/02 (Why are we matching with and without space? I'm not sure.)*/
+        /* 1-Mar-02 nm - (Why are we matching with and without space? I'm not sure.) */
         /* 30-Jan-06 nm Answer:  We need the double-spacing, and the removal
            of space in the "with spaces" case, so that "ph $ ph" will match
            "ph  ph" (0-token case) - "ph  $  ph" won't match this in the
@@ -6023,7 +5863,7 @@ void command(int argc, char *argv[])
           /* This simply replaces $* with chr(2) */
           let(&str1, cat(left(str1, p - 1), chr(2), right(str1, p + 2), NULL));
         }
-        /* 1/3/02  Also allow a plain $ as a wildcard, for convenience. */
+        /* Also allow a plain $ as a wildcard, for convenience. */
         while (1) {
           p = instr(1, str1, " $ ");
           if (!p) break;
@@ -6205,7 +6045,7 @@ void command(int argc, char *argv[])
       /* TODO: figure out why s=2 crashes program! */
       if (s < 3) s = 3; /* Less than 3 may cause a segmentation fault */
       i = g_screenWidth;
-      g_screenWidth = s; /* 26-Sep-2017 nm - print with new screen width */
+      g_screenWidth = s;
       print2("Screen width has been changed from %ld to %ld.\n",
           i, s);
       continue;
@@ -6348,8 +6188,6 @@ void command(int argc, char *argv[])
           continue;
         }
       }
-      /* 2-Oct-2017 nm OPEN HTML is obsolete */
-      /*g_htmlFlag = cmdMatches("OPEN HTML");*/
 
       /* Open a TeX file */
       let(&g_texFileName,g_fullArg[2]);
@@ -6358,7 +6196,7 @@ void command(int argc, char *argv[])
       } else {
         texHeaderFlag = 1;
       }
-      /* 14-Sep-2010 nm Added OLD_TEX */
+
       if (switchPos("/ OLD_TEX")) {
         g_oldTexFlag = 1;
       } else {
@@ -6557,7 +6395,6 @@ void command(int argc, char *argv[])
       continue;
     }
 
-    /* 10-Dec-2018 nm Added */
     if (cmdMatches("MARKUP")) {
       g_htmlFlag = 1;
       g_altHtmlFlag = (switchPos("/ ALT_HTML") != 0);

--- a/mmcmdl.c
+++ b/mmcmdl.c
@@ -26,7 +26,7 @@ pntrString *g_rawArgPntr = NULL_PNTRSTRING;
 nmbrString *g_rawArgNmbr = NULL_NMBRSTRING;
 long g_rawArgs = 0;
 pntrString *g_fullArg = NULL_PNTRSTRING;
-vstring g_fullArgString = ""; /* 1-Nov-2013 nm g_fullArg as one string */
+vstring g_fullArgString = ""; /* g_fullArg as one string */
 vstring g_commandPrompt = "";
 vstring g_commandLine = "";
 long g_showStatement = 0;
@@ -39,9 +39,7 @@ flag g_sourceChanged = 0; /* Flag that user made some change to the source file*
 flag g_proofChanged = 0; /* Flag that user made some change to proof in progress*/
 flag g_commandEcho = 0; /* Echo full command */
 flag g_memoryStatus = 0; /* Always show memory */
-/* 31-Dec-2017 nm */
 flag g_sourceHasBeenRead = 0; /* 1 if a source file has been read in */
-/* 31-Dec-2017 nm */
 vstring g_rootDirectory = ""; /* Directory prefix to use for included files */
 
 
@@ -61,7 +59,6 @@ flag processCommandLine(void)
       /* Normal mode */
       let(&tmpStr, cat("DBG|",
           "HELP|READ|WRITE|PROVE|SHOW|SEARCH|SAVE|SUBMIT|OPEN|CLOSE|",
-          /* 10-Dec-2018 nm Added MARKUP */
           "SET|FILE|BEEP|EXIT|QUIT|ERASE|VERIFY|MARKUP|MORE|TOOLS|",
           "MIDI|<HELP>",
           NULL));
@@ -69,11 +66,8 @@ flag processCommandLine(void)
       /* Proof assistant mode */
       let(&tmpStr, cat("DBG|",
           "HELP|WRITE|SHOW|SEARCH|SAVE|SUBMIT|OPEN|CLOSE|",
-          /* 9-Jun-2016 nm Added _EXIT_PA */
           "SET|FILE|BEEP|EXIT|_EXIT_PA|QUIT|VERIFY|INITIALIZE|ASSIGN|REPLACE|",
-          /* 11-Sep-2016 nm Added EXPAND */
           "LET|UNIFY|IMPROVE|MINIMIZE_WITH|EXPAND|MATCH|DELETE|UNDO|REDO|",
-          /* 10-Dec-2018 nm Added MARKUP */
           "MARKUP|MORE|TOOLS|MIDI|<HELP>",
           NULL));
     }
@@ -82,25 +76,18 @@ flag processCommandLine(void)
     }
 
     if (cmdMatches("HELP")) {
-          /* 15-Jan-2018 nm Added MARKUP */
       if (!getFullArg(1, cat("LANGUAGE|PROOF_ASSISTANT|MM-PA|",
           "BEEP|EXIT|QUIT|READ|ERASE|",
           "OPEN|CLOSE|SHOW|SEARCH|SET|VERIFY|SUBMIT|SYSTEM|PROVE|FILE|WRITE|",
-          /* 10-Dec-2018 nm Added MARKUP */
           "MARKUP|ASSIGN|REPLACE|MATCH|UNIFY|LET|INITIALIZE|DELETE|IMPROVE|",
-          /* 11-Sep-2016 nm Added EXPAND */
           "MINIMIZE_WITH|EXPAND|UNDO|REDO|SAVE|DEMO|INVOKE|CLI|EXPLORE|TEX|",
           "LATEX|HTML|COMMENTS|BIBLIOGRAPHY|MORE|",
           "TOOLS|MIDI|$|<$>", NULL))) goto pclbad;
       if (cmdMatches("HELP OPEN")) {
-        /*if (!getFullArg(2, "LOG|TEX|HTML|<LOG>")) goto pclbad;*/
-        /* 2-Oct-2017 nm Removed HTML */
         if (!getFullArg(2, "LOG|TEX|<LOG>")) goto pclbad;
         goto pclgood;
       }
       if (cmdMatches("HELP CLOSE")) {
-        /*if (!getFullArg(2, "LOG|TEX|HTML|<LOG>")) goto pclbad;*/
-        /* 2-Oct-2017 nm Removed HTML */
         if (!getFullArg(2, "LOG|TEX|<LOG>")) goto pclbad;
         goto pclgood;
       }
@@ -116,8 +103,8 @@ flag processCommandLine(void)
         if (!getFullArg(2, cat(
             "ECHO|SCROLL|WIDTH|HEIGHT|UNDO|UNIFICATION_TIMEOUT|",
             "DISCOURAGEMENT|",
-            "CONTRIBUTOR|",   /* 14-May-2017 nm */
-            "ROOT_DIRECTORY|",   /* 31-Dec-2017 nm */
+            "CONTRIBUTOR|",
+            "ROOT_DIRECTORY|",
             "EMPTY_SUBSTITUTION|SEARCH_LIMIT|JEREMY_HENTY_FILTER|<ECHO>",
             NULL)))
             goto pclbad;
@@ -193,14 +180,10 @@ flag processCommandLine(void)
           if (lastArgMatches("/")) {
             i++;
             if (!getFullArg(i, cat(
-                /* 3-May-2017 nm Removed CLEAN */
                 "FORMAT|REWRAP",
-                /* 31-Dec-2017 nm Added SPLIT, NO_VERSIONING, KEEP_INCLUDES */
-                /* 24-Aug-2020 nm Added EXTRACT */
                 "|SPLIT|NO_VERSIONING|KEEP_INCLUDES|EXTRACT",
                 "|<REWRAP>", NULL)))
               goto pclbad;
-            /* 24-Aug-2020 nm Added EXTRACT */
             if (lastArgMatches("EXTRACT")) {
               i++;
               if (!getFullArg(i, "* What statement label? "))
@@ -293,8 +276,6 @@ flag processCommandLine(void)
     }
 
     if (cmdMatches("OPEN")) {
-      /*if (!getFullArg(1, "LOG|TEX|HTML|<LOG>")) goto pclbad;*/
-      /* 2-Oct-2017 nm Removed HTML */
       if (!getFullArg(1, "LOG|TEX|<LOG>")) goto pclbad;
       if (cmdMatches("OPEN LOG")) {
         if (g_logFileOpenFlag) {
@@ -340,45 +321,10 @@ flag processCommandLine(void)
         } /* End while for switch loop */
 
       }
-
-      /* 2-Oct-2017 nm OPEN HTML is obsolete */
-      /*******
-      if (cmdMatches("OPEN HTML")) {
-        if (g_texFileOpenFlag) {
-          printLongLine(cat(
-              "?Sorry, the HTML file \"",g_texFileName, "\" is currently open.  ",
-              "Type CLOSE HTML to close the current HTML file",
-              " if you want to open another one."
-              , NULL), "", " ");
-          goto pclbad;
-        }
-        if (!getFullArg(2, "@ What is the name of HTML output file? "))
-          goto pclbad;
-
-        /@ Get any switches @/
-        i = 2;
-        while (1) {
-          i++;
-          if (!getFullArg(i, "/|$|<$>")) goto pclbad;
-          if (lastArgMatches("/")) {
-            i++;
-            if (!getFullArg(i, cat(
-                "NO_HEADER|<NO_HEADER>", NULL)))
-              goto pclbad;
-          } else {
-            break;
-          }
-          break; /@ Break if only 1 switch is allowed @/
-        } /@ End while for switch loop @/
-
-      }
-      ****/
       goto pclgood;
     }
 
     if (cmdMatches("CLOSE")) {
-      /*if (!getFullArg(1, "LOG|TEX|HTML|<LOG>")) goto pclbad;*/
-      /* 2-Oct-2017 nm Removed HTML */
       if (!getFullArg(1, "LOG|TEX|<LOG>")) goto pclbad;
       goto pclgood;
     }
@@ -475,7 +421,6 @@ flag processCommandLine(void)
           if (lastArgMatches("/")) {
             i++;
             if (!getFullArg(i, cat(
-                /* 19-May-2013 nm Added MATCH */
                 "ALL|ESSENTIAL|AXIOMS|TREE|DEPTH|COUNT_STEPS|MATCH|TO",
                 "|<ALL>", NULL)))
               goto pclbad;
@@ -484,13 +429,11 @@ flag processCommandLine(void)
               if (!getFullArg(i, "# How many indentation levels <999>? "))
                 goto pclbad;
             }
-            /* 13-May-2013 nm Added MATCH */
             if (lastArgMatches("MATCH")) {
               i++;
               if (!getFullArg(i, "* What statement label? "))
                 goto pclbad;
             }
-            /* 18-Jul-2015 nm Added TO */
             if (lastArgMatches("TO")) {
               i++;
               if (!getFullArg(i, "* What statement label? "))
@@ -576,7 +519,6 @@ flag processCommandLine(void)
             i++;
             if (!getFullArg(i, cat(
                 "FULL|COMMENT|TEX|OLD_TEX|HTML|ALT_HTML|TIME|BRIEF_HTML",
-                /* 12-May-2009 sa Added MNEMONICS */
                 "|BRIEF_ALT_HTML|MNEMONICS|NO_VERSIONING|<FULL>", NULL)))
               goto pclbad;
           } else {
@@ -617,11 +559,8 @@ flag processCommandLine(void)
             i++;
             if (!getFullArg(i, cat(
                 "ESSENTIAL|ALL|UNKNOWN|FROM_STEP|TO_STEP|DEPTH",
-                /*"|REVERSE|VERBOSE|NORMAL|COMPRESSED",*/
                 "|REVERSE|VERBOSE|NORMAL|PACKED|COMPRESSED|EXPLICIT",
-                "|FAST",   /* 2-Mar-2016 nm */
-                "|OLD_COMPRESSION",   /* 27-Dec-2013 nm */
-                /* 14-Sep-2010 nm Added OLD_TEX */
+                "|FAST|OLD_COMPRESSION",
                 "|STATEMENT_SUMMARY|DETAILED_STEP|TEX|OLD_TEX|HTML",
                 "|LEMMON|START_COLUMN|NO_REPEATED_STEPS",
                 "|RENUMBER|SIZE|<ESSENTIAL>", NULL)))
@@ -677,9 +616,8 @@ flag processCommandLine(void)
             i++;
             if (!getFullArg(i, cat(
                 "ESSENTIAL|ALL|UNKNOWN|FROM_STEP|TO_STEP|DEPTH",
-                /*"|REVERSE|VERBOSE|NORMAL|COMPRESSED",*/
                 "|REVERSE|VERBOSE|NORMAL|PACKED|COMPRESSED|EXPLICIT",
-                "|OLD_COMPRESSION",   /* 27-Dec-2013 nm */
+                "|OLD_COMPRESSION",
                 "|NOT_UNIFIED|TEX|HTML",
                 "|LEMMON|START_COLUMN|NO_REPEATED_STEPS",
                 "|RENUMBER|<ESSENTIAL>", NULL)))
@@ -784,7 +722,7 @@ flag processCommandLine(void)
             i++;
             if (!getFullArg(i, cat(
                 "NORMAL|PACKED|COMPRESSED|EXPLICIT",
-                "|FAST|OLD_COMPRESSION",   /* 27-Dec-2013 nm */
+                "|FAST|OLD_COMPRESSION",
                 "|TIME|<NORMAL>", NULL)))
               goto pclbad;
           } else {
@@ -811,8 +749,6 @@ flag processCommandLine(void)
             i++;
             if (!getFullArg(i, cat(
                 "NORMAL|PACKED|COMPRESSED|EXPLICIT",
-                /* 27-Dec-2013 nm Added / OLD_COMPRESSION */
-                /* 3-May-2016 nm Added / OVERRIDE */
                 "|OLD_COMPRESSION|OVERRIDE",
                 "|<NORMAL>", NULL)))
               goto pclbad;
@@ -845,7 +781,6 @@ flag processCommandLine(void)
           defaultArg, "? ", NULL)))
         goto pclbad;
 
-      /* 10-May-2016 nm */
       /* Get any switches */
       i = 1;
       while (1) {
@@ -922,19 +857,16 @@ flag processCommandLine(void)
 
     if (cmdMatches("INITIALIZE")) {
       if (!getFullArg(1,
-          "STEP|ALL|USER|<ALL>")) goto pclbad;  /* 16-Apr-06 nm Added USER */
+          "STEP|ALL|USER|<ALL>")) goto pclbad;
       if (cmdMatches("INITIALIZE STEP")) {
         if (!getFullArg(2, "# What step number? ")) goto pclbad;
       }
       goto pclgood;
     }
 
-    /* 26-Aug-2006 nm Changed "IMPROVE STEP <step>" to just "IMPROVE <step>"
-       for user convenience (and consistency with "ASSIGN" command) */
     if (cmdMatches("IMPROVE")) {
       if (!getFullArg(1,
         "* What step number, or FIRST, or LAST, or ALL <ALL>? ")) goto pclbad;
-                                                             /* 11-Dec-05 nm */
       /* Get any switches */
       i = 1;
       while (1) {
@@ -942,16 +874,12 @@ flag processCommandLine(void)
         if (!getFullArg(i, "/|$|<$>")) goto pclbad;
         if (lastArgMatches("/")) {
           i++;
-          if (!getFullArg(i,
-              /* 3-May-2016 nm Added / OVERRIDE */
-              /* 5-Aug-2020 nm Added / INCLUDE_MATHBOXES */
-         "DEPTH|NO_DISTINCT|1|2|3|SUBPROOFS|OVERRIDE|INCLUDE_MATHBOXES|<DEPTH>")
-              ) goto pclbad;
+          if (!getFullArg(i, "DEPTH|NO_DISTINCT|1|2|3"
+            "|SUBPROOFS|OVERRIDE|INCLUDE_MATHBOXES|<DEPTH>")) goto pclbad;
           if (lastArgMatches("DEPTH")) {
             i++;
-            if (!getFullArg(i,
-  "# What is maximum depth for searching statements with $e hypotheses <0>? "))
-              goto pclbad;
+            if (!getFullArg(i, "# What is maximum depth for "
+              "searching statements with $e hypotheses <0>? ")) goto pclbad;
           }
         } else {
           break;
@@ -960,47 +888,6 @@ flag processCommandLine(void)
       } /* end while */
       goto pclgood;
     } /* end if IMPROVE */
-
-    /* ------- Old version before 26-Aug-2006 -------
-    if (cmdMatches("IMPROVE")) {
-      if (!getFullArg(1,
-          "STEP|ALL|FIRST|LAST|<ALL>")) goto pclbad;
-
-      if (cmdMatches("IMPROVE STEP")) {
-        if (!getFullArg(2, "# What step number? ")) goto pclbad;
-      }
-      if (cmdMatches("IMPROVE STEP") || cmdMatches("IMPROVE ALL")
-          || cmdMatches("IMPROVE LAST") || cmdMatches("IMPROVE FIRST")) {
-                                                            /@ 11-Dec-05 nm @/
-        /@ Get switches @/
-        if (cmdMatches("IMPROVE STEP")) {
-          i = 2;
-        } else {
-          i = 1;
-        }
-        while (1) {
-          i++;
-          if (!getFullArg(i, "/|$|<$>")) goto pclbad;
-          if (lastArgMatches("/")) {
-            i++;
-            if (!getFullArg(i,
-                "DEPTH|NO_DISTINCT|<DEPTH>")
-                ) goto pclbad;
-            if (lastArgMatches("DEPTH")) {
-              i++;
-              if (!getFullArg(i,
-  "# What is maximum depth for searching statements with $e hypotheses <0>? "))
-                goto pclbad;
-            }
-          } else {
-            break;
-          }
-          /@break;@/ /@ Do this if only 1 switch is allowed @/
-        } /@ end while @/
-        goto pclgood;
-      } /@ end if IMPROVE STEP or IMPROVE ALL @/
-    }
-    ------- End of old version ------- */
 
 
     if (cmdMatches("MINIMIZE_WITH")) {
@@ -1013,42 +900,26 @@ flag processCommandLine(void)
         if (lastArgMatches("/")) {
           i++;
           if (!getFullArg(i, cat(
-              /*
-              "BRIEF|VERBOSE|ALLOW_GROWTH|NO_DISTINCT|EXCEPT|",
-              "REVERSE|INCLUDE_MATHBOXES|FORBID|<BRIEF>", NULL)))
-              */
               "VERBOSE|MAY_GROW|EXCEPT|OVERRIDE|INCLUDE_MATHBOXES|",
               "ALLOW_NEW_AXIOMS|NO_NEW_AXIOMS_FROM|FORBID|TIME|<VERBOSE>",
               NULL)))
-                              /* 7-Jan-06 nm Added EXCEPT */
-                              /* 28-Jun-2011 nm Added INCLUDE_MATHBOXES */
-                              /* 10-Nov-2011 nm Added REVERSE */
-                              /* 25-Jun-2014 nm Removed REVERSE, NO_DISTINCT */
-                              /* 22-Nov-2014 nm Added NO_NEW_AXIOMS_FROM */
-                              /* 3-May-2016 nm Added / OVERRIDE */
-                              /* 4-Aug-2019 nm Added ALLOW_NEW_AXIOMS; changed
-                                     ALLOW_GROWTH to MAY_GROW */
             goto pclbad;
 
-          /* 7-Jan-06 nm Added EXCEPT */
           if (lastArgMatches("EXCEPT")) {
             i++;
             if (!getFullArg(i, "* What statement label match pattern? "))
               goto pclbad;
           }
-          /* 4-Aug-2019 nm Added ALLOW_NEW_AXIOMS */
           if (lastArgMatches("ALLOW_NEW_AXIOMS")) {
             i++;
             if (!getFullArg(i, "* What statement label match pattern? "))
               goto pclbad;
           }
-          /* 22-Nov-2014 nm Added NO_NEW_AXIOMS_FROM */
           if (lastArgMatches("NO_NEW_AXIOMS_FROM")) {
             i++;
             if (!getFullArg(i, "* What statement label match pattern? "))
               goto pclbad;
           }
-          /* 20-May-2013 nm Added FORBID */
           if (lastArgMatches("FORBID")) {
             i++;
             if (!getFullArg(i, "* What statement label match pattern? "))
@@ -1062,7 +933,6 @@ flag processCommandLine(void)
       goto pclgood;
     } /* end of MINIMIZE_WITH */
 
-    /* 11-Sep-2016 nm */
     if (cmdMatches("EXPAND")) {
       if (!getFullArg(1, "* What statement label? ")) goto pclbad;
       goto pclgood;
@@ -1105,7 +975,7 @@ flag processCommandLine(void)
       goto pclgood;
     }
 
-    /*???OBSOL???*/
+    /*???OBSOLETE???*/
     if (cmdMatches("ADD")) {
       if (!getFullArg(1,
           "UNIVERSE|<UNIVERSE>")) goto pclbad;
@@ -1113,14 +983,12 @@ flag processCommandLine(void)
     }
 
     if (cmdMatches("REPLACE")) {
-      /* 14-Sep-2012 nm Added FIRST, LAST */
       if (!getFullArg(1, "* What step number, or FIRST, or LAST <LAST>? "))
           goto pclbad;
       if (!getFullArg(2, "* With what statement label? ")) goto pclbad;
       /* Get any switches */
       i = 2;
 
-      /* 3-May-2016 nm Added / OVERRIDE */
       while (1) {
         i++;
         if (!getFullArg(i, "/|$|<$>")) goto pclbad;
@@ -1154,9 +1022,7 @@ flag processCommandLine(void)
     }
 
     if (cmdMatches("ASSIGN")) {
-      if (!getFullArg(1,
-          "* What step number, or FIRST, or LAST <LAST>? ")) goto pclbad;
-                                                             /* 11-Dec-05 nm */
+      if (!getFullArg(1, "* What step number, or FIRST, or LAST <LAST>? ")) goto pclbad;
       if (!getFullArg(2, "* With what statement label? ")) goto pclbad;
       /* Get any switches */
       i = 2;
@@ -1165,9 +1031,7 @@ flag processCommandLine(void)
         if (!getFullArg(i, "/|$|<$>")) goto pclbad;
         if (lastArgMatches("/")) {
           i++;
-          if (!getFullArg(i, cat(    /* 3-May-2016 nm Added / OVERRIDE */
-              "NO_UNIFY|OVERRIDE|<NO_UNIFY>", NULL)))
-            goto pclbad;
+          if (!getFullArg(i, "NO_UNIFY|OVERRIDE|<NO_UNIFY>")) goto pclbad;
         } else {
           break;
         }
@@ -1186,12 +1050,11 @@ flag processCommandLine(void)
 
     if (cmdMatches("SET")) {
       let(&tmpStr, cat(
-          /*"ECHO|SCROLL|UNIVERSE|",*/
           "WIDTH|HEIGHT|UNDO|ECHO|SCROLL|",
           "DEBUG|MEMORY_STATUS|SEARCH_LIMIT|UNIFICATION_TIMEOUT|",
-          "DISCOURAGEMENT|",  /* 10-Jul-2016 nm */
-          "CONTRIBUTOR|",  /* 14-May-2017 nm */
-          "ROOT_DIRECTORY|",  /* 31-Dec-2017 nm */
+          "DISCOURAGEMENT|",
+          "CONTRIBUTOR|",
+          "ROOT_DIRECTORY|",
           "EMPTY_SUBSTITUTION|JEREMY_HENTY_FILTER|<WIDTH>", NULL));
       if (!getFullArg(1,tmpStr)) goto pclbad;
       if (cmdMatches("SET DEBUG")) {
@@ -1220,7 +1083,7 @@ flag processCommandLine(void)
         goto pclgood;
       }
 
-      if (cmdMatches("SET DISCOURAGEMENT")) {  /* 10-Jul-2016 nm */
+      if (cmdMatches("SET DISCOURAGEMENT")) {
         if (g_globalDiscouragement) {
           if (!getFullArg(2, "ON|OFF|<OFF>")) goto pclbad;
         } else {
@@ -1316,26 +1179,6 @@ flag processCommandLine(void)
 
     } /* end if SET */
 
-    /************** 31-Dec-2017 nm Delete unused stuff
-    if (cmdMatches("INPUT")) {
-      if (!getFullArg(1, "PROOF|<PROOF>")) goto pclbad;
-      goto pclgood;
-    }
-
-    if (cmdMatches("SET UNIVERSE") || cmdMatches("ADD UNIVERSE") ||
-        cmdMatches("DELETE UNIVERSE")) {
-      /@ Get a list of statement labels @/
-      i = 1;
-      while (1) {
-        i++;
-        /@??? The user will never be asked this. @/
-        if (!getFullArg(i, "@ Statement label or '@' or '$f'|$<$>? "))
-            goto pclbad;
-        if (lastArgMatches("")) goto pclgood; /@ End of argument list @/
-      } /@ end while @/
-    } /@ end if xxx UNIVERSE @/
-    ************/
-
     if (cmdMatches("ERASE")) {
       goto pclgood;
     }
@@ -1384,7 +1227,6 @@ flag processCommandLine(void)
         goto pclgood;
       }
 
-      /* 7-Nov-2015 nm */
       if (cmdMatches("VERIFY MARKUP")) {
         if (g_sourceHasBeenRead == 0) {
           print2("?No source file has been read in.  Use READ first.\n");
@@ -1423,7 +1265,6 @@ flag processCommandLine(void)
       goto pclgood;
     }
 
-    /* 10-Dec-2018 nm Added MARKUP command*/
     if (cmdMatches("MARKUP")) {
       if (g_sourceHasBeenRead == 0) {
         print2("?No source file has been read in.  Use READ first.\n");
@@ -1484,8 +1325,7 @@ flag processCommandLine(void)
       goto pclgood;
     }
 
-    if (cmdMatches("EXIT") || cmdMatches("QUIT")
-        || cmdMatches("_EXIT_PA")) { /* 9-Jun-2016 nm */
+    if (cmdMatches("EXIT") || cmdMatches("QUIT") || cmdMatches("_EXIT_PA")) {
 
       /* Get any switches */
       i = 0;
@@ -1735,7 +1575,6 @@ flag processCommandLine(void)
       goto pclbad;
     }
 
-    /* 23-Oct-2006 nm Added / SILENT qualifier */
     /* Get any switches */
     i = 1; /* Number of command words before switch */
     while (1) {
@@ -1787,7 +1626,7 @@ flag processCommandLine(void)
     goto pclbad;
   }
 
-  /* 1-Nov-2013 nm Create a single string containing the g_fullArg tokens */
+  /* Create a single string containing the g_fullArg tokens */
   let(&g_fullArgString, "");
   for (i = 0; i < pntrLen(g_fullArg); i++) {
     let(&g_fullArgString, cat(g_fullArgString, " ", g_fullArg[i], NULL));
@@ -1927,7 +1766,6 @@ flag getFullArg(long arg, vstring cmdList1)
 
     let(&keyword,g_rawArgPntr[arg]);
 
-    /* 1-Nov-2013 nm */
     /* Convert abbreviations of FIRST, LAST, ALL to
        full keywords.  The rest of the program works fine without doing this,
        but it provides better cosmetic appearance when the command is echoed
@@ -1950,12 +1788,10 @@ flag getFullArg(long arg, vstring cmdList1)
     }
     if (cmdList[0] == '&') {
       /* See if file exists */
-      let(&tmpStr, cat(g_rootDirectory, keyword, NULL)); /* 9-Jan-2018 nm */
+      let(&tmpStr, cat(g_rootDirectory, keyword, NULL));
       tmpFp = fopen(tmpStr, "r");
       if (!tmpFp) {
-        let(&tmpStr,  cat(
-/*"?Sorry, couldn't open the file \"", keyword, "\".", NULL));*/
-  "?Sorry, couldn't open the file \"", tmpStr, "\".", NULL)); /* 9-Jan-2018 nm */
+        let(&tmpStr,  cat("?Sorry, couldn't open the file \"", tmpStr, "\".", NULL));
         printCommandError(errorLine, arg, tmpStr);
         goto return0;
       }
@@ -2176,11 +2012,6 @@ void parseCommandLine(vstring line)
   tokenStart = 0;
 
   if (!g_toolsMode) {
-    /* 5-Nov-99:  We only really need / and =
-       Took out the others so user will have less need to put quotes around
-       e.g. single tokens in SEARCH command
-    let(&specialOneCharTokens, "()/,=:");
-    */
     let(&specialOneCharTokens, "/="); /* List of special one-char tokens */
   } else {
     let(&specialOneCharTokens, "");
@@ -2190,8 +2021,8 @@ void parseCommandLine(vstring line)
   /* mode: 0 means look for start of token, 1 means look for end of
      token, 2 means look for trailing single quote, 3 means look for
      trailing double quote */
-  /* 2/20/99 - only "!" at beginning of line now acts as comment
-     - This was done because sometimes ! might be legal as part of a command */
+  /* only "!" at beginning of line acts as comment.
+     This is done because sometimes ! might be legal as part of a command */
   mode = 0;
   for (p = 0; p < lineLen; p++) {
     let(&tmpStr, ""); /* Clean up temp alloc stack to prevent overflow */
@@ -2201,7 +2032,7 @@ void parseCommandLine(vstring line)
         continue;
       }
       /* If character is comment, we're done */
-      if (p == 0 && /* 2/20/99 */ instr(1,tokenComment,chr(line[p]))) {
+      if (p == 0 && instr(1,tokenComment,chr(line[p]))) {
         break;
       }
       /* If character is a special token, get it but don't change mode */
@@ -2240,17 +2071,7 @@ void parseCommandLine(vstring line)
         mode = 0;
         continue;
       }
-      /* If character is comment, we're done */
-      /* 2/20/99 - see above
-      if (instr(1,tokenComment,chr(line[p]))) {
-        pntrLet(&g_rawArgPntr, pntrAddElement(g_rawArgPntr));
-        nmbrLet(&g_rawArgNmbr, nmbrAddElement(g_rawArgNmbr, tokenStart));
-        let((vstring *)(&g_rawArgPntr[g_rawArgs]), seg(line,tokenStart,p));
-        g_rawArgs++;
-        mode = 0;
-        break;
-      }
-      2/20/99 */
+
       /* If character is a special token, get it and change mode */
       if (instr(1,specialOneCharTokens,chr(line[p]))) {
         pntrLet(&g_rawArgPntr, pntrAddElement(g_rawArgPntr));
@@ -2266,6 +2087,7 @@ void parseCommandLine(vstring line)
         mode = 0;
         continue;
       }
+
       /* If character is a quote, set start and change mode */
       if (line[p] == '\'') {
         pntrLet(&g_rawArgPntr, pntrAddElement(g_rawArgPntr));
@@ -2466,7 +2288,6 @@ void printCommandError(vstring line1, long arg, vstring errorMsg)
   let(&line, "");
 } /* printCommandError */
 
-/* 4-May-2017 Ari Ferrera */
 void freeCommandLine() {
   long i, j;
   j = pntrLen(g_rawArgPntr);

--- a/mmcmdl.h
+++ b/mmcmdl.h
@@ -17,33 +17,26 @@ flag lastArgMatches(vstring argString);
 flag cmdMatches(vstring cmdString);
 long switchPos(vstring swString);
 void printCommandError(vstring line, long arg, vstring errorMsg);
-void freeCommandLine(void); /* 4-May-2017 Ari Ferrera */
+void freeCommandLine(void);
 
 #define DEFAULT_COLUMN 16
 extern pntrString *g_rawArgPntr;
 extern nmbrString *g_rawArgNmbr;
 extern long g_rawArgs;
 extern pntrString *g_fullArg;
-extern vstring g_fullArgString; /* 1-Nov-2013 nm g_fullArg as one string */
+extern vstring g_fullArgString; /* g_fullArg as one string */
 extern vstring g_commandPrompt;
 extern vstring g_commandLine;
 extern long g_showStatement;
 extern vstring g_logFileName;
 extern vstring g_texFileName;
 extern flag g_PFASmode; /* Proof assistant mode, invoked by PROVE command */
-/* 15-Aug-2020 nm g_queryMode is global only within mmcmdl.c */
-/* extern flag g_queryMode; */ /* If 1, explicit questions will be asked even if
-                          a field in the input command line is optional */
-extern flag g_sourceChanged; /* Flag that user made some change to the source
-                              file*/
-extern flag g_proofChanged; /* Flag that user made some change to proof in
-                             progress*/
+extern flag g_sourceChanged; /* Flag that user made some change to the source file*/
+extern flag g_proofChanged; /* Flag that user made some change to proof in progress*/
 extern flag g_commandEcho; /* Echo full command */
 extern flag g_memoryStatus; /* Always show memory */
 
-/* 31-Dec-2017 nm */
 extern flag g_sourceHasBeenRead; /* 1 if a source file has been read in */
-/* 31-Dec-2017 nm */
 extern vstring g_rootDirectory; /* Directory to use for included files */
 
 

--- a/mmcmds.c
+++ b/mmcmds.c
@@ -12,7 +12,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <stdarg.h>
-#include <time.h>  /* 28-May-04 nm For clock() */
+#include <time.h>  /* For clock() */
 #include "mmvstr.h"
 #include "mmdata.h"
 #include "mmcmdl.h" /* For g_texFileName */
@@ -86,7 +86,7 @@ void typeStatement(long showStmt,
   if (!showStmt) bug(225); /* Must be 1 or greater */
 
   if (!commentOnlyFlag && !briefFlag) {
-    assignStmtFileAndLineNum(showStmt); /* 9-Jan-2018 nm */
+    assignStmtFileAndLineNum(showStmt);
     let(&str1, cat("Statement ", str((double)showStmt),
         " is located on line ", str((double)(g_Statement[showStmt].lineNum)),
         " of the file ", NULL));
@@ -222,7 +222,7 @@ void typeStatement(long showStmt,
       htmlDistinctVarsCommaFlag = 0;
     }
 
-    /* Note added 22-Aug-04:  This algorithm is used to re-merge $d pairs
+    /* This algorithm is used to re-merge $d pairs
        into groups of 3 or more when possible, for a more compact display.
        The algorithm does not merge groups optimally, but it should be
        adequate.  For example, in set.mm (e.g. old r19.23aivv):
@@ -282,14 +282,12 @@ void typeStatement(long showStmt,
                 if (k == 0) let(&str1, "$d");
                 else let(&str1, cat(str1, " $.  $d", NULL));
               } else {
-
-                /* 12/23/01 */
                 let(&htmlDistinctVars, cat(htmlDistinctVars, " &nbsp; ",
                     NULL));
                 htmlDistinctVarsCommaFlag = 0;
-                distVarGrps++;  /* 11-Aug-2006 nm */
-
+                distVarGrps++;
               }
+
               nmbrLet(&nmbrDDList, NULL_NMBRSTRING);
               break; /* Out of n loop */
             }
@@ -302,7 +300,6 @@ void typeStatement(long showStmt,
                 NULL));
           } else {
 
-            /* 12/23/01 */
             if (htmlDistinctVarsCommaFlag) {
               let(&htmlDistinctVars, cat(htmlDistinctVars, ",", NULL));
             }
@@ -509,13 +506,10 @@ void typeStatement(long showStmt,
 
   if (briefFlag) goto returnPoint;
 
-  /* 6-Dec-03 In the LaTeX output, the hypotheses used to be printed after the
-     statement.  Now they are printed before (see above 6-Dec-03 comments),
-     so some code below is commented out. */
   switch (type) {
     case a_:
     case p_:
-      /* 6-Dec-03  This is not really needed but keeps output consistent
+      /* This is not really needed but keeps output consistent
          with previous version.  It puts a blank line before the HTML
          "distinct variable" list. */
       if (texFlag && htmlFlg) {
@@ -540,7 +534,7 @@ void typeStatement(long showStmt,
               "      "," ");
         }
       }
-      /* 6-Dec-03  This is not really needed but keeps output consistent
+      /* This is not really needed but keeps output consistent
          with previous version.  It puts a blank line before the HTML
          "distinct variable" list. */
       if (texFlag && htmlFlg) {
@@ -941,7 +935,7 @@ void typeStatement(long showStmt,
       let(&g_printString, str2);
     } /* if (subType != SYNTAX) */
     if (subType == THEOREM) {
-      /* 10/25/02 The "referenced by" does not show up after the proof
+      /* The "referenced by" does not show up after the proof
          because we moved the typeProof() to below.  Therefore, we save
          g_printString into a temporary global holding variable to print
          at the proper place inside of typeProof().  Ugly but necessary
@@ -1105,7 +1099,7 @@ vstring htmlDummyVars(long showStmt)
              "mmset.html" :
              /* The following link will work in the NF and other
                 "Proof Explorers" */
-             "../mpeuni/mmset.html",  /* 19-Aug-2017, 26-Sep-2017 nm */
+             "../mpeuni/mmset.html",
 
         "#dvnote1\">Dummy variable",
         /* Determine whether singular or plural */
@@ -1310,7 +1304,7 @@ vstring htmlAllowedSubst(long showStmt)
 /* Note that parseProof() and verifyProof() are assumed to have been called,
    so that the g_WrkProof structure elements are assigned for the current
    statement. */
-/* 8/28/00 - this is also used for the MIDI output, since we conveniently
+/* This is also used for the MIDI output, since we conveniently
    have the necessary proof information here.  The function outputMidi()
    is called from within. */
 void typeProof(long statemNum,
@@ -1374,7 +1368,7 @@ void typeProof(long statemNum,
         qualifier except / ESSENTIAL.
     / DETAILED_STEP <step> - Shows the details of what is happening at
         a specific proof step.  May not be used with any other qualifier.
-    / MIDI - 8/28/00 - puts out a midi sound file instead of a proof
+    / MIDI - puts out a midi sound file instead of a proof
         - determined by the global variable g_midiFlag, not by a parameter to
         typeProof()
   */
@@ -1412,8 +1406,8 @@ void typeProof(long statemNum,
   nmbrString *hypPtr;
   long hyp, hypStep;
 
-  /* For statement syntax breakdown (see section below added 2/5/02 for better
-     syntax hints), we declare the following 3 variables. */
+  /* For statement syntax breakdown (see "syntax hints" section below),
+    we declare the following 3 variables. */
   static long wffToken = -1; /* array index of the hard-coded token "wff" -
       static so we only have to look it up once - set to -2 if not found */
   nmbrString *nmbrTmpPtr1; /* Pointer only; not allocated directly */
@@ -1572,8 +1566,7 @@ void typeProof(long statemNum,
     nmbrLet(&essentialFlags, NULL_NMBRSTRING);
   }
 
-  /* 8/28/00 We now have enough information for the MIDI output, so
-     do it */
+  /* We now have enough information for the MIDI output, so do it */
   if (g_midiFlag) {
     outputMidi(plen, indentationLevel,
         essentialFlags, g_midiParam, g_Statement[statemNum].labelName);
@@ -1583,7 +1576,7 @@ void typeProof(long statemNum,
   /* Get the step renumbering */
   nmbrLet(&stepRenumber, nmbrSpace(plen)); /* This initializes all step
       renumbering to step 0.  Later, we will use (for html) the fact that
-      a step renumbered to 0 is a step to be skipped (6/27/99). */
+      a step renumbered to 0 is a step to be skipped. */
   i = 0;
   maxStepNum = 0;
   for (step = 0; step < plen; step++) {
@@ -1668,7 +1661,7 @@ void typeProof(long statemNum,
     } else {
       if (nmbrElementIn(1, localLabels, step)) {
 
-        /* 6/27/99 The new philosophy is to number all local labels with the
+        /* The philosophy is to number all local labels with the
            actual step number referenced, for better readability.  This means
            that if a *.mm label is a pure number, there may be ambiguity in
            the proof display, but this is felt to be too rare to be a serious
@@ -2032,7 +2025,7 @@ void typeProof(long statemNum,
       }
 
       /******************************************************************/
-      /* Start of section added 2/5/02 - for a more complete syntax hints
+      /* Start of syntax hints section - for a more complete syntax hints
          list in the HTML pages, parse the wffs comprising the hypotheses
          and the statement, and add their syntax to the hints list. */
 
@@ -2130,7 +2123,7 @@ void typeProof(long statemNum,
         nmbrLet(&nmbrTmpPtr2, NULL_NMBRSTRING);
         nmbrLet(&nmbrTmpPtr1, NULL_NMBRSTRING);
       } /* if (wffToken >= 0) */
-      /* End of section added 2/5/02 */
+      /* End of syntax hints section */
       /******************************************************************/
 
       let(&tmpStr, "");
@@ -2141,7 +2134,7 @@ void typeProof(long statemNum,
                "<TR><TD ALIGN=LEFT><FONT SIZE=-1><B>Syntax hints:</B> ");
           }
 
-          /* 10/6/99 - Get the main symbol in the syntax */
+          /* Get the main symbol in the syntax */
           /* This section can be deleted if not wanted - it is custom
              for set.mm and might not work with other .mm's */
           let(&tmpStr1, "");
@@ -2186,7 +2179,7 @@ void typeProof(long statemNum,
           if (!strcmp(g_Statement[stmt].labelName, "co")) /* operation */
             let(&tmpStr1, "(<i>class class class</i>)");
           let(&tmpStr, cat(tmpStr, " &nbsp;", tmpStr1, NULL));
-          /* End of 10/6/99 section - Get the main symbol in the syntax */
+          /* End section - Get the main symbol in the syntax */
 
           let(&tmpStr1, "");
           tmpStr1 = pinkHTML(stmt);
@@ -2323,8 +2316,8 @@ void typeProof(long statemNum,
   let(&userPrefix, "");
   let(&contPrefix, "");
   let(&hypStr, "");
-  let(&startStringWithNum, ""); /* 22-Apr-2015 nm */
-  let(&startStringWithoutNum, ""); /* 22-Apr-2015 nm */
+  let(&startStringWithNum, "");
+  let(&startStringWithoutNum, "");
   nmbrLet(&unprovedList, NULL_NMBRSTRING);
   nmbrLet(&localLabels, NULL_NMBRSTRING);
   nmbrLet(&localLabelNames, NULL_NMBRSTRING);
@@ -2651,7 +2644,7 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
   nmbrString *proof = NULL_NMBRSTRING;
   nmbrString *essentialFlags = NULL_NMBRSTRING;
 
-  /* 10/10/02 This section is never called in HTML mode anymore.  The code is
+  /* This section is never called in HTML mode anymore.  The code is
      left in though just in case we somehow get here and the user continues
      through the bug. */
   if (texFlag && g_htmlFlag) bug(239);
@@ -2730,7 +2723,7 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
   /* Next, build the output string */
   for (stmt = 1; stmt < statemNum; stmt++) {
     if (statementUsedFlags[stmt] == 'Y') {
-      assignStmtFileAndLineNum(stmt); /* 9-Jan-2018 nm */
+      assignStmtFileAndLineNum(stmt);
       let(&str1, cat(" is located on line ",
           str((double)(g_Statement[stmt].lineNum)),
           " of the file ", NULL));
@@ -2763,7 +2756,6 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
         let(&g_printString, "");
       }
 
-      /* type = g_Statement[stmt].type; */ /* 18-Sep-2013 Not used */
       let(&str1, "");
       str1 = getDescription(stmt);
       if (str1[0]) {
@@ -3144,7 +3136,7 @@ void traceProofTreeRec(long statemNum,
     }
   }
 
-  /* 20-Oct-2013 nm Don't use bad proofs (incomplete proofs are ok) */
+  /* Don't use bad proofs (incomplete proofs are ok) */
   if (parseProof(statemNum) > 1) {
     /* The proof has an error, so use the empty proof */
     nmbrLet(&proof, nmbrAddElement(NULL_NMBRSTRING, -(long)'?'));
@@ -4588,20 +4580,6 @@ void eraseSource(void)    /* ERASE command */
   for (i = 1; i <= g_statements + 1; i++) { /* g_statements + 1 is a dummy statement
                                           to hold source after last statement */
 
-    /* 28-Aug-2013 am - g_Statement[stmt].reqVarList allocated in
-       parseStatements() was not always freed by eraseSource().  If reqVars==0
-       (in parseStatements()) then g_Statement[i].reqVarList[0]==-1 (in
-       eraseSource()) and so eraseSource() thought that
-       g_Statement[stmt].reqVarList was not allocated and should not be freed.
-
-       There were similar problems for reqHypList, reqDisjVarsA, reqDisjVarsB,
-       reqDisjVarsStmt, optDisjVarsA, optDisjVarsB, optDisjVarsStmt.
-
-       These were fixed by comparing to NULL_NMBRSTRING instead of -1.
-
-       I think other files (mathString, proofString, optHypList, optVarList)
-       should be also fixed, but I could not find simple example for memory
-       leak and leave it as it was.  */
     if (g_Statement[i].labelName[0]) free(g_Statement[i].labelName);
     if (g_Statement[i].mathString != NULL_NMBRSTRING)
         poolFree(g_Statement[i].mathString);
@@ -4643,7 +4621,7 @@ void eraseSource(void)    /* ERASE command */
 
   } /* Next i (statement) */
 
-  /* 28-Aug-2013 am - g_MathToken[g_mathTokens].tokenName is assigned in
+  /* g_MathToken[g_mathTokens].tokenName is assigned in
      parseMathDecl() by let().  eraseSource() should free every g_MathToken and
      there are (g_mathTokens + g_dummyVars) tokens. */
   for (i = 0; i <= g_mathTokens + g_dummyVars; i++) {
@@ -5360,8 +5338,6 @@ void verifyMarkup(vstring labelMatch,
   /* Check mathboxes for cross-references */
   if (mathboxSkip == 0) {
     print2("Checking mathbox independence...\n");
-    /* 5-Aug-2020 nm Deleted; these are now globals */
-    /*mathboxes = getMathboxLoc(&mathboxStart, &mathboxEnd, &mathboxUser);*/
     assignMathboxInfo();  /* Populate global mathbox variables */
     /* Scan proofs in mathboxes to see if earlier mathbox is referenced */
     for (pmbox = 2; pmbox <= g_mathboxes; pmbox++) {
@@ -6007,7 +5983,7 @@ void outputMidi(long plen, nmbrString *indentationLevels,
   long keyboardOctave; /* The number of keys spanning an octave */
   long i;
 
-  /******** Define the keyboard to midi maps (added 5/17/04 nm) *************/
+  /*** Define the keyboard to midi maps ***/
   /* The idea here is to map the proof step to pressing "keyboard" keys
      on keyboards that have all keys, or only the white keys, or only the
      black keys.   The default is all keys, the parameter b means black,

--- a/mmcmds.c
+++ b/mmcmds.c
@@ -22,15 +22,13 @@
 #include "mmveri.h"
 #include "mmwtex.h" /* For g_htmlVarColor,... */
 #include "mmpfas.h"
-#include "mmunif.h" /* 26-Sep-2010 nm For g_bracketMatchInit, g_minSubstLen */
-                    /* 1-Oct-2017 nm ...and g_firstConst */
+#include "mmunif.h" /* For g_bracketMatchInit, g_minSubstLen,
+                       ...and g_firstConst */
 
-/* 12-Nov-2018 nm */
 /* Local prototypes */
 vstring bigAdd(vstring bignum1, vstring bignum2);
 vstring bigSub(vstring bignum1, vstring bignum2);
 
-/* vstring mainFileName = ""; */ /* 28-Dec-05 nm Obsolete */
 flag g_printHelp = 0;
 
 /* For HTML output */
@@ -72,11 +70,11 @@ void typeStatement(long showStmt,
   flag q1, q2;
   flag type;
   flag subType;
-  vstring htmlDistinctVars = ""; /* 12/23/01 */
-  char htmlDistinctVarsCommaFlag = 0; /* 12/23/01 */
-  vstring str4 = ""; /* 10/10/02 */
-  vstring str5 = ""; /* 19-Sep-2012 nm */
-  long distVarGrps = 0;  /* 11-Aug-2006 nm */
+  vstring htmlDistinctVars = "";
+  char htmlDistinctVarsCommaFlag = 0;
+  vstring str4 = "";
+  vstring str5 = "";
+  long distVarGrps = 0;
 
   /* For syntax breakdown of definitions in HTML page */
   long zapStatement1stToken;
@@ -101,12 +99,10 @@ void typeStatement(long showStmt,
       printLongLine(cat(str1,
         "\"", g_Statement[showStmt].fileName,
         "\".",
-        /* 8-Feb-2007 nm Added HTML page info to SHOW STATEMENT ... /FULL */
         (g_Statement[showStmt].pinkNumber == 0) ?   /* !=0 means $a or $p */
            "" :
            cat("  Its statement number for HTML pages is ",
                str((double)(g_Statement[showStmt].pinkNumber)), ".", NULL),
-        /* 5-Aug-2020 nm Added mathbox user to SHOW STATEMENT ... /FULL */
         ((getMathboxUser(showStmt))[0] == 0) ?
            "" :
            cat("  It is in the mathbox for ", getMathboxUser(showStmt), ".",
@@ -178,7 +174,7 @@ void typeStatement(long showStmt,
     if (!str1[0] /* No comment */) {
       print2("?Warning: Statement \"%s\" has no comment\n",
           g_Statement[showStmt].labelName);
-      /* 14-Sep-2010 nm We must print a blank comment to have \begin{lemma} */
+      /* We must print a blank comment to have \begin{lemma} */
       if (texFlag && !htmlFlg && !g_oldTexFlag) {
         let(&str1, "TO DO: PUT DESCRIPTION HERE");
       }
@@ -187,21 +183,8 @@ void typeStatement(long showStmt,
       if (!texFlag) {
         printLongLine(cat("\"", str1, "\"", NULL), "", " ");
       } else {
-        /* 10/10/02 This is now done in mmwtex.c printTexComment */
-        /* Although it will affect the 2nd (and only other) call to
-           printTexComment below, that call is obsolete and there should
-           be no side effect. */
-        /*******
-        if (htmlFlg && texFlag) {
-          let(&str1, cat("<CENTER><B>Description: </B>", str1,
-              "</CENTER><BR>", NULL));
-        }
-        *******/
         if (!htmlFlg) {  /* LaTeX */
           if (!g_oldTexFlag) {
-            /* 14-Sep-2010 */
-
-            /* 1-May-2017 nm */
             /* Distinguish axiom, definition, theorem */
             /* Note: changes here must be mirrored in the \end{...} below */
             if (g_Statement[showStmt].type == a_) {
@@ -216,36 +199,24 @@ void typeStatement(long showStmt,
             let(&str1, cat("\\begin{", str3, "}\\label{",
                 left(str3, 3), ":",
                 g_Statement[showStmt].labelName, "} ", str1, NULL));
-            /* old code before 1-May-2017:
-            let(&str1, cat("\\begin{lemma}\\label{lem:",
-                g_Statement[showStmt].labelName, "} ", str1, NULL));
-            */
-
           } else {
-            /* 6-Dec-03 Add separation space between theorems */
+            /* Add separation space between theorems */
             let(&str1, cat("\n\\vspace{1ex} %2\n\n", str1, NULL));
           }
         }
         /* printTexComment(str1, 1); */
-        /* 17-Nov-2015 nm Add 3rd & 4th arguments */
         printTexComment(str1,              /* Sends result to g_texFilePtr */
             1, /* 1 = htmlCenterFlag */
-            PROCESS_EVERYTHING, /* actionBits */ /* 13-Dec-2018 nm */
+            PROCESS_EVERYTHING, /* actionBits */
             0  /* 1 = noFileCheck */);
       }
     }
   }
   if (commentOnlyFlag && !briefFlag) goto returnPoint;
 
-  if ((briefFlag && !texFlag) ||
-       (htmlFlg && texFlag) /* HTML page 12/23/01 */) {
+  if ((briefFlag && !texFlag) || (htmlFlg && texFlag)) {
     /* In BRIEF mode screen output, show $d's */
-    /* This section was added 8/31/99 */
 
-    /* 12/23/01 - added algorithm to HTML pages also; the string to print out
-       is stored in htmlDistinctVars for later printing */
-
-    /* 12/23/01 */
     if (htmlFlg && texFlag) {
       let(&htmlDistinctVars, "");
       htmlDistinctVarsCommaFlag = 0;
@@ -272,17 +243,14 @@ void typeStatement(long showStmt,
         if (!nmbrElementIn(1, nmbrDDList, nmbrTmpPtr1[k]) &&
             !nmbrElementIn(1, nmbrDDList, nmbrTmpPtr2[k])) {
           /* No, so close out the current list */
-          if (!(htmlFlg && texFlag)) { /* 12/23/01 */
+          if (!(htmlFlg && texFlag)) {
             if (k == 0) let(&str1, "$d");
             else let(&str1, cat(str1, " $.  $d", NULL));
           } else {
-
-            /* 12/23/01 */
             let(&htmlDistinctVars, cat(htmlDistinctVars, " &nbsp; ",
                 NULL));
             htmlDistinctVarsCommaFlag = 0;
-            distVarGrps++;  /* 11-Aug-2006 nm */
-
+            distVarGrps++;
           }
           nmbrLet(&nmbrDDList, NULL_NMBRSTRING);
         }
@@ -353,7 +321,6 @@ void typeStatement(long showStmt,
                 NULL));
           } else {
 
-            /* 12/23/01 */
             if (htmlDistinctVarsCommaFlag) {
               let(&htmlDistinctVars, cat(htmlDistinctVars, ",", NULL));
             }
@@ -372,19 +339,14 @@ void typeStatement(long showStmt,
         let(&str1, cat(str1, " $.", NULL));
         printLongLine(str1, "  ", " ");
       } else {
-
-        /* 12/23/01 */
         /* (do nothing) */
-        /*let(&htmlDistinctVars, cat(htmlDistinctVars, "<BR>", NULL));*/
-
       }
     } /* if i(#$d's) > 0 */
   }
 
-  if (briefFlag || texFlag /*(texFlag && htmlFlg)*/) { /* 6-Dec-03 */
+  if (briefFlag || texFlag) {
     /* For BRIEF mode, print $e hypotheses (only) before statement */
     /* Also do it for HTML output */
-    /* 6-Dec-03  For the LaTeX output, now print hypotheses before statement */
     j = nmbrLen(g_Statement[showStmt].reqHypList);
     k = 0;
     for (i = 0; i < j; i++) {
@@ -392,7 +354,6 @@ void typeStatement(long showStmt,
       if (g_Statement[g_Statement[showStmt].reqHypList[i]].type
         == (char)e_) k++;
 
-      /* Added 5/26/03 */
       /* For syntax definitions, also include $f hypotheses so user can more
          easily match them in syntax breakdowns of axioms and definitions */
       if (subType == SYNTAX && (texFlag && htmlFlg)) {
@@ -420,7 +381,6 @@ void typeStatement(long showStmt,
         k = g_Statement[showStmt].reqHypList[i];
         if (g_Statement[k].type != (char)e_
 
-            /* Added 5/26/03 */
             /* For syntax definitions, include $f hypotheses so user can more
                easily match them in syntax breakdowns of axioms & definitions */
             && !(subType == SYNTAX && (texFlag && htmlFlg)
@@ -443,7 +403,7 @@ void typeStatement(long showStmt,
           /* texFlag was (misleadingly) included below to facilitate search
              for "htmlFlg && texFlag". */
           if (!(htmlFlg && texFlag)) {
-            if (!g_oldTexFlag) {  /* 14-Sep-2010 nm */
+            if (!g_oldTexFlag) {
               /* Do nothing */
             } else {
               let(&str3, space((long)strlen(str2)));
@@ -482,7 +442,6 @@ void typeStatement(long showStmt,
   } else {
     if (!(htmlFlg && texFlag)) {  /* really !htmlFlg & texFlag */
       if (!g_oldTexFlag) {
-        /* 14-Sep-2010 nm new LaTeX code: */
         g_outputToString = 1;
         print2("\\begin{align}\n");
         let(&str3, "");
@@ -495,7 +454,6 @@ void typeStatement(long showStmt,
               g_Statement[showStmt].labelName,
               "}",
 
-              /* 1-May-2017 nm */
               /* Add "\tag{..}" to use .mm labels instead of equation numbers */
               /* (Suggested by Ari Ferrera) */
               "\\tag{",
@@ -507,7 +465,6 @@ void typeStatement(long showStmt,
         print2("\\end{align}\n");
 
 
-        /* 1-May-2017 nm */
         /* Distinguish axiom, definition, theorem for LaTeX */
         /* Note: changes here must be mirrored in the \begin{...} above */
         if (g_Statement[showStmt].type == a_) {
@@ -520,9 +477,6 @@ void typeStatement(long showStmt,
           let(&str3, "theorem");
         }
         print2("%s\n", cat("\\end{", str3, "}", NULL));
-        /* old code before 1-May-2017:
-        print2("\\end{lemma}\n");
-        */
 
         fprintf(g_texFilePtr, "%s", g_printString);
         let(&g_printString, "");
@@ -564,47 +518,37 @@ void typeStatement(long showStmt,
       /* 6-Dec-03  This is not really needed but keeps output consistent
          with previous version.  It puts a blank line before the HTML
          "distinct variable" list. */
-      if (texFlag && htmlFlg) { /* 6-Dec-03 */
+      if (texFlag && htmlFlg) {
         g_outputToString = 1;
         print2("\n");
         g_outputToString = 0;
       }
 
-      /*if (!(htmlFlg && texFlag)) {*/
-      if (!texFlag) {  /* 6-Dec-03 fix */
+      if (!texFlag) {
         print2("Its mandatory hypotheses in RPN order are:\n");
       }
-      /*if (texFlag) g_outputToString = 0;*/ /* 6-Dec-03 */
       j = nmbrLen(g_Statement[showStmt].reqHypList);
       for (i = 0; i < j; i++) {
         k = g_Statement[showStmt].reqHypList[i];
         if (g_Statement[k].type != (char)e_ && (!htmlFlg && texFlag))
-          continue; /* 9/2/99 Don't put $f's in LaTeX output */
+          continue;
         let(&str2, cat("  ",g_Statement[k].labelName,
             " $", chr(g_Statement[k].type), " ", NULL));
         if (!texFlag) {
           printLongLine(cat(str2,
               nmbrCvtMToVString(g_Statement[k].mathString), " $.", NULL),
               "      "," ");
-        } else {
-          if (!(htmlFlg && texFlag)) {  /* LaTeX */
-            /*let(&str3, space((long)strlen(str2)));*/ /* 6-Dec-03 */
-            /* This clears out g_printString */
-            /*printTexLongMath(g_Statement[k].mathString,
-                str2, str3, 0, 0);*/ /* 6-Dec-03 */
-          }
         }
       }
       /* 6-Dec-03  This is not really needed but keeps output consistent
          with previous version.  It puts a blank line before the HTML
          "distinct variable" list. */
-      if (texFlag && htmlFlg) { /* 6-Dec-03 */
+      if (texFlag && htmlFlg) {
         g_outputToString = 1;
         print2("\n");
         g_outputToString = 0;
       }
-      /*if (j == 0 && !(htmlFlg && texFlag)) print2("  (None)\n");*/
-      if (j == 0 && !texFlag) print2("  (None)\n"); /* 6-Dec-03 fix */
+      if (j == 0 && !texFlag) print2("  (None)\n");
       let(&str1, "");
       nmbrTmpPtr1 = g_Statement[showStmt].reqDisjVarsA;
       nmbrTmpPtr2 = g_Statement[showStmt].reqDisjVarsB;
@@ -639,7 +583,6 @@ void typeStatement(long showStmt,
            "Its optional hypotheses are:  ",
             nmbrCvtRToVString(
             g_Statement[showStmt].optHypList,
-                /* 25-Jan-2016 nm */
                 0, /*explicitTargets*/
                 0 /*statemNum, used only if explicitTargets*/), NULL),
             "      "," ");
@@ -650,13 +593,6 @@ void typeStatement(long showStmt,
       if (i && type == p_) {
         if (!texFlag) {
           let(&str1, "");
-        } else {
-          if (htmlFlg && texFlag) {
-            /*  12/1/01 don't output dummy variables
-            let(&str1, cat(str1,
-            " &nbsp; (Dummy variables for use in proof:) ", NULL));
-            */
-          }
         }
         for (k = 0; k < i; k++) {
           if (!texFlag) {
@@ -672,19 +608,7 @@ void typeStatement(long showStmt,
         }
       } /* if (i && type == p_) */
 
-      /* Before 12/23/01 **********
-           Future: once stable, take out redundant code producing str1
-      if (texFlag && htmlFlg && str1[0]) {
-        g_outputToString = 1;
-        printLongLine(cat("<CENTER>Substitutions into these variable",
-            " pairs may not have variables in common: ",
-            str1, "</CENTER>", NULL), "", " ");
-        g_outputToString = 0;
-      }
-      ***********/
 
-
-      /* 12/23/01 */
       if (texFlag && htmlFlg) { /* It's a web page */
 
         if (htmlDistinctVars[0] != 0) {
@@ -693,22 +617,19 @@ void typeStatement(long showStmt,
               "<CENTER>",
               "<A HREF=\"",
 
-              /* 26-Aug-2017 nm */
               /* g_htmlHome is set by htmlhome in $t comment */
               (instr(1, g_htmlHome, "mmset.html") > 0) ?
                   "mmset.html" :
                   /* The following link will work in the NF and other
                      "Proof Explorers" */
-                  "../mpeuni/mmset.html",  /* 19-Aug-2017, 26-Sep-2017 nm */
+                  "../mpeuni/mmset.html",
 
               "#distinct\">Distinct variable</A> group",
-              /* 11-Aug-2006 nm Determine whether "group" or "groups". */
-              distVarGrps > 1 ? "s" : "",  /* 11-Aug-2006 */
+              distVarGrps > 1 ? "s" : "",
               ": ",
-              /* 14-Jan-2016 nm Put a span around the variable list to localize
+              /* Put a span around the variable list to localize
                  the use of the special math font for ALT_HTML */
               (g_altHtmlFlag ? cat("<SPAN ", g_htmlFont, ">", NULL) : ""),
-                                                 /* 14-Jan-2016 nm */
               htmlDistinctVars,
               (g_altHtmlFlag ? "</SPAN>" : ""),
               "</CENTER>",
@@ -716,33 +637,10 @@ void typeStatement(long showStmt,
           g_outputToString = 0;
         }
 
-        /* 26-Aug-2017 nm Moved this down into proof section */
-        /*
-        /@ 13-Aug-2017 nm @/
-        let(&str3, "");
-        if (type == p_) {
-          str3 = htmlDummyVars(showStmt);
-          if (str3[0] != 0) {
-            g_outputToString = 1;
-            /@ We don't need <BR> if code is surrounded by <CENTER>...</CENTER>
-            if (htmlDistinctVars[0] != 0) print2("<BR>\n");
-            @/
-            /@ Print the list of dummy variables @/
-            printLongLine(str3, "", "\"");
-            g_outputToString = 0;
-          }
-        }
-        /@ (end of 13-Aug-2017) @/
-        */
-
-        /* 4-Jan-2014 nm */
         let(&str2, "");
         str2 = htmlAllowedSubst(showStmt);
         if (str2[0] != 0) {
           g_outputToString = 1;
-          /* We don't need <BR> if code is surrounded by <CENTER>...</CENTER>
-          if (htmlDistinctVars[0] != 0 || str3[0] != 0) print2("<BR>\n");
-          */
           /* Print the list of allowed free variables */
           printLongLine(str2, "", "\"");
           g_outputToString = 0;
@@ -754,10 +652,6 @@ void typeStatement(long showStmt,
         g_outputToString = 1;
         if (htmlFlg && texFlag) print2("<HR NOSHADE SIZE=1>\n");
         g_outputToString = 0; /* Restore normal output */
-        /* will be done automatically at closing
-        fprintf(g_texFilePtr, "%s", g_printString);
-        let(&g_printString, "");
-        */
         break; /* case a_ or p_ */
       }
       let(&str1, nmbrCvtMToVString(
@@ -789,10 +683,6 @@ void typeStatement(long showStmt,
   } /* End switch(type) */
   if (texFlag) {
     g_outputToString = 0;
-    /* will be done automatically at closing
-    fprintf(g_texFilePtr, "%s", g_printString);
-    let(&g_printString, "");
-    */
   }
 
   /* Start of finding definition for syntax statement */
@@ -847,8 +737,6 @@ void typeStatement(long showStmt,
                     NULL), "", "\"");
               }
 
-              /* 10/10/02 Moved here from mmwtex.c */
-              /*print2("<FONT SIZE=-1 FACE=sans-serif>Colors of variables:\n");*/
               printLongLine(cat(
                   "<CENTER><TABLE CELLSPACING=7><TR><TD ALIGN=LEFT><FONT SIZE=-1>",
                   "<B>Colors of variables:</B> ",
@@ -902,9 +790,8 @@ void typeStatement(long showStmt,
             showStmt /*statemNum*/, 0 /*maxEDepth*/,
             0, /*step:  0 = step 1 */ /*For messages*/
             0,  /*not noDistinct*/
-            /* 3-May-2016 nm */
             2, /* override discouraged-usage statements silently */
-            1 /* Always allow other mathboxes */ /* 5-Aug-2020 nm */
+            1 /* Always allow other mathboxes */
             );
 
         if (nmbrLen(nmbrTmpPtr2)) {
@@ -917,7 +804,6 @@ void typeStatement(long showStmt,
           if (strcmp(g_Statement[showStmt].proofSectionPtr, "")) bug(231);
           if (g_Statement[showStmt].proofSectionLen != 0) bug(232);
           let(&str1, nmbrCvtRToVString(nmbrTmpPtr2,
-                /* 25-Jan-2016 nm */
                 0, /*explicitTargets*/
                 0 /*statemNum, used only if explicitTargets*/));
           /* Temporarily zap proof into the $a statement */
@@ -937,7 +823,7 @@ void typeStatement(long showStmt,
               0 /*reverseFlag*/,
               1 /*noIndentFlag*/,
               0 /*splitColumn*/,
-              0 /*skipRepeatedSteps*/,  /* 28-Jun-2013 nm */
+              0 /*skipRepeatedSteps*/,
               1 /*texFlag*/,  /* Means either latex or html */
               1 /*htmlFlg*/);
 
@@ -950,7 +836,6 @@ void typeStatement(long showStmt,
           nmbrLet(&nmbrTmpPtr2, NULL_NMBRSTRING);
 
         } else { /* if (nmbrLen(nmbrTmpPtr2)) else */
-          /* 5-Aug-2011 nm */
           /* Proof was not found - probable syntax error */
           if (g_outputToString != 0) bug(246);
           printLongLine(cat(
@@ -976,9 +861,9 @@ void typeStatement(long showStmt,
   /* End of finding definition for syntax statement */
 
 
-  /* 10/6/99 - Start of creating used-by list for html page */
+  /* Start of creating used-by list for html page */
   if (htmlFlg && texFlag) {
-    /* 10/25/02 Clear out any previous g_printString accumulation
+    /* Clear out any previous g_printString accumulation
        for g_printStringForReferencedBy case below */
     fprintf(g_texFilePtr, "%s", g_printString);
     let(&g_printString, "");
@@ -989,20 +874,11 @@ void typeStatement(long showStmt,
         definitions, axioms, and theorems, not syntax statements */
       let(&str1, "");
       g_outputToString = 0; /* Switch output to console in case
-            traceUsage reports an error */ /* 8-Dec-2018 nm */
+            traceUsage reports an error */
       str1 = traceUsage(showStmt,
           0, /* recursiveFlag */
           0 /* cutoffStmt */);
-      g_outputToString = 1; /* Restore output to string */ /* 8-Dec-2018 nm */
-      /* if (str1[0]) { */ /* Used by at least one */
-      /* 18-Jul-2015 nm */
-
-      /* 30-Oct-2018 nm Commented out, and block unindented: */
-      /*if (str1[0] == 'Y') {*/ /* Used by at least one */
-
-      /* 30-Oct-2018 nm */
-      /* We now output this all the time, using "(None)" if none, per
-         request of Benoit Jubin */
+      g_outputToString = 1; /* Restore output to string */
 
       /* str1[i] will be 'Y' if used by showStmt */
       /* Convert usage list str1 to html links */
@@ -1012,97 +888,11 @@ void typeStatement(long showStmt,
         case THEOREM: let(&str3, "theorem"); break;
         default: bug(233);
       }
-      /******* pre 10/10/02
-      let(&str2, cat("<FONT SIZE=-1 FACE=sans-serif>This ", str3,
-          " is referenced by: ", NULL));
-      *******/
-      /* 10/10/02 */
       let(&str2, cat("<TR><TD ALIGN=LEFT><FONT SIZE=-1><B>This ", str3,
           " is referenced by:</B>", NULL));
 
       if (str1[0] == 'Y') { /* Used by at least one */
-        /********* 18-Jul-2015 Deleted code *********************/
-        /*
-        /@ Convert str1 to trailing space after each label @/
-        let(&str1, cat(right(str1, 2), " ", NULL));
-        let(&str5, ""); /@ Buffer for very long strings @/ /@ 19-Sep-2012 nm @/
-        i = 0;
-        while (1) {
-          j = i + 1;
-          i = instr(j, str1, " ");
-          if (!i) break;
-          /@ Extract the label @/
-          let(&str3, seg(str1, j, i - 1));
-          /@ Find the statement number @/
-          m = lookupLabel(str3);
-          if (m < 0) {
-            /@ The lookup should never fail @/
-            bug(240);
-            continue;
-          }
-          /@ It should be a $p @/
-          if (g_Statement[m].type != p_) bug(241);
-          /@ Get the pink number @/
-          let(&str4, "");
-          str4 = pinkHTML(m);
-          /@ Assemble the href @/
-          let(&str2, cat(str2, " &nbsp;<A HREF=\"",
-              str3, ".html\">",
-              str3, "</A>", str4, NULL));
-          /@ 8-Aug-2008 nm If line is very long, print it out and reset
-             it to speed up program (SHOW STATEMENT syl/HTML is very slow) @/
-          /@ 8-Aug-2008 nm This doesn't solve problem, because the bottleneck
-             is printing g_printStringForReferencedBy below.  This whole
-             code section needs to be redesigned to solve the speed problem. @/
-          /@
-          if (strlen(str2) > 500) {
-            printLongLine(str2, "", "\"");
-            let(&str2, "");
-          }
-          @/
-          /@ 19-Sep-2012 nm Try again to fix SHOW STATEMENT syl/HTML speed
-             without a major rewrite @/
-          /@
-          Unfortunately, makes little difference.  Using lcc:
-          orig    real    1m6.676s
-          500     real    1m2.285s
-          3000    real    1m2.181s
-          3000    real    1m1.663s
-          3000    real    1m1.785s
-          5000    real    1m0.678s
-          5000    real    1m0.169s
-          5000    real    1m1.951s
-          5000    real    1m2.307s
-          5000    real    1m1.717s
-          7000    real    1m2.048s
-          7000    real    1m2.012s
-          7000    real    1m1.817s
-          10000   real    1m2.779s
-          10000   real    1m1.830s
-          20000   real    1m1.431s
-          50000   real    1m1.325s
-          100000  real    1m3.172s
-          100000  real    1m4.657s
-          (Added 17-Jul-2015: The 1 minute is probably due to the old
-              traceUsage algorithm that built a huge string of labels; should
-              be faster now.)
-          @/
-          /@ Accumulate large cat buffer when small cats exceed certain size @/
-          if (strlen(str2) > 5000) {
-            let(&str5, cat(str5, str2, NULL));
-            let(&str2, "");
-          }
-          /@ End 19-Sep-2012 @/
-        }
-        /@ let(&str2, cat(str2, "</FONT></TD></TR>", NULL)); @/ /@ old @/
-         /@ 19-Sep-2012 nm Include buffer in output string@/
-        let(&str2, cat(str5, str2, "</FONT></TD></TR>", NULL));
-        printLongLine(str2, "", "\"");
-        */
-        /**************** 18-Jul-2015 End of deleted code *********/
-
-
-        let(&str5, ""); /* Buffer for very long strings */ /* 19-Sep-2012 nm */
+        let(&str5, ""); /* Buffer for very long strings */
         /* Scan all future statements in str1 Y/N list */
         for (m = showStmt + 1; m <= g_statements; m++) {
           /* Scan the used-by map */
@@ -1118,7 +908,7 @@ void typeStatement(long showStmt,
           let(&str2, cat(str2, " &nbsp;<A HREF=\"",
               str3, ".html\">",
               /*str3, "</A>", str4, NULL));*/
-              str3, "</A>\n", str4, NULL));  /* 18-Jul-2015 nm */
+              str3, "</A>\n", str4, NULL));
           /* 8-Aug-2008 nm If line is very long, print it out and reset
              it to speed up program (SHOW STATEMENT syl/HTML is very slow) */
           /* 8-Aug-2008 nm This doesn't solve problem, because the bottleneck
@@ -1134,25 +924,21 @@ void typeStatement(long showStmt,
             let(&str5, cat(str5, str2, NULL));
             let(&str2, "");
           }
-          /* End 19-Sep-2012 */
         } /* next m (statement number) */
 
 
-      /* 30-Oct-2018 nm Added "else" clause to print "(None)" if no refs */
       } else {
         /* There is no usage of this statement; print "(None)" */
         let(&str5, "");
         let(&str2, cat(str2, " (None)", NULL));
 
       } /* if (str1[0] == 'Y') */
-      /* let(&str2, cat(str2, "</FONT></TD></TR>", NULL)); */ /* old */
-       /* 19-Sep-2012 nm Include buffer in output string*/
+      /* Include buffer in output string */
       let(&str2, cat(str5, str2, "</FONT></TD></TR>", NULL));
-      /*printLongLine(str2, "", "\"");*/ /* 18-Jul-2015 nm Deleted */
       if (g_printString[0]) {
-        bug(256);  /* 18-Jul-2015 nm */
+        bug(256);
       }
-      let(&g_printString, str2); /* 18-Jul-2015 nm */
+      let(&g_printString, str2);
     } /* if (subType != SYNTAX) */
     if (subType == THEOREM) {
       /* 10/25/02 The "referenced by" does not show up after the proof
@@ -1170,10 +956,10 @@ void typeStatement(long showStmt,
     /* Printing of the trailer in mmwtex.c will close out string later */
     g_outputToString = 0;
   } /* if (htmlFlg && texFlag) */
-  /* 10/6/99 - End of used-by list for html page */
+  /* End of used-by list for html page */
 
 
-  /* 10/25/02  Moved this to after the block above, so referenced statements
+  /* After the block above, so referenced statements
      show up first for convenience */
   if (htmlFlg && texFlag) {
     /*** Output the html proof for $p statements ***/
@@ -1192,7 +978,7 @@ void typeStatement(long showStmt,
           0 /*reverseFlag*/,
           1 /*noIndentFlag*/,
           0 /*splitColumn*/,
-          0 /*skipRepeatedSteps*/,  /* 28-Jun-2013 nm */
+          0 /*skipRepeatedSteps*/,
           1 /*texFlag*/,  /* Means either latex or html */
           1 /*htmlFlg*/);
     } /* if (g_Statement[showStmt].type == (char)p_) */
@@ -1215,7 +1001,6 @@ void typeStatement(long showStmt,
 
 
 
-/* 13-Aug-2017 nm */
 /* Get the HTML string of dummy variables used by a proof for the
    theorem's web page.  It should be called only if we're in
    HTML output mode i.e.  SHOW STATEMENT .../HTML or /ALT_HTML */
@@ -1239,7 +1024,6 @@ vstring htmlDummyVars(long showStmt)
   long dummyVar; /* Current variable in a $d; test if it's a dummy variable */
 
   /* This function should be called only for web page generation */
-  /*if (!(g_htmlFlag && texFlag)) bug(261);*/  /* texFlag is not global */
   if (!g_htmlFlag) bug(261);
 
   if (g_Statement[showStmt].type != p_) bug(262);
@@ -1316,7 +1100,6 @@ vstring htmlDummyVars(long showStmt)
         "<CENTER>",
          "<A HREF=\"",
 
-         /* 26-Aug-2017 nm */
          /* g_htmlHome is set by htmlhome in $t comment */
          (instr(1, g_htmlHome, "mmset.html") > 0) ?
              "mmset.html" :
@@ -1327,19 +1110,13 @@ vstring htmlDummyVars(long showStmt)
         "#dvnote1\">Dummy variable",
         /* Determine whether singular or plural */
         dummyVarCount > 1 ? "s" : "",
-        "</A> ",  /* 14-Aug-2017 nm */
-        /* 14-Jan-2016 nm Put a span around the variable list to localize
+        "</A> ",
+        /* Put a span around the variable list to localize
            the use of the special math font for ALT_HTML */
         (g_altHtmlFlag ? cat("<SPAN ", g_htmlFont, ">", NULL) : ""),
-                                           /* 14-Jan-2016 nm */
         htmlDummyVarList,
         (g_altHtmlFlag ? "</SPAN>" : ""),
-        /*
-        dummyVarCount > 1 ? " are assumed to be mutually distinct and"
-            : " is assumed to be",
-        */
-        dummyVarCount > 1 ? " are mutually distinct and"
-            : " is",
+        dummyVarCount > 1 ? " are mutually distinct and" : " is",
         " distinct from all other variables.",
         "</CENTER>",
         NULL));
@@ -1356,7 +1133,6 @@ vstring htmlDummyVars(long showStmt)
 
 
 
-/* 4-Jan-2014 nm */
 /* Get the HTML string of "allowed substitutions" list for an axiom
    or theorem's web page.  It should be called only if we're in
    HTML output mode i.e.  SHOW STATEMENT .../HTML or /ALT_HTML */
@@ -1389,7 +1165,6 @@ vstring htmlAllowedSubst(long showStmt)
   numReqHyps = nmbrLen(reqHyp);
 
   /* This function should be called only for web page generation */
-  /*if (!(g_htmlFlag && texFlag)) bug(250);*/  /* texFlag is not global */
   if (!g_htmlFlag) bug(250);
 
   if (g_Statement[showStmt].mathStringLen < 1) bug(254);
@@ -1400,7 +1175,6 @@ vstring htmlAllowedSubst(long showStmt)
   }
 
   if (numDVs == 0) {  /* Don't create a hint list if no $d's */
-    /*let(&htmlAllowedList, "(no restrictions)");*/
     goto RETURN_POINT;
   }
 
@@ -1507,20 +1281,18 @@ vstring htmlAllowedSubst(long showStmt)
     let(&htmlAllowedList, cat("<CENTER>",
         "<A HREF=\"",
 
-        /* 26-Aug-2017 nm */
         /* g_htmlHome is set by htmlhome in $t comment */
         (instr(1, g_htmlHome, "mmset.html") > 0) ?
             "mmset.html" :
             /* The following link will work in the NF and other
                "Proof Explorers" */
-            "../mpeuni/mmset.html",  /* 19-Aug-2017, 26-Sep-2017 nm */
+            "../mpeuni/mmset.html",
 
         "#allowedsubst\">Allowed substitution</A> hint",
         ((countInfo != 1) ? "s" : ""), ": ",
         (g_altHtmlFlag ? cat("<SPAN ", g_htmlFont, ">", NULL) : ""),
-                                           /* 14-Jan-2016 nm */
         htmlAllowedList,
-        (g_altHtmlFlag ? "</SPAN>" : ""),    /* 14-Jan-2016 nm */
+        (g_altHtmlFlag ? "</SPAN>" : ""),
         "</CENTER>", NULL));
   }
 
@@ -1553,9 +1325,9 @@ void typeProof(long statemNum,
   flag reverseFlag,
   flag noIndentFlag, /* Means Lemmon-style proof */
   long splitColumn, /* START_COLUMN */
-  flag skipRepeatedSteps, /* NO_REPEATED_STEPS */  /* 28-Jun-2013 nm */
+  flag skipRepeatedSteps, /* NO_REPEATED_STEPS */
   flag texFlag,
-  flag htmlFlg /* htmlFlg added 6/27/99 */
+  flag htmlFlg
   /* flag g_midiFlag - global to avoid changing many calls to typeProof() */
   )
 {
@@ -1618,8 +1390,8 @@ void typeProof(long statemNum,
   vstring userPrefix = "";
   vstring contPrefix = "";
   vstring statementUsedFlags = "";
-  vstring startStringWithNum = ""; /* 22-Apr-2015 nm */
-  vstring startStringWithoutNum = ""; /* 22-Apr-2015 nm */
+  vstring startStringWithNum = "";
+  vstring startStringWithoutNum = "";
   nmbrString *proof = NULL_NMBRSTRING;
   nmbrString *localLabels = NULL_NMBRSTRING;
   nmbrString *localLabelNames = NULL_NMBRSTRING;
@@ -1632,7 +1404,7 @@ void typeProof(long statemNum,
   nmbrString *relativeStepNums = NULL_NMBRSTRING; /* For unknownFlag */
   long maxLabelLen = 0;
   long maxStepNumLen = 1;
-  long maxStepNumOffsetLen = 0; /* 22-Apr-2015 nm */
+  long maxStepNumOffsetLen = 0;
   char type;
   flag stepPrintFlag;
   long fromStep, toStep, byStep;
@@ -1647,8 +1419,6 @@ void typeProof(long statemNum,
   nmbrString *nmbrTmpPtr1; /* Pointer only; not allocated directly */
   nmbrString *nmbrTmpPtr2; /* Pointer only; not allocated directly */
 
-  /* 31-Jan-2010 nm */
-  /* skipRepeatedSteps = 0; */ /* 28-Jun-2010 nm Now set by parameter */
   if (htmlFlg && texFlag) skipRepeatedSteps = 1; /* Keep old behavior */
   /* Comment out the following line if you want to revert to the old
      Lemmon-style behavior with local label references for reused compressed
@@ -1656,7 +1426,6 @@ void typeProof(long statemNum,
      the same steps and step numbers as the indented proof, rather than
      those on the HTML pages. */
   /* if (noIndentFlag) skipRepeatedSteps = 1; */
-           /* 28-Jun-2013 nm Now set by parameter */
 
   if (htmlFlg && texFlag) {
 
@@ -1666,7 +1435,6 @@ void typeProof(long statemNum,
     g_outputToString = 1; /* Flag for print2 to add to g_printString */
     if (essentialFlag) {
 
-      /* 26-Aug-2017 nm */
       /* See if there are dummy variables.  If so, print them below
          "Proof of Theorem", which means we have to make the "Proof of
          Theorem" line separate and not the table caption, so that the
@@ -1685,7 +1453,6 @@ void typeProof(long statemNum,
             MINT_BACKGROUND_COLOR);
         print2("SUMMARY=\"Proof of theorem\">\n");
       } else {
-      /* End of 26-Aug-2017 */
 
         /* For bobby.cast.org approval */
         print2("<CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR=%s\n",
@@ -1718,17 +1485,11 @@ void typeProof(long statemNum,
         "<TR><TH>Step</TH><TH>Hyp</TH><TH>Ref\n");
     print2("</TH><TH>Expression</TH></TR>\n");
     g_outputToString = 0;
-    /* printTexLongMath in typeProof will do this
-    fprintf(g_texFilePtr, "%s", g_printString);
-    let(&g_printString, "");
-    */
   }
 
   if (!pipFlag) {
     parseProof(g_showStatement);
     if (g_WrkProof.errorSeverity > 1) {
-      /* 2-Nov-2014 nm Prevent population of g_printString outside of web
-         page generation to fix bug 1114 (reported by Sefan O'Rear). */
       if (htmlFlg && texFlag) {
         /* Print warning and close out proof table */
         g_outputToString = 1;
@@ -1736,7 +1497,6 @@ void typeProof(long statemNum,
       "<TD COLSPAN=4><B><FONT COLOR=RED>WARNING: Proof has a severe error.\n");
         print2("</FONT></B></TD></TR>\n");
         g_outputToString = 0;
-        /* 18-Nov-2012 nm Fix bug 243 */
         /* Clear out g_printStringForReferencedBy to prevent bug 243 above */
         let(&g_printStringForReferencedBy, "");
       }
@@ -1747,7 +1507,7 @@ void typeProof(long statemNum,
 
   if (!pipFlag) {
     nmbrLet(&proof, g_WrkProof.proofString); /* The proof */
-    if (g_midiFlag) { /* 8/28/00 */
+    if (g_midiFlag) {
       /* Get the uncompressed version of the proof */
       nmbrLet(&proof, nmbrUnsquishProof(proof));
     }
@@ -1756,17 +1516,14 @@ void typeProof(long statemNum,
   }
   plen = nmbrLen(proof);
 
-  /* 6/27/99 - to reduce the number of steps displayed in an html proof,
+  /* To reduce the number of steps displayed in an html proof,
      we will use a local label to reference the 2nd or later reference to a
      hypothesis, so the hypothesis won't have to be shown multiple times
-     in the proof.
-     31-Jan-2010 - do this for all Lemmon-style proofs */
+     in the proof. */
   if (htmlFlg && texFlag && !noIndentFlag /* Lemmon */) {
     /* Only Lemmon-style proofs are implemented for html */
     bug(218);
   }
-  /*if (htmlFlg && texFlag) {*/   /* pre-31-Jan-2010 */
-  /* 31-Jan-2010 nm Do this for all Lemmon-style proofs */
   if (skipRepeatedSteps) {
     for (step = 0; step < plen; step++) {
       stmt = proof[step];
@@ -1836,8 +1593,6 @@ void typeProof(long statemNum,
     if (renumberFlag && essentialFlag) {
       if (!essentialFlags[step]) stepPrintFlag = 0;
     }
-    /* if (htmlFlg && texFlag && proof[step] < 0) stepPrintFlag = 0; */
-    /* 31-Jan-2010 nm changed to: */
     if (skipRepeatedSteps && proof[step] < 0) stepPrintFlag = 0;
     /* For standard numbering, stepPrintFlag will be always be 1 here */
     if (stepPrintFlag) {
@@ -1847,17 +1602,12 @@ void typeProof(long statemNum,
     }
   }
 
-  /* 22-Apr-2015 nm */
   /* Get the relative offset (0, -1, -2,...) for unknown steps */
   if (unknownFlag) {
-    /* 21-Aug-2017 nm There could be unknown steps outside of MM-PA
+    /* There could be unknown steps outside of MM-PA
        So remove this bugcheck, which seems spurious.  I can't see that
        getRelStepNums() cares whether we are in MM-PA. */
-    /*
-    if (!pipFlag) {
-      bug(255);
-    }
-    */
+    /* if (!pipFlag) bug(255); */
     relativeStepNums = getRelStepNums(g_ProofInProgress.proof);
   }
 
@@ -1884,7 +1634,6 @@ void typeProof(long statemNum,
     i = i/10; /* The number is printed in base 10 */
     maxStepNumLen++;
   }
-  /* 22-Apr-2015 nm */
   /* Add extra space for negative offset numbers e.g. "3:-1" */
   if (unknownFlag) {
     maxStepNumOffsetLen = 3; /* :, -, # */
@@ -1936,9 +1685,7 @@ void typeProof(long statemNum,
   } /* Next step */
 
   /* Print the steps */
-  if (reverseFlag
-      && !g_midiFlag /* 8/28/00 */
-      ) {
+  if (reverseFlag && !g_midiFlag) {
     fromStep = plen - 1;
     toStep = -1;
     byStep = -1;
@@ -1970,14 +1717,12 @@ void typeProof(long statemNum,
       if (proof[step] != -(long)'?') stepPrintFlag = 0;
     }
 
-    /* 6/27/99 Skip steps that are local label references for html */
-    /* if (htmlFlg && texFlag) { */
-    /* 31-Jan-2010 nm changed to: */
+    /* Skip steps that are local label references for html */
     if (skipRepeatedSteps) {
       if (stepRenumber[step] == 0) stepPrintFlag = 0;
     }
 
-    /* 8/28/00 For MIDI files, ignore all qualifiers and process all steps */
+    /* For MIDI files, ignore all qualifiers and process all steps */
     if (g_midiFlag) stepPrintFlag = 1;
 
     if (!stepPrintFlag) continue;
@@ -1992,8 +1737,6 @@ void typeProof(long statemNum,
     if (stmt < 0) {
       if (stmt <= -1000) {
         stmt = -1000 - stmt;
-        /* if (htmlFlg && texFlag) bug(220); */
-        /* 31-Jan-2010 nm Changed to: */
         if (skipRepeatedSteps) bug(220); /* If html, a step referencing a
             local label will never be printed since it will be skipped above */
         /* stmt is now the step number a local label refers to */
@@ -2016,8 +1759,6 @@ void typeProof(long statemNum,
       if (nmbrElementIn(1, localLabels, step)) {
         /* This statement declares a local label */
         if (noIndentFlag) {
-          /* if (!(htmlFlg && texFlag)) { */
-          /* 31-Jan-2010 nm Changed to: */
           if (!(skipRepeatedSteps)) { /* No local label declaration is
               shown for html */
             let(&locLabDecl, cat("@", str((double)(localLabelNames[step])), ":", NULL));
@@ -2038,8 +1779,6 @@ void typeProof(long statemNum,
           if (!essentialFlag || g_Statement[hypPtr[hyp]].type == (char)e_) {
             i = stepRenumber[hypStep];
             if (i == 0) {
-              /* if (!(htmlFlg && texFlag)) bug(221); */
-              /* 31-Jan-2010 nm Changed to: */
               if (!(skipRepeatedSteps)) bug(221);
               if (proof[hypStep] != -(long)'?') {
                 if (proof[hypStep] > -1000) bug(222);
@@ -2121,7 +1860,6 @@ void typeProof(long statemNum,
         let(&contPrefix, space((long)strlen(startPrefix) + 4));
       } else {  /* not noIndentFlag */
 
-        /* 22-Apr-2015 nm */
         /* Compute prefix with and without step number.  For 'show new_proof
            /unknown', unknownFlag is set, and we add the negative offset. */
         let(&tmpStr, "");
@@ -2177,18 +1915,13 @@ void typeProof(long statemNum,
               space(maxLabelLen - (long)strlen(tgtLabel) - (long)strlen("=(User)")),
               NULL));
         }
-        /*
-        let(&contPrefix, space(maxStepNumLen + 1 + indentationLevel[step] *
-            PF_INDENT_INC
-            + maxLabelLen + 4));
-        */
         let(&contPrefix, ""); /* Continuation lines use whole screen width */
       }
 
       if (!pipFlag) {
 
         if (!texFlag) {
-          if (!g_midiFlag) { /* 8/28/00 */
+          if (!g_midiFlag) {
             printLongLine(cat(startPrefix," $", chr(type), " ",
                 nmbrCvtMToVString(g_WrkProof.mathStringPtrs[step]),
                 NULL),
@@ -2204,8 +1937,7 @@ void typeProof(long statemNum,
 
       } else { /* pipFlag */
         if (texFlag) {
-          /* nm 3-Feb-04  Added this bug check - it doesn't make sense to
-             do this and it hasn't been tested anyway */
+          /* It doesn't make sense to do this and it hasn't been tested anyway */
           print2("?Unsupported:  HTML or LaTeX proof for NEW_PROOF.\n");
           bug(244);
         }
@@ -2275,8 +2007,6 @@ void typeProof(long statemNum,
     g_outputToString = 1;
     print2("</TABLE></CENTER>\n");
 
-    /* 10/10/02 Moved here from mmwtex.c */
-    /*print2("<FONT SIZE=-1 FACE=sans-serif>Colors of variables:\n");*/
     printLongLine(cat(
         "<CENTER><TABLE CELLSPACING=5><TR><TD ALIGN=LEFT><FONT SIZE=-1>",
         "<B>Colors of variables:</B> ",
@@ -2341,11 +2071,10 @@ void typeProof(long statemNum,
                 g_Statement[g_Statement[statemNum].reqHypList[i]].mathString);
           }
           if (strcmp("|-", g_MathToken[nmbrTmpPtr1[0]].tokenName)) {
-            /* 1-Oct-05 nm Since non-standard logics may not have this,
+            /* Since non-standard logics may not have this,
                just break out of this section gracefully */
             nmbrTmpPtr2 = NULL_NMBRSTRING; /* To be known after break */
             break;
-            /* bug(235); */  /* 1-Oct-05 nm No longer a bug */
           }
           /* Turn "|-" assertion into a "wff" assertion */
           nmbrTmpPtr1[0] = wffToken;
@@ -2358,15 +2087,14 @@ void typeProof(long statemNum,
               statemNum /*statemNum*/, 0 /*maxEDepth*/,
               0, /* step; 0 = step 1 */ /*For messages*/
               0,  /*not noDistinct*/
-              /* 3-May-2016 nm */
               2, /* override discouraged-usage statements silently */
-              1 /* Always allow other mathboxes */ /* 5-Aug-2020 nm */
+              1 /* Always allow other mathboxes */
               );
           if (!nmbrLen(nmbrTmpPtr2)) {
-            /* 1-Oct-05 nm Since a proof may not be found for non-standard
+            /* Didn't find syntax proof */
+            /* Since a proof may not be found for non-standard
                logics, just break out of this section gracefully */
             break;
-            /* bug(236); */ /* Didn't find syntax proof */
           }
 
           /* Add to list of syntax statements used */
@@ -2398,7 +2126,7 @@ void typeProof(long statemNum,
           nmbrLet(&nmbrTmpPtr2, NULL_NMBRSTRING);
           nmbrLet(&nmbrTmpPtr1, NULL_NMBRSTRING);
         } /* next i */
-        /* 1-Oct-05 nm Deallocate memory in case we broke out above */
+        /* Deallocate memory in case we broke out above */
         nmbrLet(&nmbrTmpPtr2, NULL_NMBRSTRING);
         nmbrLet(&nmbrTmpPtr1, NULL_NMBRSTRING);
       } /* if (wffToken >= 0) */
@@ -2410,8 +2138,6 @@ void typeProof(long statemNum,
         if (statementUsedFlags[stmt] == 'Y') {
           if (!tmpStr[0]) {
             let(&tmpStr,
-               /* 10/10/02 */
-               /*"<FONT SIZE=-1><FONT FACE=sans-serif>Syntax hints:</FONT> ");*/
                "<TR><TD ALIGN=LEFT><FONT SIZE=-1><B>Syntax hints:</B> ");
           }
 
@@ -2431,7 +2157,7 @@ void typeProof(long statemNum,
                       ].tokenName, ")")
                   && strcmp(g_MathToken[(g_Statement[stmt].mathString)[i]
                       ].tokenName, ":")
-                  /* 14-Oct-2019 nm Use |-> rather than e. for cmpt, cmpt2 */
+                  /* Use |-> rather than e. for cmpt, cmpt2 */
                   && !(!strcmp(g_MathToken[(g_Statement[stmt].mathString)[i]
                       ].tokenName, "e.")
                       && (!strcmp(g_Statement[stmt].labelName, "cmpt")
@@ -2440,10 +2166,8 @@ void typeProof(long statemNum,
                 tmpStr1 =
                     tokenToTex(g_MathToken[(g_Statement[stmt].mathString)[i]
                     ].tokenName, stmt);
-                /* 14-Jan-2016 nm */
                 let(&tmpStr1, cat(
                     (g_altHtmlFlag ? cat("<SPAN ", g_htmlFont, ">", NULL) : ""),
-                                           /* 14-Jan-2016 nm */
                     tmpStr1,
                     (g_altHtmlFlag ? "</SPAN>" : ""),
                     NULL));
@@ -2456,7 +2180,7 @@ void typeProof(long statemNum,
             let(&tmpStr1, "<i> class class class </i>");
           if (!strcmp(g_Statement[stmt].labelName, "cv"))
             let(&tmpStr1, "[set variable]");
-          /* 10/10/02 Let's don't do cv - confusing to reader */
+          /* Let's don't do cv - confusing to reader */
           if (!strcmp(g_Statement[stmt].labelName, "cv"))
             continue;
           if (!strcmp(g_Statement[stmt].labelName, "co")) /* operation */
@@ -2466,11 +2190,6 @@ void typeProof(long statemNum,
 
           let(&tmpStr1, "");
           tmpStr1 = pinkHTML(stmt);
-          /******* 10/10/02
-          let(&tmpStr, cat(tmpStr, "<FONT FACE=sans-serif><A HREF=\"",
-              g_Statement[stmt].labelName, ".html\">",
-              g_Statement[stmt].labelName, "</A></FONT> &nbsp; ", NULL));
-          *******/
           let(&tmpStr, cat(tmpStr, "<A HREF=\"",
               g_Statement[stmt].labelName, ".html\">",
               g_Statement[stmt].labelName, "</A>", tmpStr1, NULL));
@@ -2486,27 +2205,13 @@ void typeProof(long statemNum,
       /* End of syntax hints list */
 
 
-      /* 10/25/02 Output "referenced by" list here */
-      /* 30-Oct-2018 nm Moved this block to after axioms/defs lists */
-      /*
-      if (g_printStringForReferencedBy[0]) {
-        /@ printLongLine takes 130 sec for 'sh st syl/a' @/
-        /@printLongLine(g_printStringForReferencedBy, "", "\"");@/
-        /@ 18-Jul-2015 nm Speedup for 'sh st syl/a' @/
-        if (g_outputToString != 1) bug(257);
-        let(&g_printString, cat(g_printString, g_printStringForReferencedBy, NULL));
-        let(&g_printStringForReferencedBy, "");
-      }
-      */
-
-
       /* Get list of axioms and definitions assumed by proof */
       let(&statementUsedFlags, "");
       traceProofWork(statemNum,
           1, /*essentialFlag*/
-          "", /*traceToList*/ /* 18-Jul-2015 nm */
-          &statementUsedFlags, /*&statementUsedFlags*/
-          &unprovedList /* &unprovedList */);
+          "", /*traceToList*/
+          &statementUsedFlags,
+          &unprovedList);
       if ((signed)(strlen(statementUsedFlags)) != g_statements + 1) bug(227);
 
       /* First get axioms */
@@ -2516,11 +2221,8 @@ void typeProof(long statemNum,
           let(&tmpStr1, left(g_Statement[stmt].labelName, 3));
           if (!strcmp(tmpStr1, "ax-")) {
             if (!tmpStr[0]) {
-              let(&tmpStr,
- /******* 10/10/02
- "<FONT SIZE=-1 FACE=sans-serif>The theorem was proved from these axioms: ");
- *******/
- "<TR><TD ALIGN=LEFT><FONT SIZE=-1><B>This theorem was proved from axioms:</B>");
+              let(&tmpStr, "<TR><TD ALIGN=LEFT><FONT SIZE=-1><B>"
+                "This theorem was proved from axioms:</B>");
             }
             let(&tmpStr1, "");
             tmpStr1 = pinkHTML(stmt);
@@ -2535,7 +2237,7 @@ void typeProof(long statemNum,
         printLongLine(tmpStr, "", "\"");
       }
 
-      /* 10/10/02 Then get definitions */
+      /* Then get definitions */
       let(&tmpStr, "");
       for (stmt = 1; stmt <= g_statements; stmt++) {
         if (statementUsedFlags[stmt] == 'Y' && g_Statement[stmt].type == a_) {
@@ -2590,21 +2292,13 @@ void typeProof(long statemNum,
 
       /* End of axiom list */
 
-      /* 30-Oct-2018 nm Moved down from above to put referenced by list last */
+      /* Put referenced by list last */
       if (g_printStringForReferencedBy[0]) {
-        /* printLongLine takes 130 sec for 'sh st syl/a' */
-        /*printLongLine(g_printStringForReferencedBy, "", "\"");*/
-        /* 18-Jul-2015 nm Speedup for 'sh st syl/a' */
         if (g_outputToString != 1) bug(257);
-        /* 30-Oct-2018 nm Deleted line: */
-        /*let(&g_printString, cat(g_printString, g_printStringForReferencedBy, NULL));*/
-        /* 30-Oct-2018 nm Added line: */
         printLongLine(g_printStringForReferencedBy, "", "\"");
         let(&g_printStringForReferencedBy, "");
-
-      /* 30-Oct-2018 nm */
       } else {
-        /* Since we now always print ref-by list even if "(None)",
+        /* Since we always print ref-by list even if "(None)",
            g_printStringForReferencedBy should never be empty */
         bug(263);
       }
@@ -2640,7 +2334,7 @@ void typeProof(long statemNum,
   nmbrLet(&essentialFlags, NULL_NMBRSTRING);
   nmbrLet(&stepRenumber, NULL_NMBRSTRING);
   nmbrLet(&notUnifiedFlags, NULL_NMBRSTRING);
-  nmbrLet(&relativeStepNums, NULL_NMBRSTRING); /* 22-Apr-2015 nm */
+  nmbrLet(&relativeStepNums, NULL_NMBRSTRING);
 } /* typeProof() */
 
 /* Show details of one proof step */
@@ -2990,7 +2684,7 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
     return;
   }
 
-  /* 20-Oct-2013 nm Don't use bad proofs (incomplete proofs are ok) */
+  /* Don't use bad proofs (incomplete proofs are ok) */
   if (parseProof(statemNum) > 1) {
     /* The proof has an error, so use the empty proof */
     nmbrLet(&proof, nmbrAddElement(NULL_NMBRSTRING, -(long)'?'));
@@ -3076,16 +2770,13 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
         if (!texFlag) {
           printLongLine(cat("\"", str1, "\"", NULL), "", " ");
         } else {
-          /* printTexComment(str1, 1); */
-          /* 17-Nov-2015 nm Added 3rd & 4th arguments */
           printTexComment(str1,              /* Sends result to g_texFilePtr */
               1, /* 1 = htmlCenterFlag */
-              PROCESS_EVERYTHING, /* actionBits */ /* 13-Dec-2018 nm */
+              PROCESS_EVERYTHING, /* actionBits */
               0 /* 1 = noFileCheck */);
         }
       }
 
-      /* print2("Its mandatory hypotheses in RPN order are:\n"); */
       j = nmbrLen(g_Statement[stmt].reqHypList);
       for (i = 0; i < j; i++) {
         k = g_Statement[stmt].reqHypList[i];
@@ -3139,13 +2830,12 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
 /* matchList suppresses all output except labels matching matchList */
 /* testOnlyFlag prevents any printout; it is used to determine whether
    there is an unwanted axiom for MINIMIZE_WITH /FORBID. */
-/* void traceProof(long statemNum, */ /* before 20-May-2013 */
-flag traceProof(long statemNum, /* 20-May-2013 nm */
+flag traceProof(long statemNum,
   flag essentialFlag,
   flag axiomFlag,
-  vstring matchList, /* 19-May-2013 nm */
-  vstring traceToList, /* 18-Jul-2015 nm */
-  flag testOnlyFlag /* 20-May-2013 nm */)
+  vstring matchList,
+  vstring traceToList,
+  flag testOnlyFlag)
 {
 
   long stmt, pos;
@@ -3157,7 +2847,7 @@ flag traceProof(long statemNum, /* 20-May-2013 nm */
   /* Make sure we're calling this with $p statements only */
   if (g_Statement[statemNum].type != (char)p_) bug(249);
 
-  if (!testOnlyFlag) {  /* 20-May-2013 nm */
+  if (!testOnlyFlag) {
     if (axiomFlag) {
       print2(
   "Statement \"%s\" assumes the following axioms ($a statements):\n",
@@ -3175,7 +2865,7 @@ flag traceProof(long statemNum, /* 20-May-2013 nm */
 
   traceProofWork(statemNum,
       essentialFlag,
-      traceToList, /* /TO argument of SHOW TRACE_BACK */ /* 18-Jul-2015 nm */
+      traceToList, /* /TO argument of SHOW TRACE_BACK */
       &statementUsedFlags,
       &unprovedList);
   if ((signed)(strlen(statementUsedFlags)) != g_statements + 1) bug(226);
@@ -3185,14 +2875,13 @@ flag traceProof(long statemNum, /* 20-May-2013 nm */
   for (stmt = 1; stmt < statemNum; stmt++) {
     if (statementUsedFlags[stmt] == 'Y') {
 
-      /* 19-May-2013 nm - Added MATCH qualifier */
       if (matchList[0]) {  /* There is a list to match */
         /* Don't include unmatched labels */
         if (!matchesList(g_Statement[stmt].labelName, matchList, '*', '?'))
           continue;
       }
 
-      /* 20-May-2013 nm  Skip rest of scan in testOnlyFlag mode */
+      /* Skip rest of scan in testOnlyFlag mode */
       foundFlag = 1; /* At least one label would be printed */
       if (testOnlyFlag) {
         goto TRACE_RETURN;
@@ -3214,7 +2903,7 @@ flag traceProof(long statemNum, /* 20-May-2013 nm */
     } /* End if (statementUsedFlag[stmt] == 'Y') */
   } /* Next stmt */
 
-  /* 20-May-2013 nm  Skip printing in testOnlyFlag mode */
+  /* Skip printing in testOnlyFlag mode */
   if (testOnlyFlag) {
     goto TRACE_RETURN;
   }
@@ -3252,7 +2941,7 @@ flag traceProof(long statemNum, /* 20-May-2013 nm */
    a nmbrString with a list of statements and unproved statements */
 void traceProofWork(long statemNum,
   flag essentialFlag,
-  vstring traceToList, /* /TO argument of SHOW TRACE_BACK */ /* 18-Jul-2015 nm */
+  vstring traceToList, /* /TO argument of SHOW TRACE_BACK */
   vstring *statementUsedFlagsP, /* 'Y'/'N' flag that statement is used */
   nmbrString **unprovedListP)
 {
@@ -3261,11 +2950,10 @@ void traceProofWork(long statemNum,
   nmbrString *statementList = NULL_NMBRSTRING;
   nmbrString *proof = NULL_NMBRSTRING;
   nmbrString *essentialFlags = NULL_NMBRSTRING;
-  vstring traceToFilter = ""; /* 18-Jul-2015 nm */
-  vstring str1 = ""; /* 18-Jul-2015 nm */
-  long j; /* 18-Jul-2015 nm */
+  vstring traceToFilter = "";
+  vstring str1 = "";
+  long j;
 
-  /* 18-Jul-2015 nm */
   /* Preprocess the "SHOW TRACE_BACK ... / TO" traceToList list if any */
   if (traceToList[0] != 0) {
     let(&traceToFilter, string(g_statements + 1, 'N')); /* Init. to 'no' */
@@ -3297,13 +2985,13 @@ void traceProofWork(long statemNum,
   slen = 1;
   nmbrLet(&(*unprovedListP), NULL_NMBRSTRING); /* List of unproved statements */
   let(&(*statementUsedFlagsP), string(g_statements + 1, 'N')); /* Init. to 'no' */
-  (*statementUsedFlagsP)[statemNum] = 'Y';  /* nm 22-Nov-2014 */
+  (*statementUsedFlagsP)[statemNum] = 'Y';
   for (pos = 0; pos < slen; pos++) {
     if (g_Statement[statementList[pos]].type != p_) {
       continue; /* Not a $p */
     }
 
-    /* 20-Oct-2013 nm Don't use bad proofs (incomplete proofs are ok) */
+    /* Don't use bad proofs (incomplete proofs are ok) */
     if (parseProof(statementList[pos]) > 1) {
       /* The proof has an error, so use the empty proof */
       nmbrLet(&proof, nmbrAddElement(NULL_NMBRSTRING, -(long)'?'));
@@ -3338,9 +3026,6 @@ void traceProofWork(long statemNum,
       }
       /* Add this statement to the statement list if not already in it */
       if ((*statementUsedFlagsP)[stmt] == 'N') {
-        /*(*statementUsedFlagsP)[stmt] = 'Y';*/  /* 18-Jul-2015 deleted */
-
-        /* 18-Jul-2015 nm */
         if (traceToList[0] == 0) {
           statementList[slen] = stmt;
           slen++;
@@ -3554,7 +3239,6 @@ double countSteps(long statemNum, flag essentialFlag)
   nmbrString *proof = NULL_NMBRSTRING;
   double stepCount; /* The total steps if fully expanded */
 
-  /* 12-Nov-2018 nm */
   static vstring *stmtBigCount; /* Unlimited precision stmtCount */
   vstring stepBigCount = ""; /* Unlimited precision stepCount */
   vstring tmpBig1 = "";
@@ -3574,7 +3258,6 @@ double countSteps(long statemNum, flag essentialFlag)
   if (!level) {
     stmtCount = malloc((sizeof(double) * ((size_t)g_statements + 1)));
     stmtBigCount = malloc((sizeof(vstring) * ((size_t)g_statements + 1)));
-                                                           /* 12-Nov-2018 nm */
     stmtNodeCount = malloc(sizeof(double) * ((size_t)g_statements + 1));
     stmtDist = malloc(sizeof(long) * ((size_t)g_statements + 1));
     stmtMaxPath = malloc(sizeof(long) * ((size_t)g_statements + 1));
@@ -3585,7 +3268,7 @@ double countSteps(long statemNum, flag essentialFlag)
         !stmtAveDist || !stmtProofLen || !stmtUsage) {
       print2("?Memory overflow.  Step count will be wrong.\n");
       if (stmtCount) free(stmtCount);
-      if (stmtBigCount) free(stmtBigCount); /* 12-Nov-2018 nm */
+      if (stmtBigCount) free(stmtBigCount);
       if (stmtNodeCount) free(stmtNodeCount);
       if (stmtDist) free(stmtDist);
       if (stmtMaxPath) free(stmtMaxPath);
@@ -3596,15 +3279,15 @@ double countSteps(long statemNum, flag essentialFlag)
     }
     for (stmt = 1; stmt < g_statements + 1; stmt++) {
       stmtCount[stmt] = 0;
-      stmtBigCount[stmt] = ""; /* 12-Nov-2018 nm */
+      stmtBigCount[stmt] = "";
       stmtUsage[stmt] = 0;
-      stmtDist[stmt] = 0; /* 18-Sep-2013 Initialize */
+      stmtDist[stmt] = 0;
     }
     unprovedFlag = 0; /* Flag that some proof wasn't complete */
   }
   level++;
   stepCount = 0;
-  let(&stepBigCount, "0"); /* "" and "0" both mean 0 */ /* 12-Nov-2018 nm */
+  let(&stepBigCount, "0"); /* "" and "0" both mean 0 */
   stepNodeCount = 0;
   stepDistSum = 0;
   stmtDist[statemNum] = -2; /* Forces at least one assignment */
@@ -3612,20 +3295,18 @@ double countSteps(long statemNum, flag essentialFlag)
   if (g_Statement[statemNum].type != (char)p_) {
     /* $a, $e, or $f */
     stepCount = 1;
-    let(&stepBigCount, "1"); /* 12-Nov-2018 nm */
+    let(&stepBigCount, "1");
     stepNodeCount = 0;
     stmtDist[statemNum] = 0;
     goto returnPoint;
   }
 
-  /* 20-Oct-2013 nm Don't use bad proofs (incomplete proofs are ok) */
+  /* Don't use bad proofs (incomplete proofs are ok) */
   if (parseProof(statemNum) > 1) {
     /* The proof has an error, so use the empty proof */
     nmbrLet(&proof, nmbrAddElement(NULL_NMBRSTRING, -(long)'?'));
   } else {
-    /*nmbrLet(&proof, nmbrUnsquishProof(g_WrkProof.proofString));*/ /* The proof */
-    /* 13-Nov-2018 nm - Use proof as it is saved (so user can choose
-       compressed or not) */
+    /* Use proof as it is saved (so user can choose compressed or not) */
     nmbrLet(&proof, g_WrkProof.proofString); /* The proof */
   }
 
@@ -3636,8 +3317,7 @@ double countSteps(long statemNum, flag essentialFlag)
   }
   essentialplen = 0;
   for (step = 0; step < plen; step++) {
-  /* 12-May-04 nm Use the following loop instead to get an alternate maximum
-     path */
+    /* Use the following loop to get an alternate maximum path */
     if (essentialFlag) {
       if (!essentialFlags[step]) continue;     /* Ignore floating hypotheses */
     }
@@ -3645,9 +3325,6 @@ double countSteps(long statemNum, flag essentialFlag)
     stmt = proof[step];
     if (stmt < 0) {
       if (stmt <= -1000) {
-        /* Pre-13-Nov-2010: */
-        /*bug(215);*/ /* The proof was expanded; there should be no local labels */
-        /* 13-Nov-2018 nm */
         /* User can choose to count compressed or normal steps by saving
            the proof that way */
         /* A local label does not add a proof step in the web page proof */
@@ -3657,7 +3334,6 @@ double countSteps(long statemNum, flag essentialFlag)
         unprovedFlag = 1;
         stepCount = stepCount + 1;
 
-        /* 12-Nov-2018 nm */
         let(&tmpBig1, "");
         tmpBig1 = bigAdd(stepBigCount, "1");
         let(&stepBigCount, tmpBig1);
@@ -3674,7 +3350,6 @@ double countSteps(long statemNum, flag essentialFlag)
         stepCount = stepCount + stmtCount[stmt];
       }
 
-      /* 12-Nov-2018 nm */
       /* In either case, stmtBigCount[stmt] will be populated now */
       let(&tmpBig1, "");
       tmpBig1 = bigAdd(stepBigCount, stmtBigCount[stmt]);
@@ -3687,7 +3362,6 @@ double countSteps(long statemNum, flag essentialFlag)
           if (!essentialFlag || g_Statement[k].type == (char)e_) {
             stepCount--;
 
-            /* 12-Nov-2018 nm */
             /* In either case, stmtBigCount[stmt] will be populated now */
             let(&tmpBig1, "");
             tmpBig1 = bigSub(stepBigCount, "1");
@@ -3712,7 +3386,6 @@ double countSteps(long statemNum, flag essentialFlag)
   /* Assign step count to statement list */
   stmtCount[statemNum] = stepCount;
 
-  /* 12-Nov-2018 nm */
   if ((stmtBigCount[statemNum])[0] != 0) bug(264);
   let(&stmtBigCount[statemNum], stepBigCount);
 
@@ -3774,13 +3447,6 @@ double countSteps(long statemNum, flag essentialFlag)
            str((double)actualSteps2), " steps.  ",
        "The proof would have ",
 
-       /* This is the old stepCount; can be enabled to troubleshoot
-          the new unlimited precision algorithm */
-       /* 27-May-05 nm stepCount is inaccurate for over 16 or so digits due
-          to roundoff errors. */
-       /*stepCount > 1000000000 ? ">1000000000" : str((double)stepCount),*/
-
-       /* 12-Nov-2018 nm */
        stepBigCount,
        strlen(stepBigCount) < 6 ? ""
            : cat(" =~ ",
@@ -3793,12 +3459,6 @@ double countSteps(long statemNum, flag essentialFlag)
 
 
        " steps if fully expanded back to axiom references.  ",
-       /*
-       "The proof tree has ", str((double)stmtNodeCount[statemNum])," nodes.  ",
-       "A random backtrack path has an average path length of ",
-       str((double)(stmtAveDist[statemNum])),
-       ".  ",
-       */
        "The maximum path length is ",
        str((double)(stmtDist[statemNum])),
        ".  A longest path is:  ", right(tmpStr, 5), " .", NULL),
@@ -3813,7 +3473,6 @@ double countSteps(long statemNum, flag essentialFlag)
     free(stmtProofLen);
     free(stmtUsage);
 
-    /* 12-Nov-2018 nm */
     /* Deallocate the big number strings */
     for (stmt = 1; stmt < g_statements + 1; stmt++) {
       let(&stmtBigCount[stmt], "");
@@ -3822,7 +3481,7 @@ double countSteps(long statemNum, flag essentialFlag)
 
   }
 
-  /* Deallocate local strings */ /* 12-Nov-2018 nm */
+  /* Deallocate local strings */
   let(&tmpBig1, "");
   let(&stepBigCount, "");
 
@@ -3831,7 +3490,6 @@ double countSteps(long statemNum, flag essentialFlag)
 } /* countSteps */
 
 
-/* 12-Nov-2018 nm */
 /* Add two arbitrary precision nonnegative integers represented
    as strings of digits e.g. bigAdd("1234", "55") returns "1289".
    Zero can be represented by "", "0", "00", etc. */
@@ -3872,7 +3530,6 @@ vstring bigAdd(vstring bignum1, vstring bignum2) {
 }
 
 
-/* 12-Nov-2018 nm */
 /* Subtract a nonnegative number (2nd arg) from a larger nonnegative number
    (1st arg).  If the 1st arg is smaller than the 2nd, results are
    not meaningful; there is no error checking for this.  */
@@ -3987,12 +3644,11 @@ vstring bigMul(vstring bignum1, vstring bignum2) {
 
 /* Traces what statements require the use of a given statement */
 /* The output string must be deallocated by the user. */
-/* 18-Jul-2015 nm changed the meaning of the returned string as follows: */
 /* The return string [0] will be 'Y' or 'N' depending on whether there are any
    statements that use statemNum.  Return string [i] will be 'Y' or 'N'
    depending on whether g_Statement[i] uses statemNum.  All i will be populated
    with 'Y'/'N' even if not $a or $p (always 'N' for non-$a,$p). */
-/* 18-Jul-2015 added optional 'cutoffStmt' parameter:  if nonzero, then
+/* Optional 'cutoffStmt' parameter:  if nonzero, then
    statements above cutoffStmt will not be scanned (for speedup) */
 vstring traceUsage(long statemNum,
   flag recursiveFlag,
@@ -4001,7 +3657,6 @@ vstring traceUsage(long statemNum,
   long lastPos, stmt, slen, pos;
   flag tmpFlag;
   vstring statementUsedFlags = ""; /* 'Y'/'N' flag that statement is used */
-  /* vstring outputString = ""; */ /* 18-Jun-2015 nm Deleted */
   nmbrString *statementList = NULL_NMBRSTRING;
   nmbrString *proof = NULL_NMBRSTRING;
 
@@ -4021,7 +3676,6 @@ vstring traceUsage(long statemNum,
   nmbrLet(&statementList, nmbrAddElement(statementList, statemNum));
   lastPos = 1;
 
-  /* 18-Jul-2015 nm */
   /* For speedup (in traceProofWork), scan only up to cutoffStmt if it
      is specified, otherwise scan all statements. */
   if (cutoffStmt == 0) cutoffStmt = g_statements;
@@ -4064,7 +3718,7 @@ vstring traceUsage(long statemNum,
       }
     } /* (End of speed-up code) */
 
-    /* 20-Oct-2013 nm Don't use bad proofs (incomplete proofs are ok) */
+    /* Don't use bad proofs (incomplete proofs are ok) */
     if (parseProof(stmt) > 1) {
       /* The proof has an error, so use the empty proof */
       nmbrLet(&proof, nmbrAddElement(NULL_NMBRSTRING, -(long)'?'));
@@ -4093,40 +3747,13 @@ vstring traceUsage(long statemNum,
      the output by statement number without calling a sort routine. */
   let(&statementUsedFlags, string(g_statements + 1, 'N')); /* Init. to 'no' */
   if (slen > 1) statementUsedFlags[0] = 'Y';  /* Used by at least one */
-                                              /* 18-Jul-2015 nm */
   for (pos = 1; pos < slen; pos++) { /* Start with 1 (ignore traced statement)*/
     stmt = statementList[pos];
     if (stmt <= statemNum || g_Statement[stmt].type != p_ || stmt > g_statements)
         bug(212);
     statementUsedFlags[stmt] = 'Y';
   }
-  return (statementUsedFlags); /* 18-Jul-2015 nm */
-
-  /********** 18-Jul-2015 nm Deleted code - this is now done by caller ******/
-  /*
-  /@ Next, build the output string @/
-  let(&outputString, "");
-  for (stmt = 1; stmt <= g_statements; stmt++) {
-    if (statementUsedFlags[stmt] == 'Y') {
-      let(&outputString, cat(outputString, " ", g_Statement[stmt].labelName,
-          NULL));
-      /@ For temporary unofficial use by NDM to help build command files: @/
-      /@
-      print2("prove %s$min %s/a$sa n/compr$q\n",
-          g_Statement[stmt].labelName,g_Statement[statemNum].labelName);
-      @/
-    } /@ End if (statementUsedFlag[stmt] == 'Y') @/
-  } /@ Next stmt @/
-
-  /@ Deallocate @/
-  let(&statementUsedFlags, "");
-  nmbrLet(&statementList, NULL_NMBRSTRING);
-  nmbrLet(&proof, NULL_NMBRSTRING);
-
-  return (outputString);
-  */
-  /*************** 18-Jul-2015 End of deleted code **************/
-
+  return (statementUsedFlags);
 } /* traceUsage */
 
 
@@ -4137,11 +3764,8 @@ void readInput(void)
 {
   vstring fullInput_fn = "";
 
-  let(&fullInput_fn, cat(g_rootDirectory, g_input_fn, NULL)); /* 31-Dec-2017 nm */
+  let(&fullInput_fn, cat(g_rootDirectory, g_input_fn, NULL));
 
-  /*g_includeCalls = 0;*/ /* Initialized by readSourceAndIncludes() */
-
-  /* 31-Dec-2017 nm */
   g_sourcePtr = readSourceAndIncludes(g_input_fn, &g_sourceLen);
   if (g_sourcePtr == NULL) {
     print2(
@@ -4149,8 +3773,7 @@ void readInput(void)
     goto RETURN_POINT;
   }
 
-  g_sourcePtr = readRawSource(/*g_input_fn,*/  /* 2-Feb-2018 nm */
-      g_sourcePtr, &g_sourceLen);
+  g_sourcePtr = readRawSource(g_sourcePtr, &g_sourceLen);
   parseKeywords();
   parseLabels();
   parseMathDecl();
@@ -4166,23 +3789,20 @@ void readInput(void)
 /* Note that the labelSection, mathSection, and proofSection do not
    contain keywords ($a, $p,...; $=; $.).  The keywords are added
    by outputStatement. */
-void writeSource(/* flag cleanFlag, 3-May-2017 */ /* 1 = "/ CLEAN" qualifier was chosen */
-                flag reformatFlag /* 1 = "/ FORMAT", 2 = "/REWRAP" */,
-                /* 31-Dec-2017 nm */
-                flag splitFlag,  /* /SPLIT - write out separate $[ $] includes */
-                flag noVersioningFlag, /* /NO_VERSIONING - no ~1 backup */
-                flag keepSplitsFlag, /* /KEEP_INCLUDES - don't delete included
-                                      files when /SPIT is not specified */
-                vstring extractLabelList /* "" means /EXTRACT wasn't specified */
-                )
+void writeSource(
+  flag reformatFlag /* 1 = "/ FORMAT", 2 = "/REWRAP" */,
+  flag splitFlag,  /* /SPLIT - write out separate $[ $] includes */
+  flag noVersioningFlag, /* /NO_VERSIONING - no ~1 backup */
+  flag keepSplitsFlag, /* /KEEP_INCLUDES - don't delete included
+                        files when /SPIT is not specified */
+  vstring extractLabelList /* "" means /EXTRACT wasn't specified */
+  )
 {
 
   /* Temporary variables and strings */
   long i;
-  /* long p; */ /* deleted 3-May-2017 nm */
   vstring buffer = "";
   vstring fullOutput_fn = "";
-  /* long skippedCount = 0; */ /* deleted 3-May-2017 nm */
   FILE *fp;
 
   let(&fullOutput_fn, cat(g_rootDirectory, g_output_fn, NULL));
@@ -4193,7 +3813,6 @@ void writeSource(/* flag cleanFlag, 3-May-2017 */ /* 1 = "/ CLEAN" qualifier was
     print2("Writing \"%s\"...\n", fullOutput_fn);
   }
 
-  /* 24-Aug-2020 nm */
   if (extractLabelList[0] != 0) {
     writeExtractedSource(
        extractLabelList, /* EXTRACT label list argument provided by user */
@@ -4205,80 +3824,18 @@ void writeSource(/* flag cleanFlag, 3-May-2017 */ /* 1 = "/ CLEAN" qualifier was
   }
 
   if (reformatFlag > 0) {
-    /* 31-Dec-2017 nm */
     /* Now the outputSource function just reformats and puts the
        source back into the g_Statement[] array.  So we don't need
        to do it when we're not reformatting/wrapping */
     /* TODO: turn this into a REWRAP command */
     /* Process statements */
     for (i = 1; i <= g_statements + 1; i++) {
-
-      /******** deleted 3-May-2017 nm
-      /@ Added 24-Oct-03 nm @/
-      if (cleanFlag && g_Statement[i].type == (char)p_) {
-        /@ Clean out any proof-in-progress (that user has flagged with a ? in its
-           date comment field) @/
-        /@ Get the comment section after the statement @/
-        let(&str1, space(g_Statement[i + 1].labelSectionLen));
-        memcpy(str1, g_Statement[i + 1].labelSectionPtr,
-            (size_t)(g_Statement[i + 1].labelSectionLen));
-        /@ Make sure it's a date comment @/
-        let(&str1, edit(str1, 2 + 4)); /@ Discard whitespace + control chrs @/
-        p = instr(1, str1, "]$)"); /@ Get end of date comment @/
-        let(&str1, left(str1, p)); /@ Discard stuff after date comment @/
-        if (instr(1, str1, "$([") == 0) {
-          printLongLine(cat(
-              "?Warning: The proof for $p statement \"", g_Statement[i].labelName,
-              "\" does not have a date comment after it and will not be",
-              " removed by the CLEAN qualifier.", NULL), " ", " ");
-        } else {
-          /@ See if the date comment has a "?" in it @/
-          if (instr(1, str1, "?")) {
-            skippedCount++;
-            let(&str2, cat(str2, " ", g_Statement[i].labelName, NULL));
-            /@ Write at least the date from the _previous_ statement's
-               post-comment section so that WRITE RECENT can pick it up. @/
-            let(&str1, space(g_Statement[i].labelSectionLen));
-            memcpy(str1, g_Statement[i].labelSectionPtr,
-                (size_t)(g_Statement[i].labelSectionLen));
-            /@ nm 19-Jan-04 Don't discard w.s. because string will be returned to
-               the source file @/
-            /@let(&str1, edit(str1, 2 + 4));@/ /@ Discard whitespace + ctrl chrs @/
-            p = instr(1, str1, "]$)"); /@ Get end of date comment @/
-            if (p == 0) {
-              /@ In the future, "] $)" may flag date end to conform with
-                 space-around-keyword Metamath spec recommendation @/
-              /@ 7-Sep-04 The future is now @/
-              p = instr(1, str1, "] $)"); /@ Get end of date comment @/
-              if (p != 0) p++; /@ Match what it would be for old standard @/
-            }
-            if (p != 0) {  /@ The previous statement has a date comment @/
-              let(&str1, left(str1, p + 2)); /@ Discard stuff after date cmnt @/
-              if (!instr(1, str1, "?"))
-                /@ Don't bother to print $([?]$) of previous statement because
-                   the previous statement was skipped @/
-                fprintf(g_output_fp, "%s\n", str1);
-                                               /@ Output just the date comment @/
-            }
-
-            /@ Skip the normal output of this statement @/
-            continue;
-          } /@ if (instr(1, str1, "?")) @/
-        } /@ (else clause) if (instr(1, str1, "$([") == 0) @/
-      } /@ if cleanFlag @/
-      ********** end of 3-May-2017 deletion */
-
       let(&buffer,""); /* Deallocate vstring */
 
-      /* 31-Dec-2017 nm This now only affects g_Statement[] array.  It does
-         not write any files. */
-      buffer = outputStatement(i, /* cleanFlag, 3-May-2017 */ reformatFlag);
-
-      /* fprintf(g_output_fp, "%s", str1); */ /* 31-Dec-2017 nm deleted */
+      buffer = outputStatement(i, reformatFlag);
     } /* next i */
   } /* if (reformatFlag > 0) */
 
-  /* 31-Dec-2017 nm */
   /* Get put the g_Statement[] array into one linear buffer */
   let(&buffer, "");
   buffer = writeSourceToBuffer();
@@ -4315,33 +3872,13 @@ void writeSource(/* flag cleanFlag, 3-May-2017 */ /* 1 = "/ CLEAN" qualifier was
   print2("%ld source statement(s) were written.\n", g_statements);
 
 
-  /******** deleted 3-May-2017 nm
-  /@ Added 24-Oct-03 nm @/
-  if (cleanFlag) {
-    if (skippedCount == 0) {
-      print2("No statements were deleted by the CLEAN qualifier.\n");
-    } else {
-      printLongLine(cat("The following ", str((double)skippedCount), " statement",
-          (skippedCount == 1) ? " was" : "s were",
-          " deleted by the CLEAN qualifier:", NULL), "", " ");
-      printLongLine(cat(" ", str2, NULL), "  ", " ");
-      printLongLine(cat(
-          "You should ERASE, READ the new output file, and run VERIFY PROOF",
-          " to ensure that no proof dependencies were broken.", NULL),
-          "", " ");
-    }
-  }
-  ********** end of 3-May-2017 deletion */
-
  RETURN_POINT:
   let(&buffer,""); /* Deallocate vstring */
   let(&fullOutput_fn,""); /* Deallocate vstring */
   return;
-  /* let(&str2,""); */ /* Deallocate vstring */  /* deleted 3-May-2017 nm */
 } /* writeSource */
 
 
-/* 24-Aug-2020 nm */
 /* Get info for WRITE SOURCE ... / EXTRACT */
 void writeExtractedSource(
     vstring extractLabelList, /* EXTRACT argument provided by user */
@@ -4394,15 +3931,9 @@ void writeExtractedSource(
      a statement twice, especially if we did "/ EXTRACT *" */
   print2("Tracing back through proofs for $a and $p statements needed...\n");
   if (!strcmp(extractLabelList, "*")) {
-    /**/
     print2(
        "   This may take up to 10 minutes.  (For audio alert when done,\n");
     print2("   type ahead \"b\" then \"<enter>\".)\n");
-    /**/
-    /*
-    print2(
-       "   This may take up to 10 minutes.  (\n");
-    */
   }
 
   for (stmt = g_statements; stmt >= 1; stmt--) {
@@ -4589,10 +4120,6 @@ void writeExtractedSource(
      be in the output file) or to 'N' otherwise.  Then do the same starting
      from small, then big, then huge header. */
   for (stmt = 1; stmt <= maxStmt; stmt++) {
-    /***** deleted
-    if (g_Statement[stmt].type != a_ && g_Statement[stmt].type != p_)
-      continue;
-    *****/
     /* We do ALL statements, not just $a, $p, so that headers will go to
        the right place in the output file.  We called getSectionHeadings()
        with fineResolution=1 above so that "header area" will be 1 statement
@@ -4732,23 +4259,12 @@ void writeExtractedSource(
           let(&undeclaredV, cat(undeclaredV, " ", g_MathToken[mtkn].tokenName,
             NULL));
         }
-        /* 4-Sep-2020 nm */
         /* Tag the variable as declared for use in later j loops above, so it
            won't be added to the undeclaredV twice */
         mathTokenDeclared[mtkn] = 'Y';
       }
     }
   } /* next mtkn */
-
-/*
-/@D@/for(stmt=1;stmt<=2;stmt++)
-/@D@/printf("s=%ld t=%c cs=%ld bs=%ld es=%ld en=%c %c%c%c%c\n",
-/@D@/  stmt,g_Statement[stmt].type,(long)g_Statement[stmt].scope,
-/@D@/ g_Statement[stmt].beginScopeStatementNum,
-/@D@/ g_Statement[stmt].endScopeStatementNum,extractNeeded[stmt],
-/@D@/ hugeHdrNeeded[stmt],bigHdrNeeded[stmt],
-/@D@/ smallHdrNeeded[stmt],tinyHdrNeeded[stmt]);
-*/
 
   /* Write the output file */
   /* (We don't call the standard output functions because there's too
@@ -4803,47 +4319,23 @@ void writeExtractedSource(
           &hugeHdrComment, &bigHdrComment, &smallHdrComment,
           &tinyHdrComment,
           1, /*fineResolution*/
-          1 /*fullComment*/ /* 12-Sep-2020 nm */
+          1 /*fullComment*/
           );
       let(&buf, "");
       if (hugeHdrNeeded[stmt] == 'Y') {
         fixUndefinedLabels(extractNeeded, &hugeHdrComment);
-        /**** 12-Sep-2020 nm Deleted
-        let(&buf, "");
-        buf = buildHeader(hugeHdr, hugeHdrComment, HUGE_DECORATION);
-        fprintf(fp, "%s", buf);
-        ****/
-        /* 12-Sep-2020 nm */
         fprintf(fp, "%s", cat(hugeHdr, hugeHdrComment, hdrSuffix, NULL));
       }
       if (bigHdrNeeded[stmt] == 'Y') {
         fixUndefinedLabels(extractNeeded, &bigHdrComment);
-        /**** 12-Sep-2020 nm Deleted
-        let(&buf, "");
-        buf = buildHeader(bigHdr, bigHdrComment, HUGE_DECORATION);
-        fprintf(fp, "%s", buf);
-        ****/
-        /* 12-Sep-2020 nm */
         fprintf(fp, "%s", cat(bigHdr, bigHdrComment, hdrSuffix, NULL));
       }
       if (smallHdrNeeded[stmt] == 'Y') {
         fixUndefinedLabels(extractNeeded, &smallHdrComment);
-        /**** 12-Sep-2020 nm Deleted
-        let(&buf, "");
-        buf = buildHeader(smallHdr, smallHdrComment, SMALL_DECORATION);
-        fprintf(fp, "%s", buf);
-        ****/
-        /* 12-Sep-2020 nm */
         fprintf(fp, "%s", cat(smallHdr, smallHdrComment, hdrSuffix, NULL));
       }
       if (tinyHdrNeeded[stmt] == 'Y') {
         fixUndefinedLabels(extractNeeded, &tinyHdrComment);
-        /**** 12-Sep-2020 nm Deleted
-        let(&buf, "");
-        buf = buildHeader(tinyHdr, tinyHdrComment, TINY_DECORATION);
-        fprintf(fp, "%s", buf);
-        ****/
-        /* 12-Sep-2020 nm */
         fprintf(fp, "%s", cat(tinyHdr, tinyHdrComment, hdrSuffix, NULL));
       }
     } /* if header(s) needed */
@@ -4874,7 +4366,6 @@ void writeExtractedSource(
           fprintf(fp, "%s", buf);
           if (g_Statement[stmt].type != p_) {
             fprintf(fp, "$.");
-/*D*//*fprintf(fp, "#%ld#",stmt);*/
           } else {
             /* $p */
             fprintf(fp, "$=");
@@ -4885,7 +4376,6 @@ void writeExtractedSource(
           }
         } /* if not ${ $} */
         if (extractNeeded[stmt + 1] == 'N') {
-/*D*//*printf("added \\n stmt=%ld type=%c,%c\n",stmt+1,g_Statement[stmt].type,g_Statement[stmt+1].type);*/
           /* Put a newline following end of statement since the next
              statement's label section will be suppressed */
           fprintf(fp, "\n");
@@ -4901,14 +4391,14 @@ void writeExtractedSource(
   g_outputToString = 1;
   if (undeclaredC[0] != 0) {
     print2("\n");
-    print2(  /* 4-Sep-2020 nm Can't use literal "$t"; change to $ t. */
-"  $( Unused constants to satisfy the htmldef's in the $ t comment. $)\n");
+    print2("  $( Unused constants to satisfy "
+      "the htmldef's in the $ t comment. $)\n");
     printLongLine(cat("  $c", undeclaredC, " $.", NULL), "    ", " ");
   }
   if (undeclaredV[0] != 0) {
     print2("\n");
-    print2(  /* 4-Sep-2020 nm Can't use literal "$t"; change to $ t. */
-"  $( Unused variables to satisfy the htmldef's in the $ t comment. $)\n");
+    print2("  $( Unused variables to satisfy "
+      "the htmldef's in the $ t comment. $)\n");
     printLongLine(cat("  $v", undeclaredV, " $.", NULL), "    ", " ");
   }
   g_outputToString = 0;
@@ -4919,8 +4409,6 @@ void writeExtractedSource(
 
   /* Write the non-split output file */
   fclose(fp);
-  /*print2("%ld source statement(s) were extracted.\n", extractedStmts);*/
-  /* 5-Sep-2020 nm */
   j = 0; p1 = 0; p2 = 0; p3 = 0; p4 = 0;
   for (stmt = 1; stmt <= g_statements; stmt++) {
     if (extractNeeded[stmt] == 'Y') {
@@ -4965,7 +4453,6 @@ void writeExtractedSource(
 } /* getExtractionInfo */
 
 
-/* 24-Aug-2020 nm */
 /* Some labels in comments may not exist in statements extracted
    with WRITE SOURCE ... / EXTRACT.  This function changes them
    to external links to us.metamath.org. */
@@ -4978,7 +4465,6 @@ void fixUndefinedLabels(vstring extractNeeded/*'Y'/'N' list*/,
   int mathMode; /* char gives Wconversion gcc warning */
 #define ASCII_4 4
 
-  /* 12-Sep-2020 nm */
   /* Change ~ in math symbols to nonprintable ASCII 4 to prevent
      interpretation as label indicator */
   p1 = (long)strlen(*buf);
@@ -5018,10 +4504,6 @@ void fixUndefinedLabels(vstring extractNeeded/*'Y'/'N' list*/,
     if (p3 < p2) p2 = p3;  /* p2 is end of label */
     let(&label, seg(*buf, p1 + 2, p2 - 1));
     let(&restOfComment, right(*buf, p2));
-    /*** 4-Sep-2020 nm This is taken care of by lookupLabel
-    if (instr(1, label, "//" /@ http[s]:// @/) continue; /@ Ignore special case @/
-    if (!strcmp(left(label, 2)), "mm") continue; /@ Ignore special case @/
-    ***/
     p3 = lookupLabel(label);
     if (p3 == -1) continue; /* Not a statement label (e.g. ~ http://...) */
     if (extractNeeded[p3] == 'Y') continue; /* Label link won't be broken */
@@ -5033,7 +4515,6 @@ void fixUndefinedLabels(vstring extractNeeded/*'Y'/'N' list*/,
     /* Adjust pointer to go past the modified label */
     p1 = p1 + (long)strlen(newLabelWithTilde)
           - ((long)strlen(label) + 2/*for "~ "*/);
-    /* 4-Sep-2020 nm */
     /* Put newline if not at end of line - assumes no trailing spaces in .mm! */
     /* We do this to prevent too-long lines.  But if we're already at end
        of line, we don't want to create a paragraph, so we don't add newline. */
@@ -5046,7 +4527,6 @@ void fixUndefinedLabels(vstring extractNeeded/*'Y'/'N' list*/,
   let(&(*buf), left(*buf, (long)strlen(*buf) - 2));
        /* Take off the '\n' we added at beginning of this function */
 
-  /* 12-Sep-2020 nm */
   /* Restore ASCII 4 to ~ */
   p1 = (long)strlen(*buf);
   for (p2 = 0; p2 < p1; p2++) {
@@ -5072,7 +4552,6 @@ void eraseSource(void)    /* ERASE command */
   long i;
   vstring tmpStr = "";
 
-  /* 24-Jun-2014 nm */
   /* Deallocate g_WrkProof structure if g_wrkProofMaxSize != 0 */
   /* Assigned in parseProof() in mmpars.c */
   if (g_wrkProofMaxSize) { /* It has been allocated */
@@ -5122,21 +4601,17 @@ void eraseSource(void)    /* ERASE command */
        should be also fixed, but I could not find simple example for memory
        leak and leave it as it was.  */
     if (g_Statement[i].labelName[0]) free(g_Statement[i].labelName);
-    /*if (g_Statement[i].mathString[0] != -1)*/
-    if (g_Statement[i].mathString != NULL_NMBRSTRING) /* 14-May-2014 nm */
+    if (g_Statement[i].mathString != NULL_NMBRSTRING)
         poolFree(g_Statement[i].mathString);
-    /*if (g_Statement[i].proofString[0] != -1)*/
-    if (g_Statement[i].proofString != NULL_NMBRSTRING) /* 14-May-2014 nm */
+    if (g_Statement[i].proofString != NULL_NMBRSTRING)
         poolFree(g_Statement[i].proofString);
     if (g_Statement[i].reqHypList != NULL_NMBRSTRING)
         poolFree(g_Statement[i].reqHypList);
-    /*if (g_Statement[i].optHypList[0] != -1)*/
-    if (g_Statement[i].optHypList != NULL_NMBRSTRING) /* 14-May-2014 nm */
+    if (g_Statement[i].optHypList != NULL_NMBRSTRING)
         poolFree(g_Statement[i].optHypList);
     if (g_Statement[i].reqVarList != NULL_NMBRSTRING)
         poolFree(g_Statement[i].reqVarList);
-    /*if (g_Statement[i].optVarList[0] != -1)*/
-    if (g_Statement[i].optVarList != NULL_NMBRSTRING) /* 14-May-2014 nm */
+    if (g_Statement[i].optVarList != NULL_NMBRSTRING)
         poolFree(g_Statement[i].optVarList);
     if (g_Statement[i].reqDisjVarsA != NULL_NMBRSTRING)
         poolFree(g_Statement[i].reqDisjVarsA);
@@ -5151,19 +4626,6 @@ void eraseSource(void)    /* ERASE command */
     if (g_Statement[i].optDisjVarsStmt != NULL_NMBRSTRING)
         poolFree(g_Statement[i].optDisjVarsStmt);
 
-    /**** 3-May-17 deleted
-    /@ See if the proof was "saved" @/
-    if (g_Statement[i].proofSectionLen) {
-      if (g_Statement[i].proofSectionPtr[-1] == 1) {
-        /@ Deallocate proof if not original source @/
-        /@ (ASCII 1 is the flag for this) @/
-        tmpStr = g_Statement[i].proofSectionPtr - 1;
-        let(&tmpStr, "");
-      }
-    }
-    ********/
-
-    /* 3-May-2017 nm */
     if (g_Statement[i].labelSectionChanged == 1) {
       /* Deallocate text before label if not original source */
       let(&(g_Statement[i].labelSectionPtr), "");
@@ -5187,7 +4649,6 @@ void eraseSource(void)    /* ERASE command */
   }
 
   memFreePoolPurge(0);
-  /*g_statements = 0;*/ /* Must be done below */
   g_errorCount = 0;
 
   free(g_Statement);
@@ -5196,18 +4657,14 @@ void eraseSource(void)    /* ERASE command */
   g_dummyVars = 0; /* For Proof Assistant */
   free(g_sourcePtr);
   free(g_labelKey);
-  free(g_mathKey); /* 4-May-2017 Ari Ferrera */
+  free(g_mathKey);
   free(g_allLabelKeyBase);
 
-  /* Deallocate the g_WrkProof structure */
-  /*???*/
-
-  /* Deallocate the texdef/htmldef storage */ /* Added 27-Oct-2012 nm */
-  eraseTexDefs(); /* 17-Nov-2015 nm */
+  /* Deallocate the texdef/htmldef storage */
+  eraseTexDefs();
 
   g_extHtmlStmt = 0; /* May be used by a non-zero test; init to be safe */
 
-  /* 5-Aug-2020 nm */
   /* Initialize and deallocate mathbox information */
   g_mathboxStmt = 0; /* Used by a non-zero test in mmwtex.c to see if assigned */
   nmbrLet(&g_mathboxStart, NULL_NMBRSTRING);
@@ -5225,33 +4682,19 @@ void eraseSource(void)    /* ERASE command */
      the 5 variables below */
   g_bracketMatchInit = 0; /* Clear to force mmunif.c to scan $a's again */
   g_minSubstLen = 1; /* Initialize to the default SET EMPTY_SUBSTITUTION OFF */
-  /* 1-Oct-2017 nm Fix 'erase' bug found by Benoit Jubin */
   /* Clear g_firstConst to trigger clearing of g_lastConst and
      g_oneConst in mmunif.c */
   nmbrLet(&g_firstConst, NULL_NMBRSTRING);
-  /* 2-Oct-2017 nm Clear these directly so they will be truly deallocated
-     for valgrind */
+  /* Clear these directly so they will be truly deallocated for valgrind */
   nmbrLet(&g_lastConst, NULL_NMBRSTRING);
   nmbrLet(&g_oneConst, NULL_NMBRSTRING);
 
-  /* 3-May-2016 nm */
   getMarkupFlag(0, RESET); /* Erase the cached markup flag storage */
 
-  /* 2-May-2017 nm */
   /* Erase the contributor markup cache */
-  /* 3-May-2017 nm */
   let(&tmpStr, "");
   tmpStr = getContrib(0 /*stmt is ignored*/, GC_RESET);
-  /****** old 3-May-2017
-  /@ The string arguments are not assigned in RESET mode. @/
-  getContrib(0, &tmpStr, &tmpStr,
-      &tmpStr, &tmpStr, &tmpStr, &tmpStr,
-      &tmpStr,
-      0/@printErrorsFlag@/,
-      RESET/@mode: 0 == RESET = reset, 1 = normal @/);
-  *********/
 
-  /* 2-May-2017 nm */
   /* getContrib uses g_statements (global var), so don't do this earlier */
   g_statements = 0; /* getContrib uses g_statements for loop limit */
 
@@ -5267,7 +4710,7 @@ void verifyProofs(vstring labelMatch, flag verifyFlag) {
   vstring header = "";
   flag errorFound;
 #ifdef CLOCKS_PER_SEC
-  clock_t clockStart;  /* 28-May-04 nm */
+  clock_t clockStart;
 #endif
 
 #ifdef __WATCOMC__
@@ -5279,35 +4722,13 @@ void verifyProofs(vstring labelMatch, flag verifyFlag) {
 #endif
 
 #ifdef CLOCKS_PER_SEC
-  clockStart = clock();  /* 28-May-04 nm Retrieve start time */
+  clockStart = clock();  /* Retrieve start time */
 #endif
   if (!strcmp("*", labelMatch) && verifyFlag) {
     /* Use status bar */
     let(&header, "0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%");
-#ifdef XXX /*__WATCOMC__*/
-    /* The vsprintf function discards text after "%" in 3rd argument string. */
-    /* This is a workaround. */
-    for (i = 1; i <= (long)strlen(header); i++) {
-      let(&tmpStr, mid(header, i, 1));
-      if (tmpStr[0] == '%') let(&tmpStr, "%%");
-      print2("%s", tmpStr);
-    }
-    print2("\n");
-#else
-#ifdef XXX /*VAXC*/
-    /* The vsprintf function discards text after "%" in 3rd argument string. */
-    /* This is a workaround. */
-    for (i = 1; i <= (long)strlen(header); i++) {
-      let(&tmpStr, mid(header, i, 1));
-      if (tmpStr[0] == '%') let(&tmpStr, "%%");
-      print2("%s", tmpStr);
-    }
-    print2("\n");
-#else
     print2("%s\n", header);
     let(&header, "");
-#endif
-#endif
   }
 
   errorFound = 0;
@@ -5320,7 +4741,6 @@ void verifyProofs(vstring labelMatch, flag verifyFlag) {
     }
 
     if (g_Statement[i].type != p_) continue;
-    /* 30-Jan-06 nm Added single-character-match argument */
     if (!matchesList(g_Statement[i].labelName, labelMatch, '*', '?')) continue;
     if (strcmp("*",labelMatch) && verifyFlag) {
       /* If not *, print individual labels */
@@ -5356,7 +4776,7 @@ void verifyProofs(vstring labelMatch, flag verifyFlag) {
   }
   if (!emptyProofList[0] && !errorFound && !strcmp("*", labelMatch)) {
     if (verifyFlag) {
-#ifdef CLOCKS_PER_SEC    /* 28-May-04 nm */
+#ifdef CLOCKS_PER_SEC
       print2("All proofs in the database were verified in %1.2f s.\n",
            (double)((1.0 * (double)(clock() - clockStart)) / CLOCKS_PER_SEC));
 #else
@@ -5372,55 +4792,39 @@ void verifyProofs(vstring labelMatch, flag verifyFlag) {
 } /* verifyProofs */
 
 
-/* 7-Nov-2015 nm Added this function for date consistency */
-/* 17-Nov-2015 nm Added htmldefs, bib, markup checking */
-/* 13-Dec-2016 nm Added checks for undesireable labels (mm*,
-   Microsoft conflicts) */
-/* 24-Mar-2019 nm Added topDateSkip */
-/* 25-Jun-2020 nm Added underscoreSkip */
-/* 17-Jul-2020 nm Added mathboxSkip */
 void verifyMarkup(vstring labelMatch,
     flag dateSkip, /* 1 = don't check date consistency */
     flag topDateSkip, /* 1 = don't check top date but check others */
     flag fileSkip, /* 1 = don't check external files (gifs, mmset.html,...) */
     flag underscoreSkip, /* 1 = don't check labels for "_" characters) */
     flag mathboxSkip, /* 1 = don't check mathbox cross-references) */
-    flag verboseMode) /* 1 = more details */ {   /* 26-Dec-2016 nm */
+    flag verboseMode) /* 1 = more details */ {
   flag f;
   flag saveHtmlFlag, saveAltHtmlFlag;
   flag errFound = 0;
   long stmtNum, p1, p2, p3;
-  long flen, lnum, lstart; /* For line length check */ /* 26-Dec-2016 nm */
-  /***** deleted 3-May-2017 nm
-  vstring contributor = ""; vstring contribDate = "";
-  vstring reviser = ""; vstring reviseDate = "";
-  vstring shortener = ""; vstring shortenDate = "";
-  **********/
+  long flen, lnum, lstart; /* For line length check */
 
-  /* 13-Dec-2016 nm */
   vstring mmVersionDate = ""; /* Version date at top of .mm file */
   vstring mostRecentDate = ""; /* For entire .mm file */
   long mostRecentStmt = 0; /* For error message */
-  /* 18-Dec-2016 nm For getSectionHeadings() call */
-  vstring hugeHdr = ""; /* 21-Jun-2014 nm */
+
+  /* For getSectionHeadings() call */
+  vstring hugeHdr = "";
   vstring bigHdr = "";
   vstring smallHdr = "";
-  vstring tinyHdr = ""; /* 21-Aug-2017 nm */
-  vstring hugeHdrComment = ""; /* 8-May-2015 nm */
-  vstring bigHdrComment = ""; /* 8-May-2015 nm */
-  vstring smallHdrComment = ""; /* 8-May-2015 nm */
-  vstring tinyHdrComment = ""; /* 21-Aug-2017 nm */
+  vstring tinyHdr = "";
+  vstring hugeHdrComment = "";
+  vstring bigHdrComment = "";
+  vstring smallHdrComment = "";
+  vstring tinyHdrComment = "";
 
   vstring descr = "";
   vstring str1 = ""; vstring str2 = "";
-  /* 17-Jul-2020 nm */ /* For mathbox check */
+
+  /* For mathbox check */
   long mbox, pmbox, stmt, pstmt, plen, step;
-  /**** 5-Aug-2020 nm These are now globals
-  long mathboxes;
-  nmbrString *mathboxStart = NULL_NMBRSTRING;
-  nmbrString *mathboxEnd = NULL_NMBRSTRING;
-  pntrString *mathboxUser = NULL_PNTRSTRING;
-  ****/
+
   nmbrString *proof = NULL_NMBRSTRING;
   vstring dupCheck = "";
 
@@ -5429,9 +4833,7 @@ void verifyMarkup(vstring labelMatch,
   print2("Checking statement label conventions...\n");
 
   /* Check that labels can create acceptable file names for web pages */
-
-  /* 13-Dec-2016 nm Moved this check from metamath.c */
-  /* 10/21/02 - detect Microsoft bugs reported by several users, when the
+  /* Detect Microsoft bugs reported by several users, when the
      HTML output files are named "con.html" etc. */
   /* If we want a standard error message underlining token, this could go
      in mmpars.c */
@@ -5452,7 +4854,6 @@ void verifyMarkup(vstring labelMatch,
       continue;
     }
 
-    /* 25-Jun-2020 nm */
     /* Check labels for "_" characters */
     /* See discussion in https://github.com/metamath/set.mm/pull/1691 */
     if (underscoreSkip == 0
@@ -5467,7 +4868,6 @@ void verifyMarkup(vstring labelMatch,
           "qualifier to skip this check.",
           NULL),
           "    ", " ");
-      /* g_errorCount++; */
       errFound = 1;
     }
 
@@ -5478,10 +4878,9 @@ void verifyMarkup(vstring labelMatch,
     let(&str2, cat(",", edit(g_Statement[stmtNum].labelName, 32/*uppercase*/),
         ",", NULL));
     if (instr(1, str1, str2) ||
-        /* 5-Jan-04 mm*.html is reserved for mmtheorems.html, etc. */
+        /* mm*.html is reserved for mmtheorems.html, etc. */
         !strcmp(",MM", left(str2, 3))) {
-      /*print2("\n");*/ /* 25-Jun-2020 nm Deleted */
-      assignStmtFileAndLineNum(stmtNum); /* 9-Jan-2018 nm */
+      assignStmtFileAndLineNum(stmtNum);
       printLongLine(cat("?Warning: In statement \"",
           g_Statement[stmtNum].labelName, "\" at line ",
           str((double)(g_Statement[stmtNum].lineNum)),
@@ -5493,7 +4892,6 @@ void verifyMarkup(vstring labelMatch,
           " LPT7, LPT8, and LPT9.  Also, \"mm*.html\" is reserved for",
           " Metamath file names.  Use another name for this label.", NULL),
           "    ", " ");
-      /* g_errorCount++; */
       errFound = 1;
     }
 
@@ -5503,7 +4901,7 @@ void verifyMarkup(vstring labelMatch,
           (g_Statement[stmtNum].mathString)[0]].tokenName)) {
         let(&str1, left(g_Statement[stmtNum].labelName, 3));
         if (strcmp("ax-", str1) && strcmp("df-", str1)) {
-          assignStmtFileAndLineNum(stmtNum); /* 9-Jan-2018 nm */
+          assignStmtFileAndLineNum(stmtNum);
           printLongLine(cat("?Warning: In the $a statement \"",
               g_Statement[stmtNum].labelName, "\" at line ",
               str((double)(g_Statement[stmtNum].lineNum)),
@@ -5518,13 +4916,9 @@ void verifyMarkup(vstring labelMatch,
 
 
   } /* next stmtNum */
-  /* 10/21/02 end */  /* 13-Dec-2016 nm end */
 
 
-  /* 5-Jul-2020 nm */
-  /* Check for math tokens containing "@" */
-  /* 18-Jul-2020 nm */
-  /* Check for math tokens containing "?" */
+  /* Check for math tokens containing "@" or "?" */
   /* Note:  g_MathToken[] is 0-based, not 1-based */
   for (p1 = 0; p1 < g_mathTokens; p1++) {
     if (strchr(g_MathToken[p1].tokenName, '@') != NULL) {
@@ -5540,7 +4934,6 @@ void verifyMarkup(vstring labelMatch,
           "database source code.",
           NULL),
           "    ", " ");
-      /* g_errorCount++; */
       errFound = 1;
     }
     if (strchr(g_MathToken[p1].tokenName, '?') != NULL) {
@@ -5555,16 +4948,12 @@ void verifyMarkup(vstring labelMatch,
           "\"?\" is sometimes used as a math token search wildcard.",
           NULL),
           "    ", " ");
-      /* g_errorCount++; */
       errFound = 1;
     }
   }
 
 
-  /* 20-Dec-2016 nm */
   /* Check $a ax-* vs. $p ax* */
-  /*print2("Checking ax-XXX axioms vs. axXXX theorems...\n");*/
-      /* (Don't print status - this runs very fast) */
   for (stmtNum = 1; stmtNum <= g_statements; stmtNum++) {
     if (g_Statement[stmtNum].type != a_) {
       continue;
@@ -5586,7 +4975,6 @@ void verifyMarkup(vstring labelMatch,
     p1 = lookupLabel(str2);
     if (p1 == -1) continue;  /* There is no corresponding axXXX */
 
-    /* 26-Dec-2016 nm */
     if (verboseMode == 1) {
       print2("Comparing \"%s\" to \"%s\"...\n", str2, str1);
     }
@@ -5666,17 +5054,13 @@ void verifyMarkup(vstring labelMatch,
   } /* next stmtNum */
 
 
-  /* 26-Dec-2016 nm */
   /* Check line lengths */
-  /*print2("Checking line lengths...\n");*/
-      /* (Don't print status - this runs very fast) */
   let(&str1, ""); /* Prepare to use as pointer */
   let(&str2, ""); /* Prepare to use as pointer */
-  if (g_statements >= /*1*/0
-          /* 6-Aug-2019 nm - no reason to skip empty .mm */
-      /*&& g_includeCalls == 0*/) { /* No $[...$] */ /* TODO - handle $[...$] */
-          /* 6-Aug-2019 nm - g_includeCalls is alway nonzero now - but check
-             anyway; line numbers may be off if there are >1 files. */
+  if (g_statements >= 0) {
+    /* TODO - handle $[...$] */
+    /* g_includeCalls is always nonzero now - but check
+        anyway; line numbers may be off if there are >1 files. */
     str1 = g_Statement[1].labelSectionPtr; /* Start of input file */
     str2 = g_Statement[g_statements + 1].labelSectionPtr
        + g_Statement[g_statements + 1].labelSectionLen; /* End of input file */
@@ -5689,14 +5073,12 @@ void verifyMarkup(vstring labelMatch,
     lstart = 0; /* Line start */
     for (p1 = 0; p1 < flen; p1++) {
       if (str1[p1] == 0) {
-        /* print2("pl=%ld flen=%ld\n", p1, flen); */
         bug(260); /* File shouldn't have nulls */
       }
       if (str1[p1] == '\n') {
         /* End of a line found */
         lnum++;
 
-        /* 25-Jun-2020 nm */
         if (p1 > 0) { /* Not 1st character in file */
           if (str1[p1 - 1] == ' ') {
             printLongLine(cat("?Warning: Line number ",
@@ -5727,7 +5109,6 @@ void verifyMarkup(vstring labelMatch,
         lstart = p1 + 1;
       }
 
-      /* 3-May-2017 nm */
       /* Check for tabs */
       if (str1[p1] == '\t') {
         printLongLine(cat("?Warning: Line number ",
@@ -5753,7 +5134,6 @@ void verifyMarkup(vstring labelMatch,
           fileSkip /* 1 = no GIF file existence check */  );
   if (f != 0) errFound = 1;
   if (f != 2) {   /* We continue if no severe errors (warnings are ok) */
-    /*print2("Checking htmldefs...\n");*/
     /* Check htmldef statements (reread since we've switched modes) */
     g_htmlFlag = 1; /* 1 = HTML, not TeX */
     g_altHtmlFlag = 0; /* 1 = Unicode, not GIFs (when g_htmlFlag = 1) */
@@ -5762,7 +5142,6 @@ void verifyMarkup(vstring labelMatch,
   }
   if (f != 0) errFound = 1;
   if (f != 2) {  /* We continue if no severe errors (warnings are ok) */
-    /*print2("Checking althtmldefs...\n");*/
     /* Check althtmldef statements (reread since we've switched modes) */
     g_htmlFlag = 1; /* 1 = HTML, not TeX */
     g_altHtmlFlag = 1; /* 1 = Unicode, not GIFs (when g_htmlFlag = 1) */
@@ -5774,7 +5153,7 @@ void verifyMarkup(vstring labelMatch,
 
   /* Check date consistency and comment markup in all statements */
   print2("Checking statement comments...\n");
-  let(&mostRecentDate, ""); /* 13-Dec-2016 nm */
+  let(&mostRecentDate, "");
   for (stmtNum = 1; stmtNum <= g_statements; stmtNum++) {
     if (g_Statement[stmtNum].type != a_ && g_Statement[stmtNum].type != p_) {
       continue;
@@ -5783,23 +5162,21 @@ void verifyMarkup(vstring labelMatch,
       continue;
     }
 
-    /* 3-May-2017 nm */
     /* Check the contributor */
     let(&str1, "");
     str1 = getContrib(stmtNum, CONTRIBUTOR);
     if (!strcmp(str1, DEFAULT_CONTRIBUTOR)) {
       printLongLine(cat(
-          "?Warning: Contributor \"", DEFAULT_CONTRIBUTOR,  /* 14-May-2017 nm */
+          "?Warning: Contributor \"", DEFAULT_CONTRIBUTOR,
           "\" should be updated in statement \"",
           g_Statement[stmtNum].labelName, "\".", NULL), "    ", " ");
       errFound = 1;
     }
-    /* 15-May-2017 nm */
     let(&str1, "");
     str1 = getContrib(stmtNum, REVISER);
     if (!strcmp(str1, DEFAULT_CONTRIBUTOR)) {
       printLongLine(cat(
-          "?Warning: Reviser \"", DEFAULT_CONTRIBUTOR,  /* 14-May-2017 nm */
+          "?Warning: Reviser \"", DEFAULT_CONTRIBUTOR,
           "\" should be updated in statement \"",
           g_Statement[stmtNum].labelName, "\".", NULL), "    ", " ");
       errFound = 1;
@@ -5809,21 +5186,11 @@ void verifyMarkup(vstring labelMatch,
 
       /* Check date consistency of the statement */
       /* Use the error-checking feature of getContrib() extractor */
-      /* 3-May-2017 nm */
       let(&str1, "");
       str1 = getContrib(stmtNum, GC_ERROR_CHECK_PRINT); /* Returns P or F */
       if (str1[0] == 'F') errFound = 1;
       let(&str1, "");
       str1 = getContrib(stmtNum, MOST_RECENT_DATE);
-
-      /***** deleted 3-May-2017
-      f = getContrib(stmtNum, &contributor, &contribDate,
-          &reviser, &reviseDate, &shortener, &shortenDate,
-          &str1 /@ most recent of the 3 dates @/, /@ 13-Dec-2016 nm @/
-          1/@printErrorsFlag@/,
-          1/@mode: 0 == RESET = reset, 1 = normal @/ /@ 2-May-2017 nm @/);
-      if (f == 1) errFound = 1;
-      *********/
 
       /* Save most recent date in file - used to check Version date below */
       if (compareDates(mostRecentDate, str1) == -1) {
@@ -5836,18 +5203,16 @@ void verifyMarkup(vstring labelMatch,
     let(&descr, "");
     descr = getDescription(stmtNum);
 
-    /* 17-Nov-2015 */
     /* Check comment markup of the statement */
     g_showStatement /* global */ = stmtNum; /* For printTexComment */
     g_texFilePtr /* global */  = NULL; /* Not used, but set to something */
     /* Use the errors-only (no output) feature of printTexComment() */
     f = printTexComment(descr,
         0, /* 1 = htmlCenterFlag (irrelevant for this call) */
-        PROCESS_EVERYTHING + ERRORS_ONLY, /* actionBits */ /* 13-Dec-2018 nm */
+        PROCESS_EVERYTHING + ERRORS_ONLY, /* actionBits */
         fileSkip /* 1 = noFileCheck */);
     if (f == 1) errFound = 1;
 
-    /* 20-Jun-2020 nm */
     /* Check that $a has no "(Proof modification is discouraged.)" */
     if (g_Statement[stmtNum].type == a_) {
       if (getMarkupFlag(stmtNum, PROOF_DISCOURAGED) == 1) {
@@ -5885,7 +5250,6 @@ void verifyMarkup(vstring labelMatch,
     }
   } /* next stmtNum */
 
-  /* 13-Dec-2016 nm */
   /* Check that the version date of the .mm file is g.e. all statement dates */
   /* This code expects a version date at the top of the file such as:
          $( set.mm - Version of 13-Dec-2016 $)
@@ -5927,7 +5291,6 @@ void verifyMarkup(vstring labelMatch,
   } /* if (dateSkip == 0) */
 
 
-  /* 18-Dec-2016 nm */
   print2("Checking section header comments...\n");
   for (stmtNum = 1; stmtNum <= g_statements; stmtNum++) {
     if (g_Statement[stmtNum].type != a_ && g_Statement[stmtNum].type != p_) {
@@ -5940,19 +5303,18 @@ void verifyMarkup(vstring labelMatch,
     let(&hugeHdr, "");
     let(&bigHdr, "");
     let(&smallHdr, "");
-    let(&tinyHdr, ""); /* 21-Aug-2017 nm */
+    let(&tinyHdr, "");
     let(&hugeHdrComment, "");
     let(&bigHdrComment, "");
     let(&smallHdrComment, "");
-    let(&tinyHdrComment, ""); /* 21-Aug-2017 nm */
+    let(&tinyHdrComment, "");
     f = getSectionHeadings(stmtNum, &hugeHdr, &bigHdr, &smallHdr,
-        &tinyHdr, /* 21-Aug-2017 nm */
-        /* 5-May-2015 nm */
+        &tinyHdr,
         &hugeHdrComment, &bigHdrComment, &smallHdrComment,
         &tinyHdrComment,
         0, /* fineResolution */
         0 /* fullComment */);
-    if (f != 0) errFound = 1;  /* 6-Aug-2019 nm */
+    if (f != 0) errFound = 1;
 
     g_showStatement /* global */ = stmtNum; /* For printTexComment() */
     g_texFilePtr /* global */  = NULL; /* Not used, but set to something */
@@ -5961,26 +5323,23 @@ void verifyMarkup(vstring labelMatch,
     if (hugeHdrComment[0] != 0)
       f = (char)(f + printTexComment(hugeHdrComment,
           0, /* 1 = htmlCenterFlag (irrelevant for this call) */
-          PROCESS_EVERYTHING + ERRORS_ONLY, /* actionBits */ /* 13-Dec-2018 nm */
+          PROCESS_EVERYTHING + ERRORS_ONLY, /* actionBits */
           fileSkip /* 1 = noFileCheck */));
     if (bigHdrComment[0] != 0)
       f = (char)(f + printTexComment(bigHdrComment,
           0, /* 1 = htmlCenterFlag (irrelevant for this call) */
-          PROCESS_EVERYTHING + ERRORS_ONLY, /* actionBits */ /* 13-Dec-2018 nm */
+          PROCESS_EVERYTHING + ERRORS_ONLY, /* actionBits */
           fileSkip /* 1 = noFileCheck */));
     if (smallHdrComment[0] != 0)
       f = (char)(f + printTexComment(smallHdrComment,
           0, /* 1 = htmlCenterFlag (irrelevant for this call) */
-          PROCESS_EVERYTHING + ERRORS_ONLY, /* actionBits */ /* 13-Dec-2018 nm */
+          PROCESS_EVERYTHING + ERRORS_ONLY, /* actionBits */
           fileSkip /* 1 = noFileCheck */));
-
-    /* Added 21-Aug-2017 nm */
     if (tinyHdrComment[0] != 0)
       f = (char)(f + printTexComment(tinyHdrComment,
           0, /* 1 = htmlCenterFlag (irrelevant for this call) */
-          PROCESS_EVERYTHING + ERRORS_ONLY, /* actionBits */ /* 13-Dec-2018 nm */
+          PROCESS_EVERYTHING + ERRORS_ONLY, /* actionBits */
           fileSkip /* 1 = noFileCheck */));
-    /* (End of 21-Aug-2017 addition) */
 
     if (f != 0) printf(
 "    (The warning above refers to a header above the referenced statement.)\n");
@@ -5996,7 +5355,6 @@ void verifyMarkup(vstring labelMatch,
           fileSkip); /* 1 = ignore missing external files (gifs, bib, etc.) */
   if (f != 0) errFound = 1;
 
-  /* 17-Jul-2020 nm */
   /* Check mathboxes for cross-references */
   if (mathboxSkip == 0) {
     print2("Checking mathbox independence...\n");
@@ -6018,18 +5376,7 @@ void verifyMarkup(vstring labelMatch,
           nmbrLet(&proof, g_WrkProof.proofString);
         }
         plen = nmbrLen(proof);
-        /* Get the essential step flags, if required */
-        /*
-        if (essentialFlag) {
-          nmbrLet(&essentialFlags, nmbrGetEssential(proof));
-        }
-        */
         for (step = 0; step < plen; step++) {
-          /*
-          if (essentialFlag) {
-            if (!essentialFlags[step]) continue;  /@ Ignore floating hypotheses @/
-          }
-          */
           stmt = proof[step];
           if (stmt < 0) continue; /* Local step or '?' step */
           if (stmt == 0) bug(266);
@@ -6082,14 +5429,6 @@ void verifyMarkup(vstring labelMatch,
     } /* next pmbox */
     /* Deallocate */
     let(&dupCheck, "");
-    /**** 5-Aug-2020 nm Deleted
-    nmbrLet(&mathboxStart, NULL_NMBRSTRING);
-    nmbrLet(&mathboxEnd, NULL_NMBRSTRING);
-    for (mbox = 1; mbox <= mathboxes; mbox++) {
-      let((vstring *)(&mathboxUser[mbox - 1]), "");
-    }
-    pntrLet(&mathboxUser, NULL_PNTRSTRING);
-    ****/
     nmbrLet(&proof, NULL_NMBRSTRING);
   }
 
@@ -6102,25 +5441,11 @@ void verifyMarkup(vstring labelMatch,
   eraseTexDefs();
 
   /* Deallocate string memory */
-  /**** deleted 3-May-2017 because now we use only mostRecentDate
-  let(&contributor, "");
-  let(&contribDate, "");
-  let(&reviser, "");
-  let(&reviseDate, "");
-  let(&shortener, "");
-  let(&shortenDate, "");
-  ******/
   let(&mostRecentDate, "");
   let(&mmVersionDate, "");
   let(&descr, "");
   let(&str1, "");
   let(&str2, "");
-
-  /* Added 21-Aug-2017 nm */
-  /* (It seems that I forgot to deallocate in earlier versions,
-     although it usually wouldn't have caused leakage since the last
-     statement in the .mm file normally won't have a header.  But
-     we do it here to be safe.) */
   let(&hugeHdr, "");
   let(&bigHdr, "");
   let(&smallHdr, "");
@@ -6129,15 +5454,12 @@ void verifyMarkup(vstring labelMatch,
   let(&bigHdrComment, "");
   let(&smallHdrComment, "");
   let(&tinyHdrComment, "");
-  /* (End of 21-Aug-2017 addition) */
-
   return;
 
 } /* verifyMarkup */
 
 
 
-/* 10-Dec-2018 nm Added */
 /* Function to process markup in an arbitrary non-Metamath HTML file, treating
    the file as a giant comment. */
 void processMarkup(vstring inputFileName, vstring outputFileName,
@@ -6208,12 +5530,11 @@ void processMarkup(vstring inputFileName, vstring outputFileName,
 }
 
 
-/* 3-May-2016 nm */
 /* List "discouraged" statements with "(Proof modification is discouraged."
    and "(New usage is discourged.)" comment markup tags. */
 /* This function is primarily intended for use with the "travis" system
    to identify versioning differences on GitHub. */
-void showDiscouraged(void) {   /* was: showRestricted */
+void showDiscouraged(void) {
   long stmt, s, usageCount;
   long lowStmt = 0, highStmt = 0; /* For a slight speedup */
   flag notQuitPrint = 1; /* Goes to 0 if user typed 'q' at scroll prompt */
@@ -6277,7 +5598,6 @@ void showDiscouraged(void) {   /* was: showRestricted */
   let(&str1, ""); /* Deallocate */
 } /* showDiscouraged */
 
-/* Added 14-Sep-2012 nm */
 /* Take a relative step FIRST, LAST, +nn, -nn (relative to the unknown
    essential steps) or ALL, and return the actual step for use by ASSIGN,
    IMPROVE, REPLACE, LET (or 0 in case of ALL, used by IMPROVE).  In case
@@ -6360,7 +5680,7 @@ long getStepNum(vstring relStep, /* User's argument */
           /* Found it */
           actualStepVal = i;
           break;
-        }             /* 16-Apr-06 */
+        }
       }
     } /* Next i */
   } else {
@@ -6375,7 +5695,7 @@ long getStepNum(vstring relStep, /* User's argument */
           /* Found it */
           actualStepVal = i;
           break;
-        }             /* 16-Apr-06 */
+        }
       }
     } /* Next i */
   }
@@ -6399,7 +5719,6 @@ long getStepNum(vstring relStep, /* User's argument */
 } /* getStepNum */
 
 
-/* Added 22-Apr-2015 nm */
 /* Convert the actual step numbers of an unassigned step to the relative
    -1, -2, etc. offset for SHOW NEW_PROOF ...  /UNKNOWN, to make it easier
    for the user to ASSIGN the relative step number. A 0 is returned
@@ -6432,7 +5751,6 @@ nmbrString *getRelStepNums(nmbrString *pfInProgress) {
 } /* getRelStepNums */
 
 
-/* 19-Sep-2012 nm */
 /* This procedure finds the next statement number whose label matches
    stmtName.  Wildcards are allowed.  If uniqueFlag is 1,
    there must be exactly one match, otherwise an error message is printed
@@ -6453,7 +5771,7 @@ long getStatementNum(vstring stmtName, /* Possibly with wildcards */
   flag hasWildcard;
   long matchesFound, matchStmt, matchStmt2, stmt;
   char typ;
-  flag laterMatchFound = 0; /* For better error message */ /* 16-Jan-2014 nm */
+  flag laterMatchFound = 0; /* For better error message */
 
   hasWildcard = 0;
   /* (Note strpbrk warning in mmpars.c) */
@@ -6473,16 +5791,8 @@ long getStatementNum(vstring stmtName, /* Possibly with wildcards */
   matchStmt = 1; /* Set to a legal value in case of bug */
   matchStmt2 = 1; /* Set to a legal value in case of bug */
 
-  /**** 18-Jul-2020 nm No longer needed; done in matches() (called by
-     matchesList() below) @/
-  if (!strcmp(stmtName, "=") && proveStatement != 0) {
-     let(&stmtName, g_Statement[proveStatement].labelName);
-  }
-  *****/
-
   for (stmt = startStmt; stmt <= g_statements; stmt++) {
 
-    /* 16-Jan-2014 nm */
     if (stmt >= maxStmt) {
       if (matchesFound > 0) break; /* Normal exit when a match was found */
       if (!uniqueFlag) break; /* We only want to scan up to maxStmt anyway */
@@ -6528,7 +5838,6 @@ long getStatementNum(vstring stmtName, /* Possibly with wildcards */
       }
     }
 
-    /* 16-Jan-2014 nm */
     if (stmt >= maxStmt) {
       /* For error messages:
          This signals that a later match (after the statement being
@@ -6572,9 +5881,8 @@ long getStatementNum(vstring stmtName, /* Possibly with wildcards */
         print2("?No $a or $p statement label matches \"%s\".\n",
           stmtName);
       } else {
-        /* 16-Jan-2014 nm */
-        print2(
-   "?You must specify a statement that occurs earlier the one being proved.\n");
+        print2("?You must specify a statement "
+          "that occurs earlier the one being proved.\n");
       }
     } else {
       /* This is normally for ASSIGN */
@@ -6584,9 +5892,8 @@ long getStatementNum(vstring stmtName, /* Possibly with wildcards */
             "\" was not found or is not a hypothesis of the statement ",
             "being proved.", NULL), "", " ");
       } else {
-        /* 16-Jan-2014 nm */
-        print2(
-   "?You must specify a statement that occurs earlier the one being proved.\n");
+        print2("?You must specify a statement "
+          "that occurs earlier the one being proved.\n");
       }
     }
   } else if (matchesFound == 2) {
@@ -6612,7 +5919,6 @@ long getStatementNum(vstring stmtName, /* Possibly with wildcards */
 
 
 /* Called by help() - prints a help line */
-/* THINK C gives compilation error if H() is lower-case h() -- why? */
 void H(vstring helpLine)
 {
   if (g_printHelp) {
@@ -6622,7 +5928,6 @@ void H(vstring helpLine)
 
 
 
-/******** 8/28/00 ***********************************************************/
 /******** The MIDI output algorithm is in this function, outputMidi(). ******/
 /*** Warning:  If you want to experiment with the MIDI output, please
      confine changes to this function.  Changes to other code

--- a/mmcmds.c
+++ b/mmcmds.c
@@ -4366,6 +4366,7 @@ void writeExtractedSource(
           fprintf(fp, "%s", buf);
           if (g_Statement[stmt].type != p_) {
             fprintf(fp, "$.");
+/*D*//*fprintf(fp, "#%ld#",stmt);*/
           } else {
             /* $p */
             fprintf(fp, "$=");
@@ -4376,6 +4377,7 @@ void writeExtractedSource(
           }
         } /* if not ${ $} */
         if (extractNeeded[stmt + 1] == 'N') {
+/*D*//*printf("added \\n stmt=%ld type=%c,%c\n",stmt+1,g_Statement[stmt].type,g_Statement[stmt+1].type);*/
           /* Put a newline following end of statement since the next
              statement's label section will be suppressed */
           fprintf(fp, "\n");

--- a/mmcmds.c
+++ b/mmcmds.c
@@ -204,7 +204,6 @@ void typeStatement(long showStmt,
             let(&str1, cat("\n\\vspace{1ex} %2\n\n", str1, NULL));
           }
         }
-        /* printTexComment(str1, 1); */
         printTexComment(str1,              /* Sends result to g_texFilePtr */
             1, /* 1 = htmlCenterFlag */
             PROCESS_EVERYTHING, /* actionBits */
@@ -525,7 +524,7 @@ void typeStatement(long showStmt,
       for (i = 0; i < j; i++) {
         k = g_Statement[showStmt].reqHypList[i];
         if (g_Statement[k].type != (char)e_ && (!htmlFlg && texFlag))
-          continue;
+          continue; /* Don't put $f's in LaTeX output */
         let(&str2, cat("  ",g_Statement[k].labelName,
             " $", chr(g_Statement[k].type), " ", NULL));
         if (!texFlag) {

--- a/mmcmds.h
+++ b/mmcmds.h
@@ -28,7 +28,7 @@ void typeProof(long statemNum,
   flag reverseFlag,
   flag noIndentFlag,
   long startColumn,
-  flag skipRepeatedSteps, /* 28-Jun-2013 nm Added */
+  flag skipRepeatedSteps,
   flag texFlag,
   flag htmlFlg);
 /* Show details of step */
@@ -39,12 +39,12 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag);
 flag traceProof(long statemNum,
   flag essentialFlag,
   flag axiomFlag,
-  vstring matchList, /* 19-May-2013 nm */
-  vstring traceToList, /* 18-Jul-2015 nm */
-  flag testOnlyFlag /* 20-May-2013 nm */);
+  vstring matchList,
+  vstring traceToList,
+  flag testOnlyFlag);
 void traceProofWork(long statemNum,
   flag essentialFlag,
-  vstring traceToList, /* 18-Jul-2015 nm */
+  vstring traceToList,
   vstring *statementUsedFlagsP, /* 'y'/'n' flag that statement is used */
   nmbrString **unprovedListP);
 /* Traces back the statements used by a proof, recursively, with tree display.*/
@@ -59,23 +59,20 @@ double countSteps(long statemNum, flag essentialFlag);
 /* Traces what statements require the use of a given statement */
 vstring traceUsage(long statemNum,
   flag recursiveFlag,
-  long cutoffStmt /* if nonzero, stop scan there */ /* 18-Jul-2015 nm */);
-vstring htmlDummyVars(long showStmt);  /* 12-Aug-2017 nm */
-vstring htmlAllowedSubst(long showStmt);  /* 4-Jan-2014 nm */
+  long cutoffStmt /* if nonzero, stop scan there */);
+vstring htmlDummyVars(long showStmt);
+vstring htmlAllowedSubst(long showStmt);
 
 void readInput(void);
 /* WRITE SOURCE command */
-void writeSource(/* flag cleanFlag, 3-May-2017 */ /* 1 = "/ CLEAN" qualifier was chosen */
-                flag reformatFlag /* 1 = "/ FORMAT", 2 = "/REWRAP" */,
-                /* 31-Dec-2017 nm */
-                flag splitFlag,  /* /SPLIT - write out separate $[ $] includes */
-                flag noVersioningFlag, /* /NO_VERSIONING - no ~1 backup */
-                flag keepSplitsFlag, /* /KEEP_SPLITS - don't delete included files
-                                      when /SPIT is not specified */
-                vstring extractLabels /* "" means write everything */
-                );
+void writeSource(
+  flag reformatFlag /* 1 = "/ FORMAT", 2 = "/REWRAP" */,
+  flag splitFlag,  /* /SPLIT - write out separate $[ $] includes */
+  flag noVersioningFlag, /* /NO_VERSIONING - no ~1 backup */
+  flag keepSplitsFlag, /* /KEEP_SPLITS - don't delete included files
+                        when /SPIT is not specified */
+  vstring extractLabels); /* "" means write everything */
 
-/* 24-Aug-2020 nm */
 /* Get info for WRITE SOURCE ... / EXTRACT */
 void writeExtractedSource(vstring extractLabels, /* EXTRACT argument provided by user */
   vstring fullOutput_fn, flag noVersioningFlag);
@@ -87,25 +84,21 @@ void eraseSource(void);
 void verifyProofs(vstring labelMatch, flag verifyFlag);
 
 
-/* 7-Nov-2015 nm Added this function for date consistency */
 /* If checkFiles = 0, do not open external files.
    If checkFiles = 1, check mm*.html, presence of gifs, etc. */
 void verifyMarkup(vstring labelMatch, flag dateSkip, flag topDateSkip,
     flag fileSkip,
-    flag underscoreSkip, /* 25-Jun-2020 nm */
-    flag mathboxSkip, /* 17-Jul-2020 nm */
-    flag verboseMode); /* 26-Dec-2016 nm */
+    flag underscoreSkip,
+    flag mathboxSkip,
+    flag verboseMode);
 
-/* 10-Dec-2018 nm Added */
 void processMarkup(vstring inputFileName, vstring outputFileName,
     flag processCss, long actionBits);
 
-/* 3-May-2016 nm */
 /* List "discouraged" statements with "(Proof modification is discouraged."
    and "(New usage is discourged.)" comment markup tags. */
 void showDiscouraged(void);
 
-/* 14-Sep-2012 nm */
 /* Take a relative step FIRST, LAST, +nn, -nn (relative to the unknown
    essential steps) or ALL, and return the actual step for use by ASSIGN,
    IMPROVE, REPLACE, LET (or 0 in case of ALL, used by IMPROVE).  In case
@@ -115,7 +108,6 @@ long getStepNum(vstring relStep, /* User's argument */
    nmbrString *pfInProgress, /* proofInProgress.proof */
    flag allFlag /* 1 = "ALL" is permissable */);
 
-/* 22-Apr-2015 nm */
 /* Convert the actual step numbers of an unassigned step to the relative
    -1, -2, etc. offset for SHOW NEW_PROOF ...  /UNKNOWN, to make it easier
    for the user to ASSIGN the relative step number. A 0 is returned
@@ -124,7 +116,6 @@ long getStepNum(vstring relStep, /* User's argument */
 /* The caller must deallocate the returned nmbrString. */
 nmbrString *getRelStepNums(nmbrString *pfInProgress);
 
-/* 19-Sep-2012 nm */
 /* This procedure finds the next statement number whose label matches
    stmtName.  Wildcards are allowed.  If uniqueFlag is 1,
    there must be exactly one match, otherwise an error message is printed,
@@ -142,13 +133,11 @@ long getStatementNum(vstring stmtName, /* Possibly with wildcards */
     flag efOnlyForMaxStmt, /* If 1, $e and $f must belong to maxStmt */
     flag uniqueFlag); /* If 1, match must be unique */
 
-/*extern vstring mainFileName;*/  /* 15-Aug-2020 nm Obsolete on 28-Dec-05 */
-
 /* For HELP processing */
 extern flag g_printHelp;
 void H(vstring helpLine);
 
-/* For MIDI files - added 8/28/00 */
+/* For MIDI files */
 extern flag g_midiFlag; /* Set to 1 if typeProof() is to output MIDI file */
 extern vstring g_midiParam; /* Parameter string for MIDI file */
 void outputMidi(long plen, nmbrString *indentationLevels,

--- a/mmdata.c
+++ b/mmdata.c
@@ -29,41 +29,31 @@ flag g_listMode = 0; /* 0 = metamath, 1 = list utility */
 flag g_toolsMode = 0; /* In metamath: 0 = metamath, 1 = text tools utility */
 
 
-/* 4-May-2015 nm */
 /* For use by getMarkupFlag() */
 vstring g_proofDiscouragedMarkup = "";
 vstring g_usageDiscouragedMarkup = "";
 flag g_globalDiscouragement = 1; /* SET DISCOURAGEMENT ON */
 
-/* 14-May-2017 nm */
 vstring g_contributorName = "";
 
 /* Global variables related to current statement */
 int g_currentScope = 0;
-/*long beginScopeStatementNum = 0;*/
 
 long g_MAX_STATEMENTS = 1;
 long g_MAX_MATHTOKENS = 1;
 long g_MAX_INCLUDECALLS = 2; /* Must be at least 2 (the single-file case) !!!
                          (A dummy extra top entry is used by parseKeywords().) */
 struct statement_struct *g_Statement = NULL;
-long *g_labelKey = NULL; /* 4-May-2017 Ari Ferrera - added "= NULL" */
+long *g_labelKey = NULL;
 struct mathToken_struct *g_MathToken;
 long *g_mathKey = NULL;
 long g_statements = 0, labels = 0, g_mathTokens = 0;
-/*long maxMathTokenLength = 0;*/ /* 15-Aug-2020 nm Not used */
 
-struct includeCall_struct *g_IncludeCall = NULL; /* 4-May-2017 Ari Ferrera
-                                                            - added "= NULL" */
+struct includeCall_struct *g_IncludeCall = NULL;
 long g_includeCalls = -1;  /* For eraseSouce() in mmcmds.c */
 
-char *g_sourcePtr = NULL; /* 4-May-2017 Ari Ferrera - added "= NULL" */
+char *g_sourcePtr = NULL;
 long g_sourceLen;
-
-/* 18-Jan-05 nm The structs below, and several other places, were changed
-   from hard-coded byte lengths to 'sizeof's by Waldek Hebisch
-   (hebisch at math dot uni dot wroc dot pl) so this will work on the
-   AMD64. */
 
 /* Null numString */
 struct nullNmbrStruct g_NmbrNull = {-1, sizeof(long), sizeof(long), -1};
@@ -104,9 +94,9 @@ vstring g_qsortKey; /* Used by qsortStringCmp; pointer only, do not deallocate *
 
 #define MEM_POOL_GROW 1000 /* Amount that a pool grows when it overflows. */
 /*??? Let user set this from menu. */
-long poolAbsoluteMax = /*2000000*/1000000; /* Pools will be purged when this is reached */
+long poolAbsoluteMax = 1000000; /* Pools will be purged when this is reached */
 long poolTotalFree = 0; /* Total amount of free space allocated in pool */
-/*E*/long i1,j1_,k1; /* 11-Sep-2009 nm Fix "built-in function 'j1'" warning */
+/*E*/long i1,j1_,k1; /* 'j1' is a built-in function */
 void **memUsedPool = NULL;
 long memUsedPoolSize = 0; /* Current # of partially filled arrays in use */
 long memUsedPoolMax = 0; /* Maximum # of entries in 'in use' table (grows
@@ -122,9 +112,8 @@ void *poolFixedMalloc(long size /* bytes */)
 {
   void *ptr;
   void *ptr2;
-/*E*/ /* 11-Jul-2014 nm Don't call print2() if db9 is set, since it will */
-/*E*/ /* recursively call the pool stuff causing a crash.  I changed */
-/*E*/ /* 41 cases of print2() to printf() below to resolve this. */
+/*E*/ /* Don't call print2() if db9 is set, since it will */
+/*E*/ /* recursively call the pool stuff causing a crash. */
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("a0: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
   if (!memFreePoolSize) { /* The pool is empty; we must allocate memory */
     ptr = malloc( 3 * sizeof(long) + (size_t)size);
@@ -269,21 +258,12 @@ void poolFree(void *ptr)
     poolTotalFree = poolTotalFree - ((long *)ptr)[-2] + ((long *)ptr)[-1];
     memUsedPoolSize--;
 
-    /* 11-Jul-2014 WL old code deleted */
-    /*
-    memUsedPool[usedLoc] = memUsedPool[memUsedPoolSize];
-    ptr1 = memUsedPool[usedLoc];
-    ((long @)ptr1)[-3] = usedLoc;
-/@E@/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("d: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
-    */
-    /* 11-Jul-2014 WL new code */
     if (usedLoc < memUsedPoolSize) {
       memUsedPool[usedLoc] = memUsedPool[memUsedPoolSize];
       ptr1 = memUsedPool[usedLoc];
       ((long *)ptr1)[-3] = usedLoc;
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("d: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
     }
-    /* end of 11-Jul-2014 WL new code */
   }
 
   /* Next, add the array to the memFreePool */
@@ -484,7 +464,6 @@ void outOfMemory(vstring msg)
 }
 
 
-/* 17-Nov-2015 nm Added abort, skip, ignore options */
 /* Bug check */
 void bug(int bugNum)
 {
@@ -493,7 +472,6 @@ void bug(int bugNum)
   long wrongAnswerCount = 0;
   static flag mode = 0; /* 1 = run to next bug, 2 = continue and ignore bugs */
 
-  /* 10/10/02 */
   flag saveOutputToString = g_outputToString;
   g_outputToString = 0; /* Make sure we print to screen and not to string */
 
@@ -517,7 +495,6 @@ void bug(int bugNum)
   "recording a session.  See HELP SUBMIT for help on command files.  Search\n");
     print2(
   "for \"bug(%ld)\" in the m*.c source code to find its origin.\n", bugNum);
-    /* 15-Oct-2019 nm Added the next 2 info lines */
     print2(
   "If earlier errors were reported, try fixing them first, because they\n");
     print2(
@@ -535,7 +512,7 @@ void bug(int bugNum)
     if (wrongAnswerCount > 6) {
       print2(
 "Too many wrong answers; program will be aborted to exit scripting loops.\n");
-      break; /* Added 8-Nov-03 */
+      break;
     }
     if (wrongAnswerCount > 0) {
       let(&tmpStr, "");
@@ -546,9 +523,6 @@ void bug(int bugNum)
       let(&tmpStr, "");
       tmpStr = cmdInput1("or A <return> to abort program:  ");
     }
-    /******* 8-Nov-03 This loop caused an infinite loop in a cron job when bug
-      detection was triggered.  Now, when the loop breaks above,
-      the program will abort. *******/
     wrongAnswerCount++;
   }
   oldMode = mode;
@@ -566,7 +540,6 @@ void bug(int bugNum)
     let(&tmpStr, "");
   }
   if (mode > 0) {
-    /* 10/10/02 */
     g_outputToString = saveOutputToString; /* Restore for continuation */
     return;
   }
@@ -587,7 +560,6 @@ void bug(int bugNum)
 
 #define M_MAX_ALLOC_STACK 100
 
-/* 26-Apr-2008 nm Added */
 /* This function returns a 1 if any entry in a comma-separated list
    matches using the matches() function. */
 flag matchesList(vstring testString, vstring pattern, char wildCard,
@@ -610,8 +582,7 @@ flag matchesList(vstring testString, vstring pattern, char wildCard,
     if (matchVal) break;
   }
 
-  let(&entryPattern, ""); /* Deallocate */ /* 3-Jul-2011 nm Added to fix
-                                              memory leak */
+  let(&entryPattern, ""); /* Deallocate */
   g_startTempAllocStack = saveTempAllocStack;
   return (matchVal);
 }
@@ -621,17 +592,11 @@ flag matchesList(vstring testString, vstring pattern, char wildCard,
    the second argument.  The second argument may have wildcard characters.
    wildCard matches 0 or more characters; oneCharWildCard matches any
    single character. */
-/* 30-Jan-06 nm Added single-character-match wildcard argument */
-/* 19-Apr-2015 so, nm - Added "=" to match statement being proved */
-/* 19-Apr-2015 so, nm - Added "%" to match changed proofs */
-/* 8-Mar-2016 nm Added "#1234" to match internal statement number */
-/* 18-Jul-2020 nm Added "@1234" to match web statement number */
 flag matches(vstring testString, vstring pattern, char wildCard,
     char oneCharWildCard) {
   long i, ppos, pctr, tpos, s1, s2, s3;
   vstring tmpStr = "";
 
-  /* 21-Nov-2014 Stefan O'Rear - added label ranges - see HELP SEARCH */
   if (wildCard == '*') {
     /* Checking for wildCard = * meaning this is only for labels, not
        math tokens */
@@ -661,7 +626,7 @@ flag matches(vstring testString, vstring pattern, char wildCard,
           ? 1 : 0);
     }
 
-    /* 8-Mar-2016 nm Added "#12345" to match internal statement number */
+    /* "#12345" matches internal statement number */
     if (pattern[0] == '#') {
       s1 = (long)val(right(pattern, 2));
       if (s1 < 1 || s1 > g_statements)
@@ -673,7 +638,7 @@ flag matches(vstring testString, vstring pattern, char wildCard,
       }
     }
 
-    /* 18-Jul-2020 nm Added "@12345" to match web statement number */
+    /* "@12345" matches web statement number */
     if (pattern[0] == '@') {
       s1 = lookupLabel(testString);
       if (s1 < 1) return 0;
@@ -685,17 +650,15 @@ flag matches(vstring testString, vstring pattern, char wildCard,
       }
     }
 
-    /* 19-Apr-2015 so, nm - Added "=" to match statement being proved */
+    /* "=" matches statement being proved */
     if (!strcmp(pattern,"=")) {
       s1 = lookupLabel(testString);
-      /*return (PFASmode && g_proveStatement == s1);*/
-      /* 18-Jul-2020 nm */
       /* We might as well use g_proveStatement outside of MM-PA, so =
          can be argument to PROVE command */
       return (g_proveStatement == s1);
     }
 
-    /* 19-Apr-2015 so, nm - Added "%" to match changed proofs */
+    /* "%" matches changed proofs */
     if (!strcmp(pattern,"%")) {
       s1 = lookupLabel(testString);  /* Returns -1 if not found or (not
                                         $a and not $p) */
@@ -703,11 +666,6 @@ flag matches(vstring testString, vstring pattern, char wildCard,
         /* (If it's not $p, we don't want to peek at proofSectionPtr[-1]
            to prevent bad pointer. */
         if (g_Statement[s1].type == (char)p_) { /* $p so it has a proof */
-          /*
-          /@ ASCII 1 is flag that proof is not from original source file @/
-          if (g_Statement[s1].proofSectionPtr[-1] == 1) {
-          */
-          /* 3-May-2017 nm */
           /* The proof is not from the original source file */
           if (g_Statement[s1].proofSectionChanged == 1) {
             return 1;
@@ -715,15 +673,11 @@ flag matches(vstring testString, vstring pattern, char wildCard,
         }
       }
       return 0;
-      /*
-      return nmbrElementIn(1, changedStmtNmbr, s1);
-      */
     } /* if (!strcmp(pattern,"%")) */
   } /* if (wildCard == '*') */
 
   /* Get to first wild card character */
   ppos = 0;
-  /*if (wildCard!='*') printf("'%s' vs. '%s'\n", pattern, testString);*/
   while ((pattern[ppos] == testString[ppos] ||
           (pattern[ppos] == oneCharWildCard && testString[ppos] != 0))
       && pattern[ppos] != 0) ppos++;
@@ -789,7 +743,6 @@ nmbrString *nmbrTempAlloc(long size)
   /* When "size" is >0, "size" instances of nmbrString are allocated. */
   /* When "size" is 0, all memory previously allocated with this */
   /* function is deallocated, down to g_nmbrStartTempAllocStack. */
-  /* int i; */  /* 11-Jul-2014 WL old code deleted */
   if (size) {
     if (g_nmbrTempAllocStackTop>=(M_MAX_ALLOC_STACK-1)) {
       /*??? Fix to allocate more */
@@ -797,24 +750,14 @@ nmbrString *nmbrTempAlloc(long size)
     }
     if (!(nmbrTempAllocStack[g_nmbrTempAllocStackTop++]=poolMalloc(size
         *(long)(sizeof(nmbrString)))))
-      /* outOfMemory("#106 (nmbrString stack)"); */ /*???Unnec. w/ poolMalloc*/
 /*E*/db2=db2+size*(long)(sizeof(nmbrString));
     return (nmbrTempAllocStack[g_nmbrTempAllocStackTop-1]);
   } else {
-    /* 11-Jul-2014 WL old code deleted */
-    /*
-    for (i=g_nmbrStartTempAllocStack; i < g_nmbrTempAllocStackTop; i++) {
-/@E@/db2=db2-(nmbrLen(nmbrTempAllocStack[i])+1)*(long)(sizeof(nmbrString));
-      poolFree(nmbrTempAllocStack[i]);
-    }
-    */
-    /* 11-Jul-2014 WL new code */
     while(g_nmbrTempAllocStackTop != g_nmbrStartTempAllocStack) {
 /*E*/db2=db2-(nmbrLen(nmbrTempAllocStack[g_nmbrTempAllocStackTop-1])+1)
 /*E*/                                              *(long)(sizeof(nmbrString));
       poolFree(nmbrTempAllocStack[--g_nmbrTempAllocStackTop]);
     }
-    /* end of 11-Jul-2014 WL new code */
     g_nmbrTempAllocStackTop=g_nmbrStartTempAllocStack;
     return (0);
   }
@@ -843,14 +786,13 @@ void nmbrMakeTempAlloc(nmbrString *s)
 }
 
 
-void nmbrLet(nmbrString **target,nmbrString *source)
 /* nmbrString assignment */
 /* This function must ALWAYS be called to make assignment to */
 /* a nmbrString in order for the memory cleanup routines, etc. */
 /* to work properly.  If a nmbrString has never been assigned before, */
 /* it is the user's responsibility to initialize it to NULL_NMBRSTRING (the */
 /* null string). */
-{
+void nmbrLet(nmbrString **target,nmbrString *source) {
   long targetLength,sourceLength;
   long targetAllocLen;
   long poolDiff;
@@ -859,11 +801,9 @@ void nmbrLet(nmbrString **target,nmbrString *source)
   targetLength=nmbrLen(*target);  /* Save its actual length */
   targetAllocLen=nmbrAllocLen(*target); /* Save target's allocated length */
 /*E*/if (targetLength) {
-/*E*/  /* printf("Deleting %s\n",cvtMToVString(*target,0)); */
 /*E*/  db3 = db3 - (targetLength+1)*(long)(sizeof(nmbrString));
 /*E*/}
 /*E*/if (sourceLength) {
-/*E*/  /* printf("Adding %s\n",cvtMToVString(source,0)); */
 /*E*/  db3 = db3 + (sourceLength+1)*(long)(sizeof(nmbrString));
 /*E*/}
   if (targetAllocLen) {
@@ -908,7 +848,6 @@ void nmbrLet(nmbrString **target,nmbrString *source)
                             We are replacing a smaller string with a larger one;
                             assume it is growing, and allocate twice as much as
                             needed. */
-        /*if (!*target) outOfMemory("#107 (nmbrString)");*/ /*???Unnec. w/ poolMalloc*/
         nmbrCpy(*target,source);
 
         /* Memory pool handling */
@@ -947,11 +886,9 @@ void nmbrLet(nmbrString **target,nmbrString *source)
     if (sourceLength) { /* target is 0 length, source is not */
       *target=poolMalloc((sourceLength + 1) * (long)(sizeof(nmbrString)));
                         /* Allocate new space */
-      /* if (!*target) outOfMemory("#108 (nmbrString)"); */ /*???Unnec. w/ poolMalloc*/
       nmbrCpy(*target,source);
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("k0d: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
     } else {    /* source and target are both 0 length */
-      /* *target= NULL_NMBRSTRING; */ /* Redundant */
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("k0e: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
     }
   }
@@ -1047,7 +984,7 @@ void nmbrZapLen(nmbrString *s, long length) {
 
 /* Copy a string to another (pre-allocated) string */
 /* Dangerous for general purpose use */
-void nmbrCpy(nmbrString *s,nmbrString *t)
+void nmbrCpy(nmbrString *s, nmbrString *t)
 {
   long i;
   i = 0;
@@ -1062,7 +999,7 @@ void nmbrCpy(nmbrString *s,nmbrString *t)
 /* Copy a string to another (pre-allocated) string */
 /* Like strncpy, only the 1st n characters are copied. */
 /* Dangerous for general purpose use */
-void nmbrNCpy(nmbrString *s,nmbrString *t,long n)
+void nmbrNCpy(nmbrString *s, nmbrString *t, long n)
 {
   long i;
   i = 0;
@@ -1080,7 +1017,7 @@ void nmbrNCpy(nmbrString *s,nmbrString *t,long n)
    and 0 otherwise. */
 /* Only the token is compared.  The whiteSpace string is
    ignored. */
-int nmbrEq(nmbrString *s,nmbrString *t)
+int nmbrEq(nmbrString *s, nmbrString *t)
 {
   long i;
   if (nmbrLen(s) != nmbrLen(t)) return 0; /* Speedup */
@@ -1130,7 +1067,7 @@ nmbrString *nmbrLeft(nmbrString *sin,long n)
 }
 
 /* Extract after character n */
-nmbrString *nmbrRight(nmbrString *sin,long n)
+nmbrString *nmbrRight(nmbrString *sin, long n)
 {
   /*??? We could just return &sin[n-1], but this is safer for debugging. */
   nmbrString *sout;
@@ -1140,7 +1077,7 @@ nmbrString *nmbrRight(nmbrString *sin,long n)
   if (n > i) return (NULL_NMBRSTRING);
   sout = nmbrTempAlloc(i - n + 2);
   nmbrCpy(sout, &sin[n - 1]);
-  return (sout);
+  return sout;
 }
 
 
@@ -1157,11 +1094,11 @@ nmbrString *nmbrSpace(long n)
     j++;
   }
   sout[j] = *NULL_NMBRSTRING; /* End of string */
-  return (sout);
+  return sout;
 }
 
 /* Search for string2 in string1 starting at start_position */
-long nmbrInstr(long start_position,nmbrString *string1,
+long nmbrInstr(long start_position, nmbrString *string1,
   nmbrString *string2)
 {
    long ls1, ls2, i, j;
@@ -1184,7 +1121,7 @@ long nmbrInstr(long start_position,nmbrString *string1,
 /* Warning:  This has 'let' inside of it and is not safe for use inside
    of 'let' statements.  (To make it safe, it must be rewritten to expand
    the 'mid' and remove the 'let'.) */
-long nmbrRevInstr(long start_position,nmbrString *string1,
+long nmbrRevInstr(long start_position, nmbrString *string1,
     nmbrString *string2)
 {
    long ls1, ls2;
@@ -1238,14 +1175,12 @@ vstring nmbrCvtMToVString(nmbrString *s)
 
 
 /* Converts proof to a vstring with one space between tokens */
-/* 11-Sep-2016 nm Allow it to tolerate garbage entries for debugging */
 vstring nmbrCvtRToVString(nmbrString *proof,
-    /* 25-Jan-2016 */
     flag explicitTargets, /* 1 = "target=source" for /EXPLICIT proof format */
     long statemNum) /* used only if explicitTargets=1 */
 {
   long i, j, plen, maxLabelLen, maxLocalLen, step, stmt;
-  long maxTargetLabelLen; /* 25-Jan-2016 nm */
+  long maxTargetLabelLen;
   vstring proofStr = "";
   vstring tmpStr = "";
   vstring ptr;
@@ -1266,7 +1201,6 @@ vstring nmbrCvtRToVString(nmbrString *proof,
 
   plen = nmbrLen(proof);
 
-  /* 25-Jan-2016 nm */
   if (explicitTargets == 1) {
     /* Get the list of targets for /EXPLICIT format */
     if (statemNum <= 0) bug(1388);
@@ -1284,7 +1218,7 @@ vstring nmbrCvtRToVString(nmbrString *proof,
   /* Collect local labels */
   /* Also, find longest statement label name */
   maxLabelLen = 0;
-  maxTargetLabelLen = 0; /* 25-Jan-2016 nm */
+  maxTargetLabelLen = 0;
   for (step = 0; step < plen; step++) {
     stmt = proof[step];
     if (stmt <= -1000) {
@@ -1294,7 +1228,6 @@ vstring nmbrCvtRToVString(nmbrString *proof,
       }
     } else {
 
-      /* 11-Sep-2016 nm */
       if (stmt < 1 || stmt > g_statements) {
         maxLabelLen = 100; /* For safety */
         maxTargetLabelLen = 100; /* For safety */
@@ -1308,7 +1241,6 @@ vstring nmbrCvtRToVString(nmbrString *proof,
       }
     }
 
-    /* 25-Jan-2016 nm */
     if (explicitTargets == 1) {
       /* Also consider longest target label name */
       stmt = targetHyps[step];
@@ -1328,7 +1260,7 @@ vstring nmbrCvtRToVString(nmbrString *proof,
   /* Preallocate the string for speed (the "2" accounts for a space and a
      colon). */
   let(&proofStr, space(plen * (2 + maxLabelLen
-      + ((explicitTargets == 1) ? maxTargetLabelLen + 1 : 0)  /* 25-Jan-2016 */
+      + ((explicitTargets == 1) ? maxTargetLabelLen + 1 : 0)
                                           /* The "1" accounts for equal sign */
       + maxLocalLen)));
   ptr = proofStr;
@@ -1339,29 +1271,21 @@ vstring nmbrCvtRToVString(nmbrString *proof,
         stmt = -1000 - stmt;
             /* Change stmt to the step number a local label refers to */
         let(&tmpStr, cat(
-
-            /* 25-Jan-2016 nm */
             ((explicitTargets == 1) ? g_Statement[targetHyps[step]].labelName : ""),
             ((explicitTargets == 1) ? "=" : ""),
-
             str((double)(localLabelNames[stmt])), " ", NULL));
 
-      /* 11-Sep-2016 nm */
       } else if (stmt != -(long)'?') {
         let(&tmpStr, cat("??", str((double)stmt), " ", NULL)); /* For safety */
 
       } else {
         if (stmt != -(long)'?') bug(1391); /* Must be an unknown step */
         let(&tmpStr, cat(
-
-            /* 25-Jan-2016 nm */
             ((explicitTargets == 1) ? g_Statement[targetHyps[step]].labelName : ""),
             ((explicitTargets == 1) ? "=" : ""),
-
             chr(-stmt), " ", NULL));
       }
 
-    /* 11-Sep-2016 nm */
     } else if (stmt < 1 || stmt > g_statements) {
       let(&tmpStr, cat("??", str((double)stmt), " ", NULL)); /* For safety */
 
@@ -1385,11 +1309,8 @@ vstring nmbrCvtRToVString(nmbrString *proof,
         nextLocLabNum++; /* Prepare for next local label */
       }
       let(&tmpStr, cat(tmpStr,
-
-          /* 25-Jan-2016 nm */
           ((explicitTargets == 1) ? g_Statement[targetHyps[step]].labelName : ""),
           ((explicitTargets == 1) ? "=" : ""),
-
           g_Statement[stmt].labelName, " ", NULL));
     }
     j = (long)strlen(tmpStr);
@@ -1414,11 +1335,10 @@ vstring nmbrCvtRToVString(nmbrString *proof,
 }
 
 
-nmbrString *nmbrGetProofStepNumbs(nmbrString *reason)
-{
-  /* This function returns a nmbrString of length of reason with
-     step numbers assigned to tokens which are steps, and 0 otherwise.
-     The returned string is allocated; THE CALLER MUST DEALLOCATE IT. */
+/* This function returns a nmbrString of length of reason with
+   step numbers assigned to tokens which are steps, and 0 otherwise.
+   The returned string is allocated; THE CALLER MUST DEALLOCATE IT. */
+nmbrString *nmbrGetProofStepNumbs(nmbrString *reason) {
   nmbrString *stepNumbs = NULL_NMBRSTRING;
   long rlen, start, end, i, step;
 
@@ -1490,8 +1410,7 @@ nmbrString *nmbrExtractVars(nmbrString *m)
   v[0] = *NULL_NMBRSTRING;
   j = 0; /* Length of output string */
   for (i = 0; i < length; i++) {
-    /*if (m[i] < 0 || m[i] >= g_mathTokens) {*/
-    /* Changed >= to > because tokenNum=g_mathTokens is used by mmveri.c for
+    /* Use > because tokenNum=g_mathTokens is used by mmveri.c for
        dummy token */
     if (m[i] < 0 || m[i] > g_mathTokens) bug(1328);
     if (g_MathToken[m[i]].tokenType == (char)var_) {
@@ -1722,9 +1641,7 @@ nmbrString *nmbrUnsquishProof(nmbrString *proof)
    startingLevel = 0. */
 /* ???Optimization:  remove nmbrString calls and use static variables
    to communicate to recursive calls */
-nmbrString *nmbrGetIndentation(nmbrString *proof,
-  long startingLevel)
-{
+nmbrString *nmbrGetIndentation(nmbrString *proof, long startingLevel) {
   long plen, stmt, pos, splen, hyps, i, j;
   char type;
   nmbrString *indentationLevel = NULL_NMBRSTRING;
@@ -1773,8 +1690,7 @@ nmbrString *nmbrGetIndentation(nmbrString *proof,
    function calls itself recursively. */
 /* ???Optimization:  remove nmbrString calls and use static variables
    to communicate to recursive calls */
-nmbrString *nmbrGetEssential(nmbrString *proof)
-{
+nmbrString *nmbrGetEssential(nmbrString *proof) {
   long plen, stmt, pos, splen, hyps, i, j;
   char type;
   nmbrString *essentialFlags = NULL_NMBRSTRING;
@@ -1833,8 +1749,7 @@ nmbrString *nmbrGetEssential(nmbrString *proof)
    statemNum is the statement being proved. */
 /* ???Optimization:  remove nmbrString calls and use static variables
    to communicate to recursive calls */
-nmbrString *nmbrGetTargetHyp(nmbrString *proof, long statemNum)
-{
+nmbrString *nmbrGetTargetHyp(nmbrString *proof, long statemNum) {
   long plen, stmt, pos, splen, hyps, i, j;
   char type;
   nmbrString *targetHyp = NULL_NMBRSTRING;
@@ -1913,16 +1828,12 @@ vstring compressProof(nmbrString *proof, long statemNum,
   nmbrString *localLabelFlags = NULL_NMBRSTRING;
   long hypLabels, assertionLabels, localLabels;
   long plen, step, stmt, labelLen, lab, numchrs;
-  /* long thresh, newnumchrs, newlab; */ /* 15-Oct-05 nm No longer used */
   long i, j, k;
-  /* flag breakFlag; */ /* 15-Oct-05 nm No longer used */
-  /* char c; */ /* 15-Oct-05 nm No longer used */
   long lettersLen, digitsLen;
   static char *digits = "0123456789";
   static char *letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
   static char labelChar = ':';
 
-  /* 27-Dec-2013 nm Variables for new algorithm */
   nmbrString *explList = NULL_NMBRSTRING;
   long explLabels;
   nmbrString *explRefCount = NULL_NMBRSTRING;
@@ -2014,9 +1925,6 @@ vstring compressProof(nmbrString *proof, long statemNum,
   /* To obtain the old algorithm, we simply skip the new label re-ordering */
   if (oldCompressionAlgorithm) goto OLD_ALGORITHM;
 
-
-  /* 27-Dec-2013 nm */
-  /************ New algorithm to sort labels according to usage ***********/
 
   /* This algorithm, based on an idea proposed by Mario Carneiro, sorts
      the explicit labels so that the most-used labels occur first, optimizing
@@ -2154,7 +2062,7 @@ vstring compressProof(nmbrString *proof, long statemNum,
           explWorth /*array of worths*/,
           explWidth /*maxSize*/,
           explIncluded /*itemIncluded return values*/);
-      /*if (j == 0) bug(1383);*/ /* j=0 is legal when it can't fit any labels
+      /* j=0 is legal when it can't fit any labels
          on the rest of the line (such as if the line only has 1 space left
          i.e. explWidth=1) */
       if (j < 0) bug(1383);
@@ -2203,8 +2111,6 @@ vstring compressProof(nmbrString *proof, long statemNum,
      reordered */
   nmbrLet(&assertionList, newExplList);
 
-  /********************** End of new algorithm ****************************/
-
 
  OLD_ALGORITHM:
   /* Combine all label lists */
@@ -2231,7 +2137,7 @@ vstring compressProof(nmbrString *proof, long statemNum,
         /* CPU-intensive bug check; enable only if required: */
         /* if (outputAllocated != (long)strlen(output)) bug(1348); */
         if (output[outputAllocated - 1] == 0 ||
-            output[outputAllocated] != 0) bug(1348); /* 13-Oct-05 nm */
+            output[outputAllocated] != 0) bug(1348);
       }
       output[outputLen] = '?';
       outputLen++;
@@ -2243,26 +2149,7 @@ vstring compressProof(nmbrString *proof, long statemNum,
     lab--; /* labelList array starts at 0, not 1 */
 
     /* Determine the # of chars in the compressed label */
-    /* 15-Oct-05 nm - Obsolete (skips from YT to UVA, missing UUA) */
-    /*
-    numchrs = 1;
-    if (lab > lettersLen - 1) {
-      / * It requires a numeric prefix * /
-      i = lab / lettersLen;
-      while(i) {
-        numchrs++;
-        if (i > digitsLen) {
-          i = i / digitsLen;
-        } else {
-          i = 0; / * MSB is sort of 'mod digitsLen+1' since
-                                a blank is the MSB in the case of one
-                                fewer characters in the label * /
-        }
-      }
-    }
-    */
-
-    /* 15-Oct-05 nm - A corrected algorithm was provided by Marnix Klooster. */
+    /* A corrected algorithm was provided by Marnix Klooster. */
     /* For encoding we'd get (starting with n, counting from 1):
         * start with the empty string
         * prepend (n-1) mod 20 + 1 as character using 1->'A' .. 20->'T'
@@ -2288,39 +2175,10 @@ vstring compressProof(nmbrString *proof, long statemNum,
       /* CPU-intensive bug check; enable only if required: */
       /* if (outputAllocated != (long)strlen(output)) bug(1350); */
       if (output[outputAllocated - 1] == 0 ||
-          output[outputAllocated] != 0) bug(1350); /* 13-Oct-05 nm */
+          output[outputAllocated] != 0) bug(1350);
     }
     outputLen = outputLen + numchrs;
 
-    /* 15-Oct-05 nm - Obsolete (skips from YT to UVA, missing UUA) */
-    /*
-    j = lab;
-    for (i = 0; i < numchrs; i++) { / * Create from LSB to MSB * /
-      if (!i) {
-        c = letters[j % lettersLen];
-        j = j / lettersLen;
-      } else {
-        if (j > digitsLen) {
-          c = digits[j % digitsLen];
-          j = j / digitsLen;
-        } else {
-          c = digits[j - 1]; / * MSB is sort of 'mod digitsLen+1' since
-                                a blank is the MSB in the case of one
-                                fewer characters in the label * /
-        }
-      }
-      output[outputLen - i - 1] = c;
-    } / * Next i * /
-    */
-
-    /* 15-Oct-05 nm - A corrected algorithm was provided by Marnix Klooster. */
-    /* For encoding we'd get (starting with n, counting from 1):
-        * start with the empty string
-        * prepend (n-1) mod 20 + 1 as character using 1->'A' .. 20->'T'
-        * n := (n-1) div 20
-        * while n > 0:
-           * prepend (n-1) mod 5 + 1 as character using 1->'U' .. 5->'Y'
-           * n := (n-1) div 5 */
     j = lab + 1; /* lab starts at 0, not 1 */
     i = 1;
     output[outputLen - i] = letters[(j - 1) % lettersLen];
@@ -2368,9 +2226,6 @@ vstring compressProof(nmbrString *proof, long statemNum,
   nmbrLet(&assertionList, NULL_NMBRSTRING);
   nmbrLet(&localList, NULL_NMBRSTRING);
   nmbrLet(&localLabelFlags, NULL_NMBRSTRING);
-
-  /* Deallocate arrays for new algorithm */  /* 27-Dec-2013 nm */
-
   nmbrLet(&explList, NULL_NMBRSTRING);
   nmbrLet(&explRefCount, NULL_NMBRSTRING);
   nmbrLet(&labelRefCount, NULL_NMBRSTRING);
@@ -2386,7 +2241,6 @@ vstring compressProof(nmbrString *proof, long statemNum,
 } /* compressProof */
 
 
-/* Added 11-Sep-2016 nm */
 /* Compress the input proof, create the ASCII compressed proof,
    and return its size in bytes. */
 /* TODO: call this in MINIMIZE_WITH in metamath.c */
@@ -2425,31 +2279,20 @@ pntrString *pntrTempAlloc(long size)
   /* When "size" is >0, "size" instances of pntrString are allocated. */
   /* When "size" is 0, all memory previously allocated with this */
   /* function is deallocated, down to g_pntrStartTempAllocStack. */
-  /* int i; */   /* 11-Jul-2014 WL old code deleted */
   if (size) {
     if (g_pntrTempAllocStackTop>=(M_MAX_ALLOC_STACK-1))
       /*??? Fix to allocate more */
       outOfMemory("#109 (pntrString stack array)");
     if (!(pntrTempAllocStack[g_pntrTempAllocStackTop++]=poolMalloc(size
         *(long)(sizeof(pntrString)))))
-      /* outOfMemory("#110 (pntrString stack)"); */ /*???Unnec. w/ poolMalloc*/
 /*E*/db2=db2+(size)*(long)(sizeof(pntrString));
     return (pntrTempAllocStack[g_pntrTempAllocStackTop-1]);
   } else {
-    /* 11-Jul-2014 WL old code deleted */
-    /*
-    for (i=g_pntrStartTempAllocStack; i < g_pntrTempAllocStackTop; i++) {
-/@E@/db2=db2-(pntrLen(pntrTempAllocStack[i])+1)*(long)(sizeof(pntrString));
-      poolFree(pntrTempAllocStack[i]);
-    }
-    */
-    /* 11-Jul-2014 WL new code */
     while(g_pntrTempAllocStackTop != g_pntrStartTempAllocStack) {
 /*E*/db2=db2-(pntrLen(pntrTempAllocStack[g_pntrTempAllocStackTop-1])+1)
 /*E*/                                              *(long)(sizeof(pntrString));
       poolFree(pntrTempAllocStack[--g_pntrTempAllocStackTop]);
     }
-    /* end of 11-Jul-2014 WL new code */
     g_pntrTempAllocStackTop=g_pntrStartTempAllocStack;
     return (0);
   }
@@ -2459,8 +2302,7 @@ pntrString *pntrTempAlloc(long size)
 /* Make string have temporary allocation to be released by next pntrLet() */
 /* Warning:  after pntrMakeTempAlloc() is called, the pntrString may NOT be
    assigned again with pntrLet() */
-void pntrMakeTempAlloc(pntrString *s)
-{
+void pntrMakeTempAlloc(pntrString *s) {
     if (g_pntrTempAllocStackTop>=(M_MAX_ALLOC_STACK-1)) {
       printf(
       "*** FATAL ERROR ***  Temporary pntrString stack overflow in pntrMakeTempAlloc()\n");
@@ -2477,14 +2319,13 @@ void pntrMakeTempAlloc(pntrString *s)
 }
 
 
-void pntrLet(pntrString **target,pntrString *source)
 /* pntrString assignment */
 /* This function must ALWAYS be called to make assignment to */
 /* a pntrString in order for the memory cleanup routines, etc. */
 /* to work properly.  If a pntrString has never been assigned before, */
 /* it is the user's responsibility to initialize it to NULL_PNTRSTRING (the */
 /* null string). */
-{
+void pntrLet(pntrString **target,pntrString *source) {
   long targetLength,sourceLength;
   long targetAllocLen;
   long poolDiff;
@@ -2542,7 +2383,6 @@ void pntrLet(pntrString **target,pntrString *source)
                             We are replacing a smaller string with a larger one;
                             assume it is growing, and allocate twice as much as
                             needed. */
-        /*if (!*target) outOfMemory("#111 (pntrString)");*/ /*???Unnec. w/ poolMalloc*/
         pntrCpy(*target,source);
 
         /* Memory pool handling */
@@ -2581,11 +2421,9 @@ void pntrLet(pntrString **target,pntrString *source)
     if (sourceLength) { /* target is 0 length, source is not */
       *target=poolMalloc((sourceLength + 1) * (long)(sizeof(pntrString)));
                         /* Allocate new space */
-      /* if (!*target) outOfMemory("#112 (pntrString)"); */ /*???Unnec. w/ poolMalloc*/
       pntrCpy(*target,source);
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("k0d: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
     } else {    /* source and target are both 0 length */
-      /* *target= NULL_PNTRSTRING; */ /* Redundant */
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("k0e: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
     }
   }
@@ -2597,8 +2435,8 @@ void pntrLet(pntrString **target,pntrString *source)
 
 
 
-pntrString *pntrCat(pntrString *string1,...) /* String concatenation */
-{
+/* String concatenation */
+pntrString *pntrCat(pntrString *string1,...) {
   va_list ap;   /* Declare list incrementer */
   pntrString *arg[M_MAX_CAT_ARGS];        /* Array to store arguments */
   long argLength[M_MAX_CAT_ARGS];       /* Array to store argument lengths */
@@ -3048,54 +2886,9 @@ vstring getDescription(long statemNum) {
   let(&description, edit(seg(description, p1 + 2, p2 - 1),
       8 + 128 /* discard leading and trailing blanks */));
   return description;
-
-  /* 3-May-2017 nm Old code may have been somewhat faster, but it doesn't
-     work when g_Statement[statemNum].labelSectionChanged */
-  /************* deleted *******
-  char @fbPtr; /@ Source buffer pointer @/
-  vstring description = "";
-  char @startDescription;
-  char @endDescription;
-  char @startLabel;
-
-  fbPtr = g_Statement[statemNum].mathSectionPtr;
-  if (!fbPtr[0]) return (description);
-  startLabel = g_Statement[statemNum].labelSectionPtr;
-  if (!startLabel[0]) return (description);
-  endDescription = NULL;
-  while (1) { /@ Get end of embedded comment @/
-    if (fbPtr <= startLabel) break;
-    if (fbPtr[0] == '$' && fbPtr[1] == ')') {
-      endDescription = fbPtr;
-      break;
-    }
-    fbPtr--;
-  }
-  if (!endDescription) return (description); /@ No embedded comment @/
-  while (1) { /@ Get start of embedded comment @/
-    if (fbPtr < startLabel) bug(216);
-    if (fbPtr[0] == '$' && fbPtr[1] == '(') {
-      startDescription = fbPtr + 2;
-      break;
-    }
-    fbPtr--;
-  }
-  let(&description, space(endDescription - startDescription));
-  memcpy(description, startDescription,
-      (size_t)(endDescription - startDescription));
-  if (description[endDescription - startDescription - 1] == '\n') {
-    /@ Trim trailing new line @/
-    let(&description, left(description, endDescription - startDescription - 1));
-  }
-  /@ Discard leading and trailing blanks @/
-  let(&description, edit(description, 8 + 128));
-  return (description);
-  *********** end of 3-May-2017 deletion *****/
-
 } /* getDescription */
 
 
-/* 24-Aug-2020 nm */
 /* Returns the label section of a statement with all comments except the
    last removed.  Unlike getDescription, this function returns the comment
    surrounded by $( and $) as well as the leading indentation space
@@ -3106,7 +2899,7 @@ vstring getDescription(long statemNum) {
 vstring getDescriptionAndLabel(long stmt) {
   vstring descriptionAndLabel = "";
   long p1, p2;
-  flag dontUseComment = 0; /* 12-Sep-2020 nm */
+  flag dontUseComment = 0;
 
   let(&descriptionAndLabel, space(g_Statement[stmt].labelSectionLen));
   memcpy(descriptionAndLabel, g_Statement[stmt].labelSectionPtr,
@@ -3132,28 +2925,17 @@ vstring getDescriptionAndLabel(long stmt) {
       || instr(1, descriptionAndLabel, cat("\n", SMALL_DECORATION, NULL)) != 0
       || instr(1, descriptionAndLabel, cat("\n", BIG_DECORATION, NULL)) != 0
       || instr(1, descriptionAndLabel, cat("\n", HUGE_DECORATION, NULL)) != 0) {
-    /*let(&descriptionAndLabel, "");*/
-    dontUseComment = 1; /* 12-Sep-2020 nm */
+    dontUseComment = 1;
   }
   /* Remove comments with file inclusion markup */
   if (instr(1, descriptionAndLabel, "$[") != 0) {
-    /*let(&descriptionAndLabel, "");*/
-    dontUseComment = 1; /* 12-Sep-2020 nm */
+    dontUseComment = 1;
   }
 
   /* Remove comments with $j markup */
   if (instr(1, descriptionAndLabel, "$j") != 0) {
-    /*let(&descriptionAndLabel, "");*/
-    dontUseComment = 1; /* 12-Sep-2020 nm */
+    dontUseComment = 1;
   }
-
-  /****** deleted 12-Sep-2020
-  /@ If the cleaned description is empty, e.g. ${ after a header,
-     add in spaces corresponding to the scope @/
-  if (descriptionAndLabel[0] == 0) {
-    let(&descriptionAndLabel, space(2 * (g_Statement[stmt].scope + 1)));
-  }
-  *******/
 
   if (dontUseComment == 1) {
     /* Get everything that follows the comment */
@@ -3164,39 +2946,6 @@ vstring getDescriptionAndLabel(long stmt) {
 
   return descriptionAndLabel;
 } /* getDescriptionAndLabel */
-
-
-/**** Deleted 12-Sep-2020 nm
-/@ 24-Aug-2020 nm @/
-/@ Reconstruct the full header from the strings returned by
-   getSectionHeadings().  The caller should deallocate the returned string. @/
-/@ getSectionHeadings() currently return strings extracted from headers,
-   but not the full header needed for writeExtractedSource().  Maybe we
-   should have it return the full header in the future, but for now this
-   function reconstructs the full header. @/
-vstring buildHeader(vstring header, vstring hdrComment, vstring decoration) {
-  long i;
-  vstring fullDecoration = "";
-  vstring fullHeader = "";
-  /@ The HUGE_DECORATION etc. have only the 1st 4 chars of the full line.
-     Build the full line. @/
-  let(&fullDecoration, "");
-  for (i = 1; i <= 5; i++) {
-    let(&fullDecoration, cat(fullDecoration, decoration, decoration,
-        decoration, decoration, NULL));
-  }
-  let(&fullDecoration, left(fullDecoration, 79));
-  i = (long)strlen(hdrComment);
-  let(&fullHeader, cat("\n\n$(\n", fullDecoration, "\n",
-      space((79 - (long)strlen(header))/2), header, "\n", fullDecoration,
-      "\n", hdrComment,
-      (i == 0) ? "$)\n" :
-          (hdrComment[i - 1] == ' ') ? "$)\n" : "\n$)\n",
-      NULL));
-  let(&fullDecoration, "");
-  return fullHeader;
-} /@ buildHeader @/
-*******/
 
 
 /* Returns 0 or 1 to indicate absence or presence of an indicator in
@@ -3216,12 +2965,6 @@ flag getMarkupFlag(long statemNum, flag mode) {
   static vstring proofFlags = "";  /* Y if proof discouragement, else N */
   static vstring usageFlags = "";  /* Y if usage discouragement, else N */
   vstring str1 = "";
-  /* These are global in mmdata.h
-#define PROOF_DISCOURAGED_MARKUP "(Proof modification is discouraged.)"
-#define USAGE_DISCOURAGED_MARKUP "(New usage is discouraged.)"
-  extern vstring g_proofDiscouragedMarkup;
-  extern vstring g_usageDiscouragedMarkup;
-  */
 
   if (mode == RESET) { /* Deallocate */ /* Should be called by ERASE command */
     let(&commentSearchedFlags, "");
@@ -3252,8 +2995,7 @@ flag getMarkupFlag(long statemNum, flag mode) {
   if (statemNum < 1 || statemNum > g_statements) bug(1392);
 
   if (commentSearchedFlags[statemNum] == 'N') {
-    if (g_Statement[statemNum].type == f_
-        || g_Statement[statemNum].type == e_ /* 24-May-2016 nm */ ) {
+    if (g_Statement[statemNum].type == f_ || g_Statement[statemNum].type == e_) {
       /* Any comment before a $f, $e statement is assumed irrelevant */
       proofFlags[statemNum] = 'N';
       usageFlags[statemNum] = 'N';
@@ -3286,8 +3028,6 @@ flag getMarkupFlag(long statemNum, flag mode) {
 } /* getMarkupFlag */
 
 
-/* 7-Nov-2015 nm */
-
 /* Extract contributor or date from statement description per the
    following mode argument:
 
@@ -3319,21 +3059,8 @@ flag getMarkupFlag(long statemNum, flag mode) {
    It should be called whenever the labelSection is changed e.g. by
    SAVE PROOF.  The empty string is returned.
 */
-/* 3-May-2017 nm Changed to return a single result each call, to allow
-   expandability in the future */
 /* The caller must deallocate the returned string. */
 vstring getContrib(long stmtNum, char mode) {
-
-/******** deleted 3-May-2017
-flag getContrib(long stmtNum,
-    vstring @contributor, vstring @contribDate,
-    vstring @reviser, vstring @reviseDate,
-    vstring @shortener, vstring @shortenDate,
-    vstring @mostRecentDate, /@ The most recent of all 3 dates @/
-    flag printErrorsFlag,
-    flag mode /@ 0 == RESET = reset, 1 = normal @/ /@ 2-May-2017 nm @/) {
-*******/
-  /* 2-May-2017 nm */
   /* For speedup, the algorithm searches a statement's comment for markup
      matches only the first time, then saves the result for subsequent calls
      for that statement. */
@@ -3373,12 +3100,10 @@ flag getContrib(long stmtNum,
 #define SHORTEN_MATCH " (Proof shortened by "
 #define END_MATCH ".) "
 
-  /* 3-May-2017 nm */
   if (mode == GC_ERROR_CHECK_SILENT || mode == GC_ERROR_CHECK_PRINT) {
     errorCheckFlag = 1;
   }
 
-  /* 2-May-2017 nm */
   if (mode == GC_RESET) {
     /* This is normally called by the ERASE command only */
     if (init != 0) {
@@ -3414,7 +3139,6 @@ flag getContrib(long stmtNum,
     return "";
   }
 
-  /* 3-May-2017 nm */
   if (mode == GC_RESET_STMT) {
     /* This should be called whenever the labelSection is changed e.g. by
        SAVE PROOF. */
@@ -3494,10 +3218,6 @@ flag getContrib(long stmtNum,
     } else {
       /* The contributorList etc. are already initialized to the empty
          string, so we don't have to assign them here. */
-      /*
-      let((vstring *)(&(contributorList[stmtNum])), "");
-      let((vstring *)(&(contribDateList[stmtNum])), "");
-      */
     }
 
     rStart = 0;
@@ -3523,11 +3243,6 @@ flag getContrib(long stmtNum,
           seg(description, rStart, rMid - 2));
       let((vstring *)(&(reviseDateList[stmtNum])),
           seg(description, rMid + 1, rEnd - 1));
-    } else {
-      /* redundant; already done by init
-      let((vstring *)(&(reviserList[stmtNum])), "");
-      let((vstring *)(&(reviseDateList[stmtNum])), "");
-      */
     }
 
     sStart = 0;
@@ -3553,15 +3268,10 @@ flag getContrib(long stmtNum,
           seg(description, sStart, sMid - 2));
       let((vstring *)(&(shortenDateList[stmtNum])),
          seg(description, sMid + 1, sEnd - 1));
-    } else {
-      /* redundant; already done by init
-      let((vstring *)(&(shortenerList[stmtNum])), "");
-      let((vstring *)(&(shortenDateList[stmtNum])), "");
-      */
     }
 
 
-    /* 13-Dec-2016 nm Get the most recent date */
+    /* Get the most recent date */
     let((vstring *)(&(mostRecentDateList[stmtNum])),
         (vstring)(contribDateList[stmtNum]));
     /* Note that compareDate() treats empty string as earliest date */
@@ -3576,7 +3286,7 @@ flag getContrib(long stmtNum,
           (vstring)(shortenDateList[stmtNum]));
     }
 
-    /* 2-May-2017 nm Tag the cache entry as updated */
+    /* Tag the cache entry as updated */
     commentSearchedFlags[stmtNum] = 'Y';
   } /* commentSearchedFlags[stmtNum] == 'N' || errorCheckFlag == 1 */
 
@@ -3881,7 +3591,6 @@ flag getContrib(long stmtNum,
 } /* getContrib */
 
 
-/* 4-Nov-2015 nm */
 /* Extract up to 2 dates after a statement's proof.  If no date is present,
    date1 will be blank.  If no 2nd date is present, date2 will be blank.
    THIS WILL BECOME OBSOLETE WHEN WE START TO USE DATES IN THE
@@ -3913,7 +3622,6 @@ void getProofDate(long stmtNum, vstring *date1, vstring *date2) {
 } /* getProofDate */
 
 
-/* 4-Nov-2015 nm */
 /* Get date, month, year fields from a dd-mmm-yyyy date string,
    where dd may be 1 or 2 digits, mmm is 1st 3 letters of month,
    and yyyy is 2 or 4 digits.  A 1 is returned if an error was detected. */
@@ -3939,7 +3647,6 @@ flag parseDate(vstring dateStr, long *dd, long *mmm, long *yyyy) {
 } /* parseDate */
 
 
-/* 4-Nov-2015 nm */
 /* Build date from numeric fields.  mmm should be a number from 1 to 12.
    There is no error-checking. */
 void buildDate(long dd, long mmm, long yyyy, vstring *dateStr) {
@@ -3949,13 +3656,11 @@ void buildDate(long dd, long mmm, long yyyy, vstring *dateStr) {
 } /* buildDate */
 
 
-/* 4-Nov-2015 nm */
 /* Compare two dates in the form dd-mmm-yyyy.  -1 = date1 < date2,
    0 = date1 = date2,  1 = date1 > date2.  There is no error checking. */
 flag compareDates(vstring date1, vstring date2) {
   long d1, m1, y1, d2, m2, y2, dd1, dd2;
 
-  /* 13-Dec-2016 nm */
   /* If a date is the empty string, treat it as being _before_ any other
      date */
   if (date1[0] == 0 || date2[0] == 0) {
@@ -4009,7 +3714,6 @@ int qsortStringCmp(const void *p1, const void *p2)
   }
 }
 
-/* 4-May-2017 Ari Ferrera */
 void freeData() {
   /* 15-Aug-2020 nm TODO: are some of these called twice? (in eraseSource) */
   free(g_IncludeCall);

--- a/mmdata.c
+++ b/mmdata.c
@@ -296,7 +296,7 @@ void poolFree(void *ptr)
   /* In theory, [-3] should never get referenced for an entry in the
      memFreePool. However, here we make it a definite (illegal) value in
      case it is referenced by code with a bug. */
-  ((long *)ptr)[-3] = -2;  /* 11-Jul-2014 WL */
+  ((long *)ptr)[-3] = -2;
   memFreePoolSize++;
   poolTotalFree = poolTotalFree + ((long *)ptr)[-2];
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("e: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
@@ -1188,7 +1188,6 @@ vstring nmbrCvtRToVString(nmbrString *proof,
   nmbrString *localLabelNames = NULL_NMBRSTRING;
   long nextLocLabNum = 1; /* Next number to be used for a local label */
   void *voidPtr; /* bsearch result */
-  /* 26-Jan-2016 nm */
   nmbrString *targetHyps = NULL_NMBRSTRING; /* Targets for /EXPLICIT format */
 
   long saveTempAllocStack;
@@ -2203,7 +2202,7 @@ vstring compressProof(nmbrString *proof, long statemNum,
       /* CPU-intensive bug check due to strlen; enable only if required: */
       /* if (outputAllocated != (long)strlen(output)) bug(1352); */
       if (output[outputAllocated - 1] == 0 ||
-          output[outputAllocated] != 0) bug(1352); /* 13-Oct-05 nm */
+          output[outputAllocated] != 0) bug(1352);
     }
     output[outputLen] = labelChar;
     outputLen++;
@@ -2215,7 +2214,6 @@ vstring compressProof(nmbrString *proof, long statemNum,
       /* Trim off leading implicit required hypotheses */
       nmbrRight(hypList, g_Statement[statemNum].numReqHyp + 1),
       assertionList, NULL),
-                /* 25-Jan-2016 nm */
                 0, /*explicitTargets*/
                 0 /*statemNum used only if explicitTargets*/),
       " ) ", left(output, outputLen), NULL));
@@ -3358,12 +3356,11 @@ vstring getContrib(long stmtNum, char mode) {
         NULL), "    ", " ");
   }
 
-  /* 3-May-2017 nm */
   if (cStart != 0 && description[cMid - 2] != ',') {
     err = 1;
     if (mode == GC_ERROR_CHECK_PRINT) printLongLine(cat(
         "?Warning: There is no comma between contributor and date",
-        ", or period is missing,",   /* 5-Aug-2017 nm */
+        ", or period is missing,",
         " in the comment above statement ",
         str((double)stmtNum), ", label \"", g_Statement[stmtNum].labelName, "\".",
         NULL), "    ", " ");
@@ -3372,7 +3369,7 @@ vstring getContrib(long stmtNum, char mode) {
     err = 1;
     if (mode == GC_ERROR_CHECK_PRINT) printLongLine(cat(
         "?Warning: There is no comma between reviser and date",
-        ", or period is missing,",   /* 5-Aug-2017 nm */
+        ", or period is missing,",
         " in the comment above statement ",
         str((double)stmtNum), ", label \"", g_Statement[stmtNum].labelName, "\".",
         NULL), "    ", " ");
@@ -3381,7 +3378,7 @@ vstring getContrib(long stmtNum, char mode) {
     err = 1;
     if (mode == GC_ERROR_CHECK_PRINT) printLongLine(cat(
         "?Warning: There is no comma between proof shortener and date",
-        ", or period is missing,",   /* 5-Aug-2017 nm */
+        ", or period is missing,",
         " in the comment above statement ",
         str((double)stmtNum), ", label \"", g_Statement[stmtNum].labelName, "\".",
         NULL), "    ", " ");
@@ -3642,7 +3639,7 @@ flag parseDate(vstring dateStr, long *dd, long *mmm, long *yyyy) {
       *yyyy = *yyyy + 1900;
     }
   }
-  if (*dd < 1 || *dd > 31 || *mmm < 1 || *mmm > 12) err = 1; /* 13-Dec-2016 nm */
+  if (*dd < 1 || *dd > 31 || *mmm < 1 || *mmm > 12) err = 1;
   return err;
 } /* parseDate */
 
@@ -3690,7 +3687,6 @@ flag compareDates(vstring date1, vstring date2) {
 
 
 
-/* 17-Nov-2015 Moved out of metamath.c for better modularization */
 /* Compare strings via pointers for qsort */
 /* g_qsortKey is a global string key at which the sort starts; if empty,
    start at the beginning of each line. */

--- a/mmdata.h
+++ b/mmdata.h
@@ -39,7 +39,6 @@ enum mTokenType { var_, con_ };
 #define illegal_ '?' /* anything else */
 /* Global variables related to current statement */
 extern int g_currentScope;
-/*extern long beginScopeStmtNum;*/ /* 15-Aug-2020 nm changed to local in mmpars.c */
 
 struct statement_struct { /* Array index is statement number, starting at 1 */
   long lineNum; /* Line number in file; 0 means not yet determined */
@@ -54,24 +53,21 @@ struct statement_struct { /* Array index is statement number, starting at 1 */
                 outermost block */
   long endScopeStatementNum;  /* statement of next $} (populated for opening
                                  ${ only, 0 otherwise); g_statements+1 if
-                              we're in outermost block */ /* 24-Aug-2020 nm */
+                              we're in outermost block */
   vstring statementPtr; /* Pointer to end of (unmodified) label section used
              to determine file and line number for error or info messages about
              the statement */
   vstring labelSectionPtr; /* Source code before statement keyword
                  - will be updated if labelSection changed */
   long labelSectionLen;
-  /* 3-May-2017 nm Added labelSectionChanged */
   char labelSectionChanged; /* Default is 0; if 1, labelSectionPtr points to an
                                allocated vstring that must be freed by ERASE */
   vstring mathSectionPtr; /* Source code between keyword and $= or $. */
   long mathSectionLen;
-  /* 3-May-2017 nm Added mathSectionChanged */
   char mathSectionChanged; /* Default is 0; if 1, mathSectionPtr points to an
                                allocated vstring that must be freed by ERASE */
   vstring proofSectionPtr; /* Source code between $= and $. */
   long proofSectionLen;
-  /* 3-May-2017 nm Added proofSectionChanged */
   char proofSectionChanged; /* Default is 0; if 1, proofSectionPtr points to an
                                allocated vstring that must be freed by ERASE */
   nmbrString *mathString; /* Parsed mathSection */
@@ -88,8 +84,7 @@ struct statement_struct { /* Array index is statement number, starting at 1 */
   nmbrString *optDisjVarsA; /* Optional disjoint variables, 1st of pair */
   nmbrString *optDisjVarsB; /* Optional disjoint variables, 2nd of pair */
   nmbrString *optDisjVarsStmt; /* Opt disjoint variables, statem number */
-  long pinkNumber; /* 25-Oct-02 The $a/$p sequence number for web pages */
-  /* 18-Dec-2016 nm */
+  long pinkNumber; /* The $a/$p sequence number for web pages */
   long headerStartStmt; /* # of stmt following previous $a, $p */
   };
 
@@ -137,7 +132,6 @@ extern struct statement_struct *g_Statement;
 /* Warning: mathToken[i] is 0-based, not 1-based! */
 extern struct mathToken_struct *g_MathToken;
 extern long g_statements, /*labels,*/ g_mathTokens;
-/*extern long maxMathTokenLength;*/ /* 15-Aug-2020 nm Not used */
 
 extern long g_MAX_INCLUDECALLS;
 extern struct includeCall_struct *g_IncludeCall;
@@ -146,7 +140,6 @@ extern long g_includeCalls;
 extern char *g_sourcePtr; /* Pointer to buffer in memory with input source */
 extern long g_sourceLen; /* Number of chars. in all inputs files combined (after includes)*/
 
-/* 4-May-2016 nm */
 /* For use by getMarkupFlag() */
 #define PROOF_DISCOURAGED_MARKUP "(Proof modification is discouraged.)"
 #define USAGE_DISCOURAGED_MARKUP "(New usage is discouraged.)"
@@ -167,9 +160,8 @@ extern long g_sourceLen; /* Number of chars. in all inputs files combined (after
 #define GC_ERROR_CHECK_SILENT 8
 #define GC_ERROR_CHECK_PRINT 9
 
-/* 14-May-2017 nm */
-/* TODO: someday we should create structures to hold global vars, and
-   clear their string components in eraseSource() */
+/* 14-May-2017 nm - TODO: someday we should create structures to
+   hold global vars, and clear their string components in eraseSource() */
 extern vstring g_contributorName;
 #define DEFAULT_CONTRIBUTOR "?who?"
 
@@ -219,7 +211,6 @@ extern struct nullPntrStruct g_PntrNull;
 #define NULL_PNTRSTRING &(g_PntrNull.nullElement)
 
 
-/* 26-Apr-2008 nm Added */
 /* This function returns a 1 if any entry in a comma-separated list
    matches using the matches() function. */
 flag matchesList(vstring testString, vstring pattern, char wildCard,
@@ -228,7 +219,6 @@ flag matchesList(vstring testString, vstring pattern, char wildCard,
 /* This function returns a 1 if the first argument matches the pattern of
    the second argument.  The second argument may have 0-or-more and
    exactly-1 character match wildcards, typically '*' and '?'.*/
-/* 30-Jan-06 nm Added single-character-match argument */
 flag matches(vstring testString, vstring pattern, char wildCard,
     char oneCharWildCard);
 
@@ -290,10 +280,9 @@ int nmbrEq(nmbrString *sout,nmbrString *sin);
 vstring nmbrCvtMToVString(nmbrString *s);
 
 /* Converts rString to a vstring with one space between tokens */
-/* 25-Jan-2016 nm Added explicitFormat, statemNum */
 vstring nmbrCvtRToVString(nmbrString *s,
-    flag explicitTargets,    /* 25-Jan-2016 */
-    long statemNum);        /* 25-Jan-2016 */
+    flag explicitTargets,
+    long statemNum);
 
 /* Get step numbers in an rString - needed by cvtRToVString & elsewhere */
 nmbrString *nmbrGetProofStepNumbs(nmbrString *reason);
@@ -484,13 +473,11 @@ void buildDate(long dd, long mmm, long yyyy, vstring *dateStr);
    0 = date1 = date2,  1 = date1 > date2.  There is no error checking. */
 flag compareDates(vstring date1, vstring date2);
 
-/* 17-Nov-2015 nm */
 extern vstring g_qsortKey;
       /* Used by qsortStringCmp; pointer only, do not deallocate */
 /* Comparison function for qsort */
 int qsortStringCmp(const void *p1, const void *p2);
 
-/* 4-May-2017 Ari Ferrera */
 /* Call on exit to free memory */
 void freeData(void);
 

--- a/mmdata.h
+++ b/mmdata.h
@@ -458,26 +458,8 @@ vstring getDescription(long statemNum);
    last removed. */
 vstring getDescriptionAndLabel(long statemNum);
 
-/* Reconstruct the full header from the strings returned by
-   getSectionHeadings() */
-/*** deleted 12-Sep-2020
-vstring buildHeader(vstring header, vstring hdrComment, vstring decoration);
-***/
-
 /* Returns 1 if comment has an "is discouraged" markup tag */
 flag getMarkupFlag(long statemNum, char mode);
-
-/***** deleted 3-May-2017
-/@ Extract any contributors and dates from statement description.
-   If missing, the corresponding return strings are blank. @/
-flag getContrib(long stmtNum,
-    vstring @contributor, vstring @contribDate,
-    vstring @revisor, vstring @reviseDate,
-    vstring @shortener, vstring @shortenDate,
-    vstring @mostRecentDate,
-    flag printErrorsFlag,
-    flag mode /@ 0 == RESET = reset, 1 = normal @/);
-************/
 
 /* Extract any contributors and dates from statement description.
    If missing, the corresponding return string is blank.

--- a/mmhlpa.c
+++ b/mmhlpa.c
@@ -19,10 +19,8 @@
 #include "mmhlpa.h"
 
 /* help0 is mostly for TOOLS help */
-void help0(vstring helpCmd)
-{
+void help0(vstring helpCmd) {
 
-/* 5-Sep-2012 nm */
 vstring saveHelpCmd = "";
 /* help0() may be called with a temporarily allocated argument (left(),
    cat(), etc.), and the let()s in the eventual print2() calls will
@@ -47,20 +45,17 @@ H("  DELETE - Delete a section of each line in a file");
 H("  INSERT - Insert a string at a specified column in each line of a file");
 H("  SUBSTITUTE - Make a simple substitution on each line of the file");
 H("  TAG - Like ADD, but restricted to a range of lines");
-/*H("  LSUBSTITUTE - Substitute according to a match-and-substitute list");*/
 H("  SWAP - Swap the two halves of each line in a file");
 H("Other file processing commands:");
 H("  BREAK - Break up (parse) a file into a list of tokens (one per line)");
 H("  BUILD - Build a file with multiple tokens per line from a list");
 H("  COUNT - Count the occurrences in a file of a specified string");
-/*H("  FORMAT - Produce a formatted list of tokens for documentation");*/
 H("  NUMBER - Create a list of numbers");
 H("  PARALLEL - Put two files in parallel");
 H("  REVERSE - Reverse the order of the lines in a file");
 H("  RIGHT - Right-justify lines in a file (useful before sorting numbers)");
 H("  SORT - Sort the lines in a file with key starting at specified string");
 H("  MATCH - Extract lines containing (or not) a specified string");
-/*H("  LEXTRACT - Extract lines containing (or not) strings from a list");*/
 H("  UNDUPLICATE - Eliminate duplicate occurrences of lines in a file");
 H("  DUPLICATE - Extract first occurrence of any line occurring more than");
 H("      once in a file, discarding lines occurring exactly once");
@@ -69,20 +64,12 @@ H(
 "  (UNDUPLICATE, DUPLICATE, and UNIQUE also sort the lines as a side effect.)");
 H("  UPDATE (deprecated) - Update a C program for revision control");
 H("  TYPE (10 lines) - Display 10 lines of a file; similar to Unix \"head\"");
-/*H("  COPY, RENAME - Similar to Unix cat, mv but with backups created");*/
 H(
 "  COPY - Similar to Unix \"cat\" but safe (same input & output name allowed)");
 H("  SUBMIT - Run a script containing Tools commands.");
 H("");
-/* 3-Jun-2016 nm Reorganize a little */
 H("Command syntax ([] means optional):");
 H("  From TOOLS prompt:  TOOLS> <command> [<arg1> <arg2>...]");
-/*
-if (listMode) {
-H("  From VMS shell:  $ DO TOOLS [<command>] [<arg1> <arg2>...]");
-H("  From Unix/DOS shell:  tools [<command>] [<arg1> <arg2>...]");
-}
-*/
 H("You need to type only as many characters of the command as are needed to");
 H("uniquely specify it.  Any arguments will answer questions automatically");
 H("until the argument list is exhausted; the remaining questions will be");
@@ -92,25 +79,12 @@ H("");
 H("Notes:");
 H("(1) The commands are not case sensitive.  File names and match strings");
 H("are case sensitive.");
-/*
-H("(2) Output files are created only after a command finishes running.");
-H("Therefore it is usually safe to hit ^C before a command is completed.");
-H("(3) The file \"zztools.tmp\", which is always created, can be used as a");
-H("command file to re-run the command sequence with the SUBMIT command.");
-*/
 H("(2) Previous versions of output files (except under VMS) are renamed with");
 H("~1 (most recent), ~2,...,~9 (oldest) appended to file name.  You may want");
 H("to purge them periodically.");
 H("(3) The command B(EEP) will make the terminal beep.  It can be useful to");
 H("type it ahead to let you know when the current command is finished.");
-/*
-H("(6) It is suggested you use a \".tmp\" file extension for intermediate");
-H("results to eliminate directory clutter.");
-*/
 H("");
-/*
-H("Please see NDM if you have any suggestions for this program.");
-*/
 
 
 g_printHelp = !strcmp(saveHelpCmd, "HELP ADD");
@@ -118,7 +92,6 @@ H("This command adds a character string prefix and/or suffix to each");
 H("line in a file.");
 H("Syntax:  ADD <iofile> <begstr> <endstr>");
 
-/* 2-Jul-2011 nm Added TAG command */
 g_printHelp = !strcmp(saveHelpCmd, "HELP TAG");
 H("TAG is the same as ADD but has 4 additional arguments that let you");
 H("specify a range of lines.  Syntax:");
@@ -199,7 +172,6 @@ H("Syntax:  INSERT <iofile> <string> <column>");
 g_printHelp = !strcmp(saveHelpCmd, "HELP BREAK");
 H("This command breaks up a file into tokens, one per line, breaking at");
 H("whitespace and any special characters you specify as delimiters.");
-/* 3-Jul-2020 nm Added: */
 H("Use an explicit (quoted) space as <specchars> to avoid the default");
 H("special characters and break only on whitespace.");
 H("Syntax:  BREAK <iofile> <specchars>");
@@ -380,10 +352,8 @@ return;
 
 
 /* Note: help1 should contain Metamath help */
-void help1(vstring helpCmd)
-{
+void help1(vstring helpCmd) {
 
-/* 5-Sep-2012 nm */
 vstring saveHelpCmd = "";
 /* help1() may be called with a temporarily allocated argument (left(),
    cat(), etc.), and the let()s in the eventual print2() calls will
@@ -452,10 +422,10 @@ H("Some additional CLI-related features are explained by:");
 H("");
 H("    HELP SET ECHO");
 H("    HELP SET SCROLL");
-H("    HELP SET WIDTH");  /* 18-Nov-05 nm Was SCREEN_WIDTH */
-H("    HELP SET HEIGHT"); /* 18-Nov-05 nm New */
+H("    HELP SET WIDTH");
+H("    HELP SET HEIGHT");
 H("    HELP SUBMIT");
-H("    HELP UNDO (or REDO) - in Proof Assistant only");  /* 21-Oct-2016 */
+H("    HELP UNDO (or REDO) - in Proof Assistant only");
 H("");
 
 
@@ -611,7 +581,6 @@ H("       recursive, or self reference to a file is ignored");
 H("");
 
 
-/* 10-Dec-2018 nm */
 g_printHelp = !strcmp(saveHelpCmd, "HELP MARKUP");
 H("(See HELP VERIFY MARKUP for the markup language used in database");
 H("comments.)");
@@ -876,7 +845,6 @@ H("unconditionally.  This means any unsaved work will be lost.");
 H("");
 
 
-/* Added 3-Jun-2018 nm */
 g_printHelp = !strcmp(saveHelpCmd, "HELP _EXIT_PA");
 H("Syntax:  _EXIT_PA [/ FORCE]");
 H("");
@@ -990,7 +958,6 @@ H("to enter this utility, which has its own HELP commands.  Once you are");
 H("inside, EXIT will return to Metamath.");
 H("");
 
-/* 3-May-2017 nm - removed CLEAN qualifier */
 g_printHelp = !strcmp(saveHelpCmd, "HELP WRITE SOURCE");
 H("Syntax:  WRITE SOURCE <filename> [/ FORMAT] [/ REWRAP] [/ SPLIT]");
 H("           [/ KEEP_INCLUDES] [/ NO_VERSIONING]");
@@ -1030,7 +997,6 @@ H("        / NO_VERSIONING is specified) to prevent the possibly confusing");
 H("        source duplication in both the output file and the included file.");
 H("        The / KEEP_INCLUDES qualifier will prevent this deletion.");
 H("    / NO_VERSIONING - Backup files suffixed with ~1 are not created.");
-/* 4-Sep-2020 nm Added EXTRACT */
 H("    / EXTRACT <label-match> - Write to the output file only those");
 H("        statements needed to support and prove the statements matching");
 H("        <label-match>.  See HELP SEARCH for the format of <label-match>.");

--- a/mmhlpb.c
+++ b/mmhlpb.c
@@ -19,7 +19,6 @@
 void help2(vstring helpCmd)
 {
 
-/* 5-Sep-2012 nm */
 vstring saveHelpCmd = "";
 /* help2() may be called with a temporarily allocated argument (left(),
    cat(), etc.), and the let()s in the eventual print2() calls will
@@ -158,9 +157,7 @@ H("");
 
 
 g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW STATEMENT");
-/* 14-Sep-2010 nm Added OLD_TEX */
-H(
-"Syntax:  SHOW STATEMENT <label-match> [/ COMMENT] [/ FULL] [/ TEX]");
+H("Syntax:  SHOW STATEMENT <label-match> [/ COMMENT] [/ FULL] [/ TEX]");
 H("             [/ OLD_TEX] [/ HTML] [/ ALT_HTML] [/ BRIEF_HTML]");
 H("             [/ BRIEF_ALT_HTML] [/ NO_VERSIONING] [/ MNEMONICS]");
 H("");
@@ -183,7 +180,6 @@ H("    / FULL - Show complete information about each statement, and show all");
 H("        statements matching <label> (including $e and $f statements).");
 H("    / TEX - This qualifier will write the statement information to the");
 H("        LaTeX file previously opened with OPEN TEX.");
-/* 14-Sep-2010 nm Added OLD_TEX */
 H("    / OLD_TEX - Same as / TEX, except that LaTeX macros are used to fit");
 H("        equations into line.  This mode is obsolete and will be");
 H("        removed eventually.");
@@ -197,7 +193,6 @@ H("        above, a backup file suffixed with ~1 is not created (i.e. the");
 H("        previous version is overwritten).");
 H("    / TIME - When used with / HTML or the 3 HTML qualifiers, prints");
 H("        the run time used by each statement.");
-/* 12-May-2009 nm  Added MNEMONICS */
 H("    / MNEMONICS - Produces the output file mnemosyne.txt for use with");
 H("        Mnemosyne http://www.mnemosyne-proj.org/principles.php.  Should");
 H("        not be used with any other qualifier.");
@@ -362,14 +357,9 @@ return;
 } /* help2 */
 
 
-/* 18-Jul-2015 nm Split up help2 into help2 and help3 so lcc
-   optimizer wouldn't overflow */
+/* Split up help2 into help2 and help3 so lcc optimizer wouldn't overflow */
+void help3(vstring helpCmd) {
 
-
-void help3(vstring helpCmd)
-{
-
-/* 5-Sep-2012 nm */
 vstring saveHelpCmd = "";
 /* help3() may be called with a temporarily allocated argument (left(),
    cat(), etc.), and the let()s in the eventual print2() calls will
@@ -512,7 +502,7 @@ H("scrolled without pausing.");
 H("");
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET WIDTH"); /* 18-Nov-05 nm Revised */
+g_printHelp = !strcmp(saveHelpCmd, "HELP SET WIDTH");
 H("Syntax:  SET WIDTH <number>");
 H("");
 H("Metamath assumes the width of your screen is 79 characters.  If your");
@@ -530,7 +520,7 @@ H("Note:  This command was SET SCREEN_WIDTH prior to Version 0.07.9.");
 H("");
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET HEIGHT"); /* 18-Nov-05 nm New */
+g_printHelp = !strcmp(saveHelpCmd, "HELP SET HEIGHT");
 H("Syntax:  SET HEIGHT <number>");
 H("");
 H("Metamath assumes your screen height is 24 lines of characters.  If your");
@@ -538,7 +528,6 @@ H("screen is taller or shorter, this command lets you to change the number");
 H("of lines at which the display pauses and prompts you to continue.");
 H("");
 
-/* 10-Jul-2015 nm */
 g_printHelp = !strcmp(saveHelpCmd, "HELP SET DISCOURAGEMENT");
 H("Syntax:  SET DISCOURAGEMENT OFF or SET DISCOURAGEMENT ON");
 H("");
@@ -552,7 +541,6 @@ H("when maintaining \"discouraged\" statements.  SHOW SETTINGS will show you");
 H("the current value.");
 H("");
 
-/* 14-May-2017 nm */
 g_printHelp = !strcmp(saveHelpCmd, "HELP SET CONTRIBUTOR");
 H("Syntax:  SET CONTRIBUTOR <name>");
 H("");
@@ -562,7 +550,6 @@ H("around <name> if it contains spaces.  The current contributor is");
 H("displayed by SHOW SETTINGS.");
 H("");
 
-/* 31-Dec-2017 nm */
 g_printHelp = !strcmp(saveHelpCmd, "HELP SET ROOT_DIRECTORY");
 H("Syntax:  SET ROOT_DIRECTORY <directory path>");
 H("");
@@ -684,14 +671,12 @@ H("    / FILE_SKIP - This qualifier will skip checks that require");
 H("        external files to be present, such as checking GIF existence and");
 H("        bibliographic links to mmset.html or equivalent.  It is useful");
 H("        for doing a quick check from a directory without these files");
-       /* 25-Jun-2020 nm Added UNDERSCORE_SKIP */
 H("    / UNDERSCORE_SKIP - This qualifier will skip warnings for labels");
 H("        containing underscore (\"_\") characters.  Although they are");
 H("        legal per the Metamath spec, they may cause ambiguities with");
 H("        certain translators (such as to MM0) that convert \"-\" to \"_\".");
 H("        bibliographic links to mmset.html or equivalent.  It is useful");
 H("        for doing a quick check from a directory without these files");
-       /* 17-Jul-2020 nm Added MATHBOX_SKIP */
 H("    / MATHBOX_SKIP - This qualifier will skip checking for mathbox");
 H("        independence i.e. that no mathbox proof references a statement");
 H("        in another (earlier) mathbox.");
@@ -908,7 +893,7 @@ H("many UNDOs as were issued since the last proof-changing command.");
 H("");
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET UNDO"); /* 1-Nov-2013 nm */
+g_printHelp = !strcmp(saveHelpCmd, "HELP SET UNDO");
 H("Syntax:  SET UNDO <number>");
 H("");
 H("(This command affects the Proof Assistant only.)");
@@ -924,7 +909,7 @@ H("");
 
 g_printHelp = !strcmp(saveHelpCmd, "HELP ASSIGN");
 H("Syntax:  ASSIGN <step> <label> [/ NO_UNIFY] [/ OVERRIDE]");
-H("         ASSIGN FIRST <label> [/ NO_UNIFY] [/ OVERRIDE]");  /* 11-Dec-05 nm */
+H("         ASSIGN FIRST <label> [/ NO_UNIFY] [/ OVERRIDE]");
 H("         ASSIGN LAST <label> [/ NO_UNIFY] [/ OVERRIDE]");
 H("");
 H("This command, available in the Proof Assistant only, assigns an unknown");
@@ -1162,7 +1147,6 @@ H("");
 g_printHelp = !strcmp(saveHelpCmd, "HELP IMPROVE");
 H("Syntax:  IMPROVE <step> [/ DEPTH <number>] [/ NO_DISTINCT] [/ 2] [/ 3]");
 H("                       [/ SUBPROOFS] [/ INCLUDE_MATHBOXES] [/ OVERRIDE]");
-                              /* 26-Aug-2006 nm */ /* 4-Sep-2012 */
 H("         IMPROVE FIRST [/ DEPTH <number>] [/ NO_DISTINCT] [/ 2] [/ 3]");
 H("                       [/ SUBPROOFS] [/ INCLUDE_MATHBOXES] [/ OVERRIDE]");
 H("         IMPROVE LAST [/ DEPTH <number>] [/ NO_DISTINCT] [/ 2] [/ 3]");
@@ -1230,11 +1214,9 @@ H("    / SUBPROOFS - Look at each subproof that isn't completely known, and");
 H("        try to see if it can be proved independently.  This qualifier is");
 H("        meaningful only for IMPROVE ALL / 2 or IMPROVE ALL / 3.  It may");
 H("        take a very long time to run, especially with / 3.");
-/* 5-Aug-2020 nm - Added INCLUDE_MATHBOXES */
 H("    / INCLUDE_MATHBOXES - By default, MINIMIZE_WITH skips statements");
 H("        beyond the one with label \"mathbox\" and not in the mathbox of");
 H("        the PROVE argument.  This qualifier allows them to be included.");
-/* 3-May-2016 nm - Added OVERRIDE */
 H("    / OVERRIDE - By default, IMPROVE skips statements that have");
 H("        \"(New usage is discouraged.)\" in their description comment.");
 H("        This qualifier tries to use them anyway.");
@@ -1245,31 +1227,11 @@ H("there is no need to specify more than one.  Finally, since / 1 is the");
 H("default, you never need to use it; it is included for completeness (or");
 H("in case the default is changed in the future).");
 H("");
-/*   This seems obsolete now with today's computers.  4-Sep-2012 nm
-H("Note:  If memory is limited, IMPROVE ALL on a large proof may overflow");
-H("memory.  If you use SET UNIFICATION_TIMEOUT 1 before IMPROVE ALL,");
-H("there will usually be sufficient improvement to later easily recover and");
-H("completely IMPROVE the proof on a larger computer.  Warning:  Once");
-H("memory has overflowed, there is no recovery.  If in doubt, save the");
-H("intermediate proof (SAVE NEW_PROOF then WRITE SOURCE) before IMPROVE ALL.");
-H("");
-*/
 H("See also:  HELP SET SEARCH_LIMIT");
 H("");
 
 
 g_printHelp = !strcmp(saveHelpCmd, "HELP MINIMIZE_WITH");
-/*
-H("Syntax:  MINIMIZE_WITH <label-match> [/ BRIEF] [/ ALLOW_GROWTH]");
-H("             [/ NO_DISTINCT] [/ EXCEPT <label-match>]");
-H("              [/ FORBID <label-match>] [/ REVERSE] [/ INCLUDE_MATHBOXES]");
-*/
-/*
-H("Syntax:  MINIMIZE_WITH <label-match> [/ VERBOSE] [/ ALLOW_GROWTH]");
-H("              [/ EXCEPT <label-match>] [/ FORBID <label-match>]");
-H("              [/ INCLUDE_MATHBOXES] [/ NO_NEW_AXIOMS_FROM <label-match>]");
-H("              [/ OVERRIDE] [/ TIME]");
-*/
 H("Syntax:  MINIMIZE_WITH <label-match> [/ VERBOSE] [/ MAY_GROW]");
 H("              [/ EXCEPT <label-match>] [/ INCLUDE_MATHBOXES]");
 H("              [/ ALLOW_NEW_AXIOMS <label-match>]");
@@ -1289,44 +1251,21 @@ H("For ordinary use with set.mm, we recommend running it as follows:");
 H("   MINIMIZE_WITH * / ALLOW_NEW_AXIOMS * / NO_NEW_AXIOMS_FROM ax-*");
 H("For some additional information on the qualifiers see");
 H("    https://groups.google.com/d/msg/metamath/f-L91-1jI24/3KJnGa8qCgAJ");
-/*
-H("  Warning:  MINIMIZE_WITH does not check for $d violations, so");
-H("SAVE PROOF then VERIFY PROOF should be run afterwards to check for them");
-H("if you don't use / NO_DISTINCT.");
-*/
 H("");
 H("Optional qualifiers:");
-/* 4-Feb-2013 nm - Added VERBOSE */
 H("    / VERBOSE - Shows additional information such as uncompressed proof");
 H("        lengths and reverted shortening attempts");
-/* 25-Jun-2014 nm Removed BRIEF, NO_DISTINCT, REVERSE */
-/*
-H("    / BRIEF - The labels of statements that were tested but didn't reduce");
-H("        the proof length will not be listed, for brevity.  (This qualifier");
-H("        is the default and is never needed, but is retained for backwards");
-H("        compatibility with older program versions.)");
-*/
 H("    / MAY_GROW - If a substitution is possible, it will be made even");
 H("        if the proof length increases.  This is useful if we are just");
 H("        updating the proof with a newer version of an obsolete theorem.");
 H("        (Note: this qualifier used to be named / ALLOW_GROWTH).");
-/*
-H("    / NO_DISTINCT - Skip the trial statement if it has a $d requirement.");
-H("        This qualifier is useful when <label-match> has wildcards, to");
-H("        prevent illegal shortenings that would violate $d requirements.");
-*/
-/* 7-Jan-06 nm - Added EXCEPT */
 H("    / EXCEPT <label-match> - Skip trial statements matching <label-match>,");
 H("        which may contain * and ? wildcard characters; see HELP SEARCH");
 H("        for wildcard matching rules.  Note:  Multiple EXCEPT qualifiers");
 H("        are not allowed; use wildcards instead.");
-/* 28-Jun-2011 nm - Added INCLUDE_MATHBOXES */
-/* 14-Aug-2012 nm - Added note about current mathbox */
 H("    / INCLUDE_MATHBOXES - By default, MINIMIZE_WITH skips statements");
 H("        beyond the one with label \"mathbox\" and not in the mathbox of");
 H("        the PROVE argument.  This qualifier allows them to be included.");
-/* 28-Jun-2011 nm - Added INCLUDE_MATHBOXES */
-/* 14-Aug-2012 nm - Added note about current mathbox */
 H("    / ALLOW_NEW_AXIOMS <label-match> - By default, MINIMIZE_WITH skips");
 H("        statements that depend on $a statements not already used by the");
 H("        proof.  This qualifier allows new $a consequences to be used.");
@@ -1335,7 +1274,6 @@ H("        and / NO_NEW_AXIOMS, which take priority over / ALLOW_NEW_AXOMS.");
 H("        Example:  / ALLOW_NEW_AXIOMS df-* will allow new definitions to be");
 H("        used. / ALLOW_NEW_AXIOMS * / NO_NEW_AXIOMS_FROM ax-ac*,ax-reg");
 H("        will allow any new axioms except those matching ax-ac*,ax-reg.");
-/* 22-Nov-2014 nm - Added NO_NEW_AXIOMS_FROM */
 H("    / NO_NEW_AXIOMS_FROM <label-match> - skip any trial statement whose");
 H("        proof depends on a $a statement matching <label-match> but that");
 H("        isn't used by the current proof.  This makes it easier to avoid");
@@ -1346,7 +1284,6 @@ H("        will allow any new axioms except those matching ax-ac*,ax-reg.");
 H("        Notes:  1. In this example, if ax-reg is already used by the proof,");
 H("        statements depending on ax-reg WILL be tried. 2. The use of");
 H("        / NO_NEW_AXIOMS_FROM without / ALLOW_NEW_AXIOMS has no effect.");
-/* 20-May-2013 nm - Added FORBID */
 H("    / FORBID <label-match> - Skip any trial");
 H("        statement whose backtrack (from SHOW TRACE_BACK) contains any");
 H("        statement matching <label-match>.  This is useful for avoiding");
@@ -1358,15 +1295,6 @@ H("        can be less useful than / NO_NEW_AXIOMS_FROM because it will");
 H("        also suppress trying statements that depend on <label-list> axioms");
 H("        already used by the proof.  / FORBID may become deprecated.  2. The");
 H("        use of / FORBID without / ALLOW_NEW_AXIOMS has no effect.");
-/* 10-Nov-2011 nm - Added REVERSE */
-/*
-H("    / REVERSE - Reverse the order of statement scanning.  By default,");
-H("        statements are scanned from last to first, since empirically this");
-H("        usually leads to better results.  With this qualifier they are");
-H("        scanned from first to last.  You may wish to try both ways");
-H("        (from the same starting proof) and choose the shorter result.");
-*/
-/* 3-May-2016 nm - Added OVERRIDE */
 H("    / OVERRIDE - By default, MINIMIZE_WITH skips statements that have");
 H("        \"(New usage is discouraged.)\" in their description comment.");
 H("        With this qualifier it will try to use them anyway.");

--- a/mminou.c
+++ b/mminou.c
@@ -11,11 +11,11 @@
 #include <ctype.h>
 #include <stdarg.h>
 #include <setjmp.h>
-#include <time.h>  /* 16-Aug-2016 nm For ELAPSED_TIME */
+#include <time.h>  /* For ELAPSED_TIME */
 #include "mmvstr.h"
 #include "mmdata.h"
 #include "mminou.h"
-#include "mmcmdl.h" /* 9/3/99 - for g_commandPrompt global */
+#include "mmcmdl.h" /* for g_commandPrompt global */
 
 #ifdef __WATCOMC__
   /* Bugs in WATCOMC:
@@ -47,8 +47,7 @@ long g_commandFileNestingLevel = 0;
 FILE *g_commandFilePtr[MAX_COMMAND_FILE_NESTING + 1];
 vstring g_commandFileName[MAX_COMMAND_FILE_NESTING + 1];
 flag g_commandFileSilent[MAX_COMMAND_FILE_NESTING + 1];
-flag g_commandFileSilentFlag = 0;
-                                   /* 23-Oct-2006 nm For SUBMIT ... /SILENT */
+flag g_commandFileSilentFlag = 0; /* For SUBMIT ... /SILENT */
 
 FILE *g_input_fp; /* File pointers */
 vstring g_input_fn="", g_output_fn="";        /* File names */
@@ -56,7 +55,7 @@ vstring g_input_fn="", g_output_fn="";        /* File names */
 long g_screenWidth = MAX_LEN; /* Width default = 79 */
 /* g_screenHeight is one less than the physical screen to account for the
    prompt line after pausing. */
-long g_screenHeight = SCREEN_HEIGHT; /* Default = 23 */ /* 18-Nov-05 nm */
+long g_screenHeight = SCREEN_HEIGHT; /* Default = 23 */
 int printedLines = 0; /* Lines printed since last user input (mod scrn hght) */
 flag g_scrollMode = 1; /* Flag for continuous (0) or prompted (1) scroll */
 flag g_quitPrint = 0; /* Flag that user quit the output */
@@ -85,7 +84,7 @@ flag print2(char* fmt, ...) {
   /* gcc (Debian 4.9.2-10+deb8u2) 4.9.2 gives error for ssize_t if -c99
      is specified; gcc (GCC) 7.3.0 doesn't complain if -c99 is specified */
   /* See https://sourceforge.net/p/predef/wiki/Compilers/ for __LCC__ */
-#ifdef __LCC__   /* 19-Jun-2020 nm ssize_t not defined for lcc compiler */
+#ifdef __LCC__   /* ssize_t not defined for lcc compiler */
   long bufsiz;
 #else
   ssize_t bufsiz; /* ssize_t (signed size_t) can represent the number -1 for
@@ -275,7 +274,7 @@ flag print2(char* fmt, ...) {
       system to get the `verify proof *' progress bar to display
       progressively (rather than all at once). I've conditionalized it on
       __STDC__, since it should be harmless on any ANSI C system.
-        -- Stephen McCamant  smccam @ uclink4.berkeley.edu 12/9/00
+        -- Stephen McCamant  smccam @ uclink4.berkeley.edu 12-Sep-00
       */
       fflush(stdout);
 #endif
@@ -371,7 +370,7 @@ flag print2(char* fmt, ...) {
 /* Special:  if breakMatch is \, then put % at end of previous line for LaTeX*/
 /* Special:  if breakMatch is " (quote), treat as if space but don't break
              quotes, and also let lines grow long - use this call for all HTML
-             code */ /* Added 10/14/02 */
+             code */
 void printLongLine(vstring line, vstring startNextLine, vstring breakMatch)
 {
   vstring longLine = "";
@@ -435,7 +434,7 @@ void printLongLine(vstring line, vstring startNextLine, vstring breakMatch)
   /* Whenever we are inside of a quote, we change a space to ASCII 3 to
      prevent matching it.  The reverse is done in the print2() function,
      where all ASCII 3's are converted back to space. */
-  /* Note added 10/20/02: tidy.exe breaks HREF quotes with new line.
+  /* Note added 20-Oct-02: tidy.exe breaks HREF quotes with new line.
      Check HTML spec - do we really need this code? */
   j = (long)strlen(multiLine);
   /* Do a bug check to make sure no real ASCII 3's are ever printed */
@@ -1180,9 +1179,7 @@ vstring fGetTmpName(vstring filePrefix)
     let(&fname, cat(filePrefix, str((double)counter), ".tmp", NULL));
     fp = fopen(fname, "r");
     if (!fp) break;
-
-    /* Fix resource leak reported by David Binderman 10-Oct-2016 */
-    fclose(fp);  /* 10-Oct-2016 nm */
+    fclose(fp);
 
     if (counter > 1000) {
       print2("?Warning: too many %snnn.tmp files - will reuse %s\n",
@@ -1322,7 +1319,7 @@ vstring readFileToString(vstring fileName, char verbose, long *charCount) {
       i++;
       j++;
     }
-    (*charCount) = i - 1; /* nm 6-Feb-04 */
+    (*charCount) = i - 1;
   }
 
   /* Make sure the last line is not a partial line */
@@ -1336,7 +1333,7 @@ vstring readFileToString(vstring fileName, char verbose, long *charCount) {
     fileBuf[(*charCount)] = 0;
   }
 
-  if (fileBuf[(*charCount)] != 0) {  /* nm 6-Feb-04 */
+  if (fileBuf[(*charCount)] != 0) {
     bug(1522); /* Keeping track of charCount went wrong somewhere */
   }
 

--- a/mminou.h
+++ b/mminou.h
@@ -30,23 +30,13 @@ extern flag g_commandFileSilent[MAX_COMMAND_FILE_NESTING + 1];
 extern flag g_commandFileSilentFlag;
                                     /* 23-Oct-2006 nm For SUBMIT ... /SILENT */
 
-extern FILE /* *inputDef_fp,*/ *g_input_fp /*,*g_output_fp*/;  /* File pointers */
-                             /* 31-Dec-2017 nm g_output_fp deleted */
-extern vstring /* inputDef_fn,*/ g_input_fn, g_output_fn;  /* File names */
-
-/* 19-Jun-2020 nm No longer needed since printBuffer is now dynamically
-   allocated. */
-/*****************************
-/@ PRINTBUFFERSIZE should be at least as long as the longest string we
-   expect (an unfortunate, dangerous limitation of C?) - although if >79
-   chars are output on a line bug #1505 warning will occur @/
-#define PRINTBUFFERSIZE 10001
-**********************************/
+extern FILE *g_input_fp;  /* File pointers */
+extern vstring g_input_fn, g_output_fn;  /* File names */
 
 /* Warning:  never call print2 with string longer than PRINTBUFFERSIZE - 1 */
 /* print2 returns 0 if the user has quit the printout. */
 flag print2(char* fmt,...);
-extern long g_screenHeight; /* Height of screen */ /* 18-Nov-05 nm Added */
+extern long g_screenHeight; /* Height of screen */
 extern long g_screenWidth; /* Width of screen */
 #define MAX_LEN 79 /* Default width of screen */
 #define SCREEN_HEIGHT 23 /* Lines on screen, minus 1 to account for prompt */
@@ -84,13 +74,12 @@ vstring fGetTmpName(vstring filePrefix);
 /* 31-Dec-2017 nm Add charCount return argument */
 vstring readFileToString(vstring fileName, char verbose, long *charCount);
 
-/* 16-Aug-2016 nm */
 /* Returns total elapsed time in seconds since starting session (for the
    lcc compiler) or the CPU time used (for the gcc compiler).  The
    argument is assigned the time since the last call to this function. */
 double getRunTime(double *timeSinceLastCall);
 
 /* Call before exiting to free memory allocated by this module */
-void freeInOu(void); /* 4-May-2017 Ari Ferrera */
+void freeInOu(void);
 
 #endif /* METAMATH_MMINOU_H_*/

--- a/mminou.h
+++ b/mminou.h
@@ -27,8 +27,7 @@ extern long g_commandFileNestingLevel;
 extern FILE *g_commandFilePtr[MAX_COMMAND_FILE_NESTING + 1];
 extern vstring g_commandFileName[MAX_COMMAND_FILE_NESTING + 1];
 extern flag g_commandFileSilent[MAX_COMMAND_FILE_NESTING + 1];
-extern flag g_commandFileSilentFlag;
-                                    /* 23-Oct-2006 nm For SUBMIT ... /SILENT */
+extern flag g_commandFileSilentFlag; /* For SUBMIT ... /SILENT */
 
 extern FILE *g_input_fp;  /* File pointers */
 extern vstring g_input_fn, g_output_fn;  /* File names */
@@ -71,7 +70,6 @@ vstring fGetTmpName(vstring filePrefix);
    MUST DEALLOCATE THE RETURNED STRING.  If a NULL is returned, the file
    could not be opened or had a non-ASCII Unicode character or some other
    problem.   If verbose is 0, error and warning messages are suppressed. */
-/* 31-Dec-2017 nm Add charCount return argument */
 vstring readFileToString(vstring fileName, char verbose, long *charCount);
 
 /* Returns total elapsed time in seconds since starting session (for the

--- a/mmpars.c
+++ b/mmpars.c
@@ -940,7 +940,7 @@ void parseStatements(void) {
             /* Not really an out-of-memory situation, but use the error msg. */
         /* Note that g_Statement[stmt].beginScopeStatementNum for this ${
            points to the previous ${ (or 0 if in outermost scope) */
-        beginScopeStmtNum = stmt; /* 24-Aug-2020 nm */
+        beginScopeStmtNum = stmt;
         /* Note that g_Statement[stmt].endScopeStatementNum for this ${
            will be assigned in the rb_ case below. */
         break;
@@ -1037,10 +1037,9 @@ void parseStatements(void) {
             }
             for (j = lowerKey; j <= upperKey; j++) {
               if (g_MathToken[g_mathKey[j]].active) {
-                /* 18-Jun-2011 nm Detect conflicting active vars declared
+                /* Detect conflicting active vars declared
                    in multiple scopes */
                 if (g_MathToken[g_mathKey[j]].scope <= g_currentScope) {
-                /* if (g_MathToken[g_mathKey[j]].scope == g_currentScope) { bad */
                   mathTokenError(i, nmbrTmpPtr, stmt,
                       "This symbol has already been declared in this scope.");
                 }
@@ -1966,7 +1965,7 @@ char parseProof(long statemNum)
   flag subProofMoved; /* Flag to restart scan after moving subproof */
 
   if (g_Statement[statemNum].type != p_) {
-    bug(1723); /* 13-Oct-05 nm - should never get here */
+    bug(1723); /* should never get here */
     g_WrkProof.errorSeverity = 4;
     return 4; /* Do nothing if not $p */
   }
@@ -2220,7 +2219,7 @@ char parseProof(long statemNum)
     if (voidPtr) { /* It was found */
       j = ( (struct sortHypAndLoc *)voidPtr)->labelTokenNum; /* Statement number */
       if (!g_WrkProof.errorCount) {
-        assignStmtFileAndLineNum(j); /* 9-Jan-2018 nm */
+        assignStmtFileAndLineNum(j);
         sourceError(fbPtr, tokLength, statemNum,cat(
             "The local label at proof step ",
             str((double)(g_WrkProof.numSteps + 1)),
@@ -2461,7 +2460,7 @@ char parseProof(long statemNum)
               " is the label of this statement.  A statement may not be used to",
               " prove itself.",NULL));
         } else {
-          assignStmtFileAndLineNum(j); /* 9-Jan-2018 nm */
+          assignStmtFileAndLineNum(j);
           sourceError(fbPtr, tokLength, statemNum, cat(
               "The label \"", g_Statement[j].labelName, "\" at proof step ",
               str((double)step + 1),
@@ -2819,7 +2818,7 @@ char parseCompressedProof(long statemNum)
   static long lettersLen;
   static long digitsLen;
 
-  /* 15-Oct-05 nm - Used to detect old buggy compression */
+  /* Used to detect old buggy compression */
   long bggyProofLen;
   char bggyZapSave;
   flag bggyAlgo;
@@ -3080,7 +3079,7 @@ char parseCompressedProof(long statemNum)
              " is the label of this statement.  A statement may not be used to",
               " prove itself.",NULL));
         } else {
-          assignStmtFileAndLineNum(j); /* 9-Jan-2018 nm */
+          assignStmtFileAndLineNum(j);
           sourceError(fbPtr, tokLength, statemNum, cat(
               "The label \"", g_Statement[j].labelName, "\" at proof step ",
               str((double)step + 1),
@@ -3268,7 +3267,6 @@ char parseCompressedProof(long statemNum)
 
         hypLocUnkFlag = 0;
 
-        /* 21-Mar-06 nm Fix bug reported by o'cat */
         if (g_WrkProof.numSteps == 0) {
           /* This will happen if labelChar (Z) is in 1st char pos of
              compressed proof */
@@ -3782,7 +3780,7 @@ long whiteSpaceLen(char *ptr) {
 } /* whiteSpaceLen */
 
 
-/* 31-Dec-2017 nm For .mm file splitting */
+/* For .mm file splitting */
 /* This function is like whiteSpaceLen() except that comments are NOT
    considered white space.  ptr should point to the first character
    of the white space.  If ptr does not point to a white space character, 0
@@ -3863,7 +3861,7 @@ long rawTokenLen(char *ptr)
    character of the token.  If ptr points to a white space character, 0
    is returned.  If ptr points to a null character, 0 is returned.  If ptr
    points to a keyword, 0 is returned.  A keyword ends a token.
-   ":" and "?" and "(" and ")" and "=" (25-Jan-2016) are considered tokens. */
+   ":" and "?" and "(" and ")" and "=" are considered tokens. */
 long proofTokenLen(char *ptr)
 {
   long i = 0;
@@ -3933,7 +3931,7 @@ long countLines(vstring start, long length) {
 /* Note that the labelSection, mathSection, and proofSection do not
    contain keywords ($a, $p,...; $=; $.).  The keywords are added
    by this function when the statement is written. */
-/* 31-Dec-2020 nm This must be called in sequence for all statements,
+/* This must be called in sequence for all statements,
    since the previous statement is needed to populate dollarDpos
    and previousType */
 vstring outputStatement(long stmt, flag reformatFlag) {

--- a/mmpars.h
+++ b/mmpars.h
@@ -10,8 +10,7 @@
 #include "mmvstr.h"
 #include "mmdata.h"
 
-char *readRawSource(/*vstring inputFn,*/ /* 2-Feb-2018 nm Unused argument */
-    vstring inputBuf, long *size);
+char *readRawSource(vstring inputBuf, long *size);
 void parseKeywords(void);
 void parseLabels(void);
 void parseMathDecl(void);
@@ -20,9 +19,7 @@ char parseProof(long statemNum);
 char parseCompressedProof(long statemNum);
 nmbrString *getProof(long statemNum, flag printFlag);
 
-void rawSourceError(char *startFile, char *ptr, long tokenLen,
-    /*long lineNum,*/                       /* 2-Feb-2018 nm */
-    /*vstring fileName,*/ vstring errMsg);  /* 2-Feb-2018 nm */
+void rawSourceError(char *startFile, char *ptr, long tokenLen, vstring errMsg);
 void sourceError(char *ptr, long tokenLen, long stmtNum, vstring errMsg);
 void mathTokenError(long tokenNum /* 0 is 1st one */,
     nmbrString *tokenList, long stmtNum, vstring errMsg);
@@ -52,7 +49,7 @@ int hypAndLocSrchCmp(const void *key, const void *data);
    is returned.  If ptr points to a null character, 0 is returned. */
 long whiteSpaceLen(char *ptr);
 
-/* 31-Dec-2017 nm For .mm file splitting */
+/* For .mm file splitting */
 /* Like whiteSpaceLen except comments are not whitespace */
 long rawWhiteSpaceLen(char *ptr);
 
@@ -78,7 +75,6 @@ long rawTokenLen(char *ptr);
    ":" is considered a token. */
 long proofTokenLen(char *ptr);
 
-/* 9-Jan-2018 nm */
 /* Counts the number of \n between start for length chars.
    If length = -1, then use end-of-string 0 to stop.
    If length >= 0, then scan at most length chars, but stop
@@ -143,18 +139,15 @@ extern struct wrkProof_struct g_WrkProof;
    provides the context for the parse (to get correct active symbols) */
 nmbrString *parseMathTokens(vstring userText, long statemNum);
 
-/* 12-Jun-2011 nm Added reformatFlag */
 vstring outputStatement(long stmt, /*flag cleanFlag,*/ flag reformatFlag);
-/* 12-Jun-2011 nm */
 /* Caller must deallocate return string */
 vstring rewrapComment(vstring comment);
 
-/* 10/10/02 */
 /* Lookup $a or $p label and return statement number.
    Return -1 if not found. */
 long lookupLabel(vstring label);
 
-/* 31-Dec-2017 nm For file splitting */
+/* For file splitting */
 
 /* Get the next real $[...$] or virtual $( Begin $[... inclusion */
 void getNextInclusion(char *fileBuf, long startOffset, /* inputs */
@@ -173,7 +166,6 @@ void getNextInclusion(char *fileBuf, long startOffset, /* inputs */
    to a linear buffer in preparation for creating the output file. */
 vstring writeSourceToBuffer(void);
 
-/* 31-Dec-2017 nm */
 /* This function creates split files containing $[ $] inclusions, from
    a nonsplit source with $( Begin $[... etc. inclusions */
 /* Note that *fileBuf is assigned to the empty string upon return, to
@@ -186,7 +178,6 @@ void writeSplitSource(vstring *fileBuf, vstring fileName,
    to ~1) since their content will be in the main output file. */
 void deleteSplits(vstring *fileBuf, flag noVersioningFlag);
 
-/* 9-Jan-2018 nm */
 /* Get file name and line number given a pointer into the read buffer */
 /* The user must deallocate the returned string (file name) */
 /* The globals includeCall structure and includeCalls are used */
@@ -194,7 +185,6 @@ vstring getFileAndLineNum(vstring buffPtr/*start of read buffer*/,
     vstring currentPtr/*place at which to get file name and line no*/,
     long *lineNum/*return argument*/);
 
-/* 9-Jan-2018 nm */
 /* statement[stmtNum].fileName and .lineNum are initialized to "" and 0.
    To save CPU time, they aren't normally assigned until needed, but once
    assigned they can be reused without looking them up again.  This function

--- a/mmpfas.c
+++ b/mmpfas.c
@@ -20,7 +20,6 @@
 #include "mmpars.h"
 #include "mmunif.h"
 #include "mmpfas.h"
-/* For mathbox stuff: */ /* 5-Aug-2020 nm */
 #include "mmwtex.h"
 
 /* Allow user to define INLINE as "inline".  lcc doesn't support inline. */
@@ -35,7 +34,7 @@ flag g_proofChangedFlag; /* Flag to push 'undo' stack - global */
 /* 11-Dec-2010 nm Changed from 10000 to 25000 to accomodate df-plig in set.mm
    (which needs >= 23884 to generate with 'show statement / html'). */
 /* g_userMaxProveFloat can be overridden by user with SET SEARCH_LIMIT */
-long g_userMaxProveFloat = /*10000*/ 50000; /* Upper limit for proveFloating */
+long g_userMaxProveFloat = 50000; /* Upper limit for proveFloating */
 
 long g_dummyVars = 0; /* Total number of dummy variables declared */
 long g_pipDummyVars = 0; /* Number of dummy variables used by proof in progress */
@@ -150,11 +149,9 @@ void interactiveMatch(long step, long maxEssential)
   }
 
   let(&tmpStr1, nmbrCvtRToVString(matchList,
-                /* 25-Jan-2016 nm */
                 0, /*explicitTargets*/
                 0 /*statemNum, used only if explicitTargets*/));
   let(&tmpStr4, nmbrCvtRToVString(timeoutList,
-                /* 25-Jan-2016 nm */
                 0, /*explicitTargets*/
                 0 /*statemNum, used only if explicitTargets*/));
 
@@ -271,9 +268,7 @@ nmbrString *proveByReplacement(long prfStmt,
     flag dummyVarFlag, /* 0 means no dummy vars are in prfStmt */
     flag searchMethod, /* 1 means to try proveFloating on $e's also */
     long improveDepth, /* depth for proveFloating() */
-    /* 3-May-2016 nm */
     flag overrideFlag, /* 1 means to override usage locks */
-    /* 5-Aug-2020 nm */
     flag mathboxFlag
     )
 {
@@ -281,21 +276,19 @@ nmbrString *proveByReplacement(long prfStmt,
   long trialStmt;
   nmbrString *prfMath;
   nmbrString *trialPrf = NULL_NMBRSTRING;
-  long prfMbox; /* 5-Aug-2020 nm */
+  long prfMbox;
 
   prfMath = (g_ProofInProgress.target)[prfStep];
-  prfMbox = getMathboxNum(prfStmt); /* 5-Aug-2020 nm */
+  prfMbox = getMathboxNum(prfStmt);
   for (trialStmt = 1; trialStmt < prfStmt; trialStmt++) {
 
     if (quickMatchFilter(trialStmt, prfMath, dummyVarFlag) == 0) continue;
 
-    /* 3-May-2016 nm */
     /* Skip statements with discouraged usage (the above skips non-$a,p) */
     if (overrideFlag == 0 && getMarkupFlag(trialStmt, USAGE_DISCOURAGED)) {
       continue;
     }
 
-    /* 5-Aug-2020 nm */
     /* Skip statements in other mathboxes unless /INCLUDE_MATHBOXES.  (We don't
        care about the first mathbox since there are no others above it.) */
     if (mathboxFlag == 0 && prfMbox >= 2) {
@@ -320,13 +313,12 @@ nmbrString *proveByReplacement(long prfStmt,
         noDistinct,
         searchMethod,
         improveDepth,
-        overrideFlag,  /* 3-May-2016 nm */
-        mathboxFlag /* 1 means allow mathboxes */ /* 5-Aug-2020 nm */
+        overrideFlag,
+        mathboxFlag /* 1 means allow mathboxes */
         );
     if (nmbrLen(trialPrf) > 0) {
       /* A proof for the step was found. */
 
-      /* 3-May-2016 nm */
       /* Inform user that we're using a statement with discouraged usage */
       if (overrideFlag == 1 && getMarkupFlag(trialStmt, USAGE_DISCOURAGED)) {
         /* print2("\n"); */ /* Enable for more emphasis */
@@ -338,8 +330,8 @@ nmbrString *proveByReplacement(long prfStmt,
 
       return trialPrf;
     }
+    /* Don't need to do this because it is already null */
     /* nmbrLet(&trialPrf, NULL_NMBRSTRING); */
-                       /* Don't need to do this because it is already null */
   }
   return trialPrf;  /* Proof not found - return empty proof */
 }
@@ -352,7 +344,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
     flag noDistinct, /* 1 means proveFloating won't try statements with $d's */
     flag searchMethod, /* 1 means to try proveFloating on $e's also */
     long improveDepth, /* Depth for proveFloating */
-    /* 3-May-2016 nm */
     flag overrideFlag,  /* 1 means to override statement usage locks */
     flag mathboxFlag /* 1 means allow mathboxes */ /* 5-Aug-2020 nm */
     ) {
@@ -386,17 +377,14 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
   nmbrString *hypTestPtr; /* Points to what we are testing hyp. against */
   flag hypOrSubproofFlag; /* 0 means testing against hyp., 1 against proof*/
   vstring indepKnownSteps = ""; /* 'Y' = ok to try step; 'N' = not ok */
-                                                 /* 22-Aug-2012 nm */
-  long pfLen;          /* 22-Aug-2012 nm */
-  long scanLen;         /* 22-Aug-2012 nm */
-  long scanUpperBound;  /* 22-Aug-2012 nm */
-  long scanLowerBound;  /* 22-Aug-2012 nm */
+  long pfLen;
+  long scanLen;
+  long scanUpperBound;
+  long scanLowerBound;
   vstring hasFloatingProof = "";  /* 'N' or 'Y' for $e hyps */
-                                                            /* 4-Sep-2012 nm */
-  vstring tryFloatingProofLater = "";  /* 'N' or 'Y' */     /* 4-Sep-2012 nm */
+  vstring tryFloatingProofLater = "";  /* 'N' or 'Y' */
   flag hasDummyVar;     /* 4-Sep-2012 nm */
 
-  /* 3-May-2016 nm */
   /* If we are overriding discouraged usage, a warning has already been
      printed.  If we are not, then we should never get here. */
   if (overrideFlag == 0 && getMarkupFlag(replStatemNum, USAGE_DISCOURAGED)) {
@@ -421,7 +409,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
        existing proof will be scanned to see if there is a match to
        the $e hypotheses of the replacement statement.  */
     pfLen = nmbrLen(g_ProofInProgress.proof);
-    /* scanLen = pfLen; */ /* 28-Sep-2013 never used */
     scanUpperBound = pfLen - 1;  /* Last proof step (0=1st step, 1=2nd, etc. */
     scanLowerBound = 0; /* scanUpperBound - scanLen + 1;  */
   }
@@ -436,8 +423,8 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
   reqVars = nmbrLen(g_Statement[replStatemNum].reqVarList);
 
   /* hasFloatingProof is used only when searchMethod=1 */
-  let(&hasFloatingProof, string(schReqHyps, ' ')); /* 4-Sep-2012 nm Init */
-  let(&tryFloatingProofLater, string(schReqHyps, ' ')); /* 4-Sep-2012 nm Init */
+  let(&hasFloatingProof, string(schReqHyps, ' '));
+  let(&tryFloatingProofLater, string(schReqHyps, ' '));
   replStmtSchemePtr = g_Statement[replStatemNum].mathString;
   replStmtSchemeLen = nmbrLen(replStmtSchemePtr);
 
@@ -491,7 +478,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
     }
   }
 
-  /* 9/2/99 - Speedup - sort essential hyp's according to decreasing length to
+  /* Speedup - sort essential hyp's according to decreasing length to
      maximize the chance of early rejection */
   for (hyp = 0; hyp < schEHyps; hyp++) {
     /* Bubble sort - but should be OK for typically small # of hyp's */
@@ -507,7 +494,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
   /* If we are just scanning the subproof, all subproof steps are independent,
      so the getIndepKnownSteps scan would be redundant. */
   if (!subProofFlag) {
-    /* 22-Aug-2012 nm - if subProofFlag is not set, we scan the whole proof,
+    /* If subProofFlag is not set, we scan the whole proof,
        not just the subproof starting at prfStep, to find additional possible
        matches. */
     /* Get a list of the possible steps to look at that are not dependent
@@ -540,8 +527,8 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
     tmpFlag = unifyH(scheme, prfMath, &stateVector, reEntryFlag);
     if (!tmpFlag) break; /* (Next) unification not possible */
     if (tmpFlag == 2) {
-      print2(
-"Unification timed out.  Larger SET UNIFICATION_TIMEOUT may improve results.\n");
+      print2("Unification timed out.  "
+        "Larger SET UNIFICATION_TIMEOUT may improve results.\n");
       g_unifTrialCount = 1; /* Reset unification timeout */
       break; /* Treat timeout as if unification not possible */
     }
@@ -562,8 +549,8 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
           stateVector);
 
       /* Initially, a $e has no proveFloating proof */
-      hasFloatingProof[hyp] = 'N';  /* Init for this pass */ /* 4-Sep-2012 nm */
-      tryFloatingProofLater[hyp] = 'N'; /* Init for this pass */ /* 4-Sep-2012 nm */
+      hasFloatingProof[hyp] = 'N';  /* Init for this pass */
+      tryFloatingProofLater[hyp] = 'N'; /* Init for this pass */
 
       /* Make substitutions from each earlier hypothesis unification */
       for (i = 0; i < hyp; i++) {
@@ -576,7 +563,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
            we don't want to make substitutions since it has no
            stateVector.  (This is the only place we look
            at hasFloatingProof.) */
-        if (hasFloatingProof[i] == 'Y') continue;  /* 4-Sep-2012 nm */
+        if (hasFloatingProof[i] == 'Y') continue;
 
         makeSubstPtr = makeSubstUnif(&dummyVarFlag,
             hypMakeSubstList[hypSortMap[hyp]],
@@ -589,21 +576,11 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
       if (hyp < schEHyps) {
         /* It's a $e hypothesis */
         if (g_Statement[g_Statement[replStatemNum].reqHypList[hypSortMap[hyp]]
-            ].type != (char)e_) bug (1823);
+            ].type != (char)e_) bug(1823);
       } else {
         /* It's a $f hypothesis */
         if (g_Statement[g_Statement[replStatemNum].reqHypList[hypSortMap[hyp]]
              ].type != (char)f_) bug(1824);
-        /* At this point there should be no dummy variables in $f
-           hypotheses */
-        /* 22-Aug-2012 nm This can now occur with new algorithm.  For now,
-           let it continue; I'm not sure if there are adverse side effects. */
-        /*
-        if (dummyVarFlag) {
-          printSubst(stateVector);
-          bug(1825);
-        }
-        */
       }
 
 
@@ -632,7 +609,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
         if (hypReEntryFlagList[hypSortMap[hyp]] == 1) {
           /* Start at the beginning of the proof */
           /* trialStep = prfStep - subPfLen + 1; */ /* obsolete */
-          trialStep = scanLowerBound;   /* 22-Aug-2012 nm */
+          trialStep = scanLowerBound;
           /* Later enhancement:  start at required hypotheses */
           /* (Here we use the trick of shifting down the starting
               trialStep to below the real subproof start) */
@@ -645,7 +622,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
                call again. */
             hypReEntryFlagList[hypSortMap[hyp]] = 1;
             reenterFFlag = 1; /* Skip proveFloating call */
-            /*trialStep = prfStep;  old */ /* Skip loop */
             trialStep = scanUpperBound; /* Skip loop */
           } else {
             bug(1826);
@@ -653,49 +629,26 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
         }
       }
 
-      /* for (trialStep = trialStep; trialStep < prfStep; trialStep++) { old */
       for (trialStep = trialStep + 0; trialStep < scanUpperBound;
-          trialStep++) {                             /* 22-Aug-2012 nm */
+          trialStep++) {
         /* Note that step scanUpperBound is not scanned since that is
            the statement we want to replace (subProofFlag = 1) or the
            last statement of the proof (subProofFlag = 0), neither of
            which would be useful for a replacement step subproof. */
 
-        /* if (trialStep < prfStep - subPfLen + 1) { */ /* obsolete */
-        if (trialStep < scanLowerBound) {  /* 22-Aug-2012 nm */
+        if (trialStep < scanLowerBound) {
           /* We're scanning required hypotheses */
           hypOrSubproofFlag = 0;
           /* Point to what we are testing hyp. against */
           /* (Note offset to trialStep needed to compensate for trick) */
           hypTestPtr =
               g_Statement[g_Statement[provStmtNum].reqHypList[
-              /* trialStep - (prfStep - subPfLen + 1 - reqHyps)]].mathString;*/
               trialStep - (scanLowerBound - reqHyps)]].mathString;
-                                                           /* 22-Aug-2012 nm */
         } else {
           /* We're scanning the subproof */
           hypOrSubproofFlag = 1;
           /* Point to what we are testing hyp. against */
           hypTestPtr = (g_ProofInProgress.target)[trialStep];
-
-          /* Do not consider unknown subproof steps or those with
-             unknown variables */
-          /* Break flag */
-/***** obsolete  22-Aug-2012 nm - the new IMPROVE allows non-shared dummy
-       vars - but we'll keep the commented-out code for a while in case
-       it's needed for debugging
-          j = 0;
-          i = nmbrLen(hypTestPtr);
-          if (i == 0) bug(1824);
-          for (i = i - 1; i >= 0; i--) {
-            if (((nmbrString *)hypTestPtr)[i] >
-                g_mathTokens) {
-              j = 1;
-              break;
-            }
-          }
-          if (j) continue;
-*******/
 
           /* Subproof step has dummy var.; don't use it */
           if (!subProofFlag) {
@@ -765,7 +718,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
                  replacement hypothesis having this situation.) */
               /* trialStep = prfStep - 1;  old version */
               trialStep = scanUpperBound - 1;
-                       /* Make this the last loop pass */  /* 22-Aug-2012 nm */
+                       /* Make this the last loop pass */
             }
           }
 
@@ -780,21 +733,14 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
           /* If this subproof step has previously occurred in a hypothesis
              or an earlier subproof step, don't consider it since that
              would be redundant. */
-          if (hypReEntryFlagList[hypSortMap[hyp]] == 1
-              /* && 0 */  /* To skip this for testing */
-              ) {
+          if (hypReEntryFlagList[hypSortMap[hyp]] == 1) {
             j = 0; /* Break flag */
-            /*for (i = prfStep - subPfLen + 1 - reqHyps; i < trialStep; i++) {*/
             for (i = scanLowerBound - reqHyps; i < trialStep; i++) {
-                                                            /* 22-Aug-2012 nm */
-              /* if (i < prfStep - subPfLen + 1) { */
-              if (i < scanLowerBound) { /* 22-Aug-2012 nm */
+              if (i < scanLowerBound) {
                 /* A required hypothesis */
                 if (nmbrEq(hypTestPtr,
                     g_Statement[g_Statement[provStmtNum].reqHypList[
-                    /*i - (prfStep - subPfLen + 1 - reqHyps)]].mathString)) { */
                     i - (scanLowerBound - reqHyps)]].mathString)) {
-                                                           /* 22-Aug-2012 nm */
                   j = 1;
                   break;
                 }
@@ -827,8 +773,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
             nmbrLet((nmbrString **)(&hypProofList[hypSortMap[hyp]]),
                 nmbrAddElement(NULL_NMBRSTRING,
                 g_Statement[provStmtNum].reqHypList[
-                /* trialStep - (prfStep - subPfLen + 1 - reqHyps)])); */
-                trialStep - (scanLowerBound - reqHyps)])); /* 22-Aug-2012 nm */
+                trialStep - (scanLowerBound - reqHyps)]));
           } else {
             /* We're scanning the subproof */
             i = subproofLen(g_ProofInProgress.proof, trialStep);
@@ -858,10 +803,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
         /* (However, if this is 2nd pass of backtrack, i.e. reenterFFlag is
            set, we already got an exact $f match earlier and don't need this
            scan, and shouldn't do it to prevent inf. loop.) */
-        /* if (hyp >= schEHyps */   /* old */
-        if ((hyp >= schEHyps || searchMethod == 1) /* 4-Sep-2012 */
-             && !reenterFFlag
-             /*&& !hasDummyVar*/) { /* 25-Aug-2012 nm (Do we need this?) */
+        if ((hyp >= schEHyps || searchMethod == 1) && !reenterFFlag) {
           /* It's a $f hypothesis, or any hypothesis when searchMethod=1 */
           if (hasDummyVar) {
             /* If it's a $f and we have dummy vars, that is bad so we leave
@@ -886,8 +828,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
             hypProofPtr =
                 proveFloating(hypMakeSubstList[hypSortMap[hyp]],
                     provStmtNum, improveDepth, prfStep, noDistinct,
-                    overrideFlag, mathboxFlag /* 5-Aug-2020 nm */
-                    );
+                    overrideFlag, mathboxFlag);
             g_unifTrialCount = saveUnifTrialCount; /* Restore unif. timeout */
             if (nmbrLen(hypProofPtr)) { /* Proof was found */
               nmbrLet((nmbrString **)(&hypProofList[hypSortMap[hyp]]),
@@ -896,7 +837,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
               foundTrialStepMatch = 1;
               hypReEntryFlagList[hypSortMap[hyp]] = 3;
               /* Set flag so that we won't attempt subst. on $e w/ float prf */
-              hasFloatingProof[hyp] = 'Y'; /* 4-Sep-2012 */
+              hasFloatingProof[hyp] = 'Y';
             }
           }
         } /* end if $f, or $e and searchMethod 1 */
@@ -940,9 +881,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
             hypProofPtr =
                 proveFloating(hypMakeSubstList[hypSortMap[i]],
                     provStmtNum, improveDepth, prfStep, noDistinct,
-                    overrideFlag,  /* 3-May-2016 nm */
-                    mathboxFlag /* 5-Aug-2020 nm */
-                    );
+                    overrideFlag, mathboxFlag);
             g_unifTrialCount = saveUnifTrialCount; /* Restore unif. timeout */
             if (nmbrLen(hypProofPtr)) { /* Proof was found */
               nmbrLet((nmbrString **)(&hypProofList[hypSortMap[i]]),
@@ -951,7 +890,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
               foundTrialStepMatch = 1;
               hypReEntryFlagList[hypSortMap[i]] = 3;
               /* Set flag so that we won't attempt subst. on $e w/ float prf */
-              hasFloatingProof[i] = 'Y'; /* 4-Sep-2012 */
+              hasFloatingProof[i] = 'Y';
             } else {   /* Proof not found */
               foundTrialStepMatch = 0; /* Force backtrack */
               /* If we don't have a proof at this point, we didn't save
@@ -967,7 +906,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
       if (!foundTrialStepMatch) {
         /* We must backtrack */
 
-        /* 16-Sep-2012 nm fix infinite loop under weird conditions */
         /* Backtrack through all of postponed hypotheses with
            dummy variables whose proof wasn't found yet.  If we
            don't do this, we could end up with an infinite loop since we
@@ -1019,10 +957,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
 
  returnPoint:
 
-  /* 25-Jun-2014 nm This was moved from before returnPoint to after
-     returnPoint.  This seems to solve a memory leak problem with
-     MINIMIZE_WITH.  Not clear why it wasn't discovered before; this
-     is very old from before Feb. 2010 at least */
   /* Deallocate hypothesis schemes and proofs */
   for (hyp = 0; hyp < schReqHyps; hyp++) {
     nmbrLet((nmbrString **)(&(hypList[hyp])), NULL_NMBRSTRING);
@@ -1043,13 +977,12 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
   let(&hypReEntryFlagList, "");
   nmbrLet(&hypStepList, NULL_NMBRSTRING);
   let(&indepKnownSteps, "");
-  let(&hasFloatingProof, ""); /* 4-Sep-2012 */
-  let(&tryFloatingProofLater, ""); /* 4-Sep-2012 */
+  let(&hasFloatingProof, "");
+  let(&tryFloatingProofLater, "");
 
 
 /*E*/if(db8)print2("%s\n", cat("Returned: ",
 /*E*/   nmbrCvtRToVString(proof,
-/*E*/                /* 25-Jan-2016 nm */
 /*E*/                0, /*explicitTargets*/
 /*E*/                0 /*statemNum, used only if explicitTargets*/), NULL));
   return (proof); /* Caller must deallocate */
@@ -1057,7 +990,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
 
 
 
-/* 22-Aug-2012 nm Added this function */
 /* This function identifies all steps in the proof in progress that (1) are
    independent of step refStep, (2) have no dummy variables, (3) are
    not $f's or $e's, and (4) have subproofs that are complete
@@ -1156,7 +1088,6 @@ vstring getIndepKnownSteps(long proofStmt, long refStep)
 
 
 
-/* 22-Aug-2012 nm Added this function */
 /* This function classifies each proof step in g_ProofInProgress.proof
    as known or unknown ('K' or 'U' in the returned string) depending
    on whether the step has a completely known subproof.
@@ -1239,7 +1170,6 @@ void addSubProof(nmbrString *subProof, long step) {
       step + 1), NULL));
 } /* addSubProof */
 
-/* 11-Sep-2016 nm */
 /* This function eliminates any occurrences of statement sourceStmtNum in the
    targetProof by substituting it with the proof of sourceStmtNum.  The
    unchanged targetProof is returned if there was an error. */
@@ -1436,15 +1366,9 @@ nmbrString *expandProof(
 void deleteSubProof(long step) {
   long sbPfLen, pos;
 
-  /* 22-Aug-2012 nm  We now allow this so we can REPLACE an unassigned
-     step.  User detection for DELETE of unassigned step is still done
-     separately in metamath.c. */
-  /*
-  if ((g_ProofInProgress.proof)[step] == -(long)'?') bug (1805);
-  */
-                       /* Unknown step should not be allowed at cmd interface */
+  /* Unknown step should not be allowed at cmd interface */
+  /* Don't do anything if step is unassigned. */
   if ((g_ProofInProgress.proof)[step] == -(long)'?') return;
-           /* 22-Aug-2012 nm Don't do anything if step is unassigned. */
 
   sbPfLen = subproofLen(g_ProofInProgress.proof, step);
   nmbrLet(&g_ProofInProgress.proof, nmbrCat(nmbrAddElement(
@@ -1484,10 +1408,6 @@ char checkStmtMatch(long statemNum, long step)
   long targetLen, mStringLen, reqVars, stsym, tasym, sym, var, hyp, numHyps;
   flag breakFlag;
   flag firstSymbsAreConstsFlag;
-
-  /* This is no longer a bug.  (Could be true for REPLACE command.)
-  if ((g_ProofInProgress.proof)[step] != -(long)'?') bug(1806);
-  */
 
   targetLen = nmbrLen((g_ProofInProgress.target)[step]);
   if (!targetLen) bug(1807);
@@ -1646,13 +1566,10 @@ char checkMStringMatch(nmbrString *mString, long step)
 /* The caller must deallocate the returned nmbrString. */
 nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
     long step, /* 0 means step 1; used for messages */
-    flag noDistinct, /* 1 means don't try statements with $d's  16-Aug-04 */
-    /* 3-May-2016 nm */
+    flag noDistinct, /* 1 means don't try statements with $d's */
     flag overrideFlag, /* 1 means to override usage locks, 2 means to
               override silently (for web-page syntax breakdown in mmcmds.c) */
-    flag mathboxFlag /* 5-Aug-2020 nm */
-    )
-{
+    flag mathboxFlag) {
 
   long reqHyps, optHyps;
   long hyp, stmt, sym, var, i, j;
@@ -1662,7 +1579,6 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
   nmbrString *hypOrdMap = NULL_NMBRSTRING; /* Order remapping for speedup */
   pntrString *hypProofList = NULL_PNTRSTRING;
   pntrString *stateVector = NULL_PNTRSTRING;
-  /* long firstSymbol, secondSymbol, lastSymbol; */ /* 22-Aug-2012 nm Deleted */
   nmbrString *stmtMathPtr;
   nmbrString *hypSchemePtr;
   nmbrString *hypProofPtr;
@@ -1671,24 +1587,24 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
   flag tmpFlag;
   flag breakFlag;
   flag firstEHypFlag;
-  long schemeLen, /*mStringLen,*/ schemeVars, schReqHyps, hypLen, reqVars;
+  long schemeLen, schemeVars, schReqHyps, hypLen, reqVars;
   long saveUnifTrialCount;
   static long depth = 0;
   static long trials;
-  static flag maxDepthExceeded; /* 2-Oct-2015 nm */
+  static flag maxDepthExceeded;
   long selfScanSteps;
   long selfScanStep;
-  long prfMbox; /* 5-Aug-2020 nm */
+  long prfMbox;
 
 /*E*/  long unNum;
 /*E*/if (db8)print2("%s\n", cat(space(depth+2), "Entered: ",
 /*E*/   nmbrCvtMToVString(mString), NULL));
 
-  prfMbox = getMathboxNum(statemNum); /* 5-Aug-2020 nm */
+  prfMbox = getMathboxNum(statemNum);
 
   if (depth == 0) {
     trials = 0; /* Initialize trials */
-    maxDepthExceeded = 0; /* 2-Oct-2015 nm  Initialize */
+    maxDepthExceeded = 0;
   } else {
     trials++;
   }
@@ -1701,7 +1617,6 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
     goto returnPoint;
   }
 
-  /* 2-Oct-2015 nm */
   if (maxDepthExceeded) {
     /* Pop out of the recursive calls to avoid an infinite loop */
     nmbrLet(&proof, NULL_NMBRSTRING);
@@ -1719,7 +1634,7 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
        nmbrCvtMToVString(mString),
        "\".  Your axiom system may have an error ",
        "or you may have to SET EMPTY_SUBSTITUTION ON.", NULL), " ", " ");
-    maxDepthExceeded = 1;  /* 2-Oct-2015 nm  Flag to exit recursion */
+    maxDepthExceeded = 1;  /* Flag to exit recursion */
     goto returnPoint;
   }
 
@@ -1745,7 +1660,7 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
     }
   }
 
-  /* 7/31/99 - Scan all proved steps in the current proof to see if the
+  /* Scan all proved steps in the current proof to see if the
      statement has already been proved in another subproof */
   selfScanSteps = nmbrLen(g_ProofInProgress.proof); /* Original proof length */
   /* Note: proveFloating() can be called from typeStatement() (for HTML syntax
@@ -1777,29 +1692,10 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
       goto returnPoint;
     } /* if (nmbrEq(mString, (g_ProofInProgress.target)[selfScanStep]) */
   } /* Next selfScanStep */
-  /* 7/31/99 - End of scanning current proof */
 
   /* Scan all statements up to the current statement to see if we can unify */
 
-  /* 22-Aug-2012 nm Now done with quickMatchFilter() *******
-  mStringLen = nmbrLen(mString);
-  /@ For speedup @/
-  firstSymbol = mString[0];
-  if (g_MathToken[firstSymbol].tokenType != (char)con_) firstSymbol = 0;
-  if (mStringLen > 1) {
-    secondSymbol = mString[1];
-    if (g_MathToken[secondSymbol].tokenType != (char)con_) secondSymbol = 0;
-    /@ If first symbol is a variable, second symbol shouldn't be tested. @/
-    if (!firstSymbol) secondSymbol = 0;
-  } else {
-    secondSymbol = 0;
-  }
-  lastSymbol = mString[mStringLen - 1];
-  if (g_MathToken[lastSymbol].tokenType != (char)con_) lastSymbol = 0;
-  **** */
-
-  /* for (stmt = 1; stmt < statemNum; stmt++) { */   /* old code */
-  /* 30-Nov-2013 nm Reversed the scan order so that w3a will match before
+  /* Reversed scan order so that w3a will match before
      wa, helping to prevent an exponential blowup for definition syntax
      breakdown.  If wa is first, then wa will incorrectly match a w3a
      subexpression, with the incorrect trial only detected deeper down;
@@ -1807,16 +1703,14 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
      will get rejected immediately. */
   for (stmt = statemNum - 1; stmt >= 1; stmt--) {
 
-    /* 22-Aug-2012 nm Separated quick filter for reuse in other functions */
+    /* Separated quick filter for reuse in other functions */
     if (quickMatchFilter(stmt, mString, 0/*no dummy vars*/) == 0) continue;
 
-    /* 3-May-2016 nm */
     if (!overrideFlag && getMarkupFlag(stmt, USAGE_DISCOURAGED)) {
       /* Skip usage-discouraged statements */
       continue;
     }
 
-    /* 5-Aug-2020 nm */
     /* Skip statements in other mathboxes unless /INCLUDE_MATHBOXES.  (We don't
        care about the first mathbox since there are no others above it.) */
     if (mathboxFlag == 0 && prfMbox >= 2) {
@@ -1826,12 +1720,7 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
       }
     }
 
-    /* 22-Aug-2012 nm Now done with quickMatchFilter() ****
-    if (g_Statement[stmt].type != (char)a_ &&
-        g_Statement[stmt].type != (char)p_) continue; /@ Not $a or $p @/
-    **** */
-
-    /* 16-Aug-04 nm  noDistinct is set by NO_DISTICT qualifier in IMPROVE */
+    /* noDistinct is set by NO_DISTICT qualifier in IMPROVE */
     if (noDistinct) {
       /* Skip the statement if it has a $d requirement.  This option
          prevents illegal minimizations that would violate $d requirements
@@ -1842,65 +1731,7 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
     }
 
     stmtMathPtr = g_Statement[stmt].mathString;
-
-    /* 22-Aug-2012 nm Now done with quickMatchFilter() ****
-    /@ Speedup:  if first or last tokens in instance and scheme are constants,
-       they must match @/
-    if (firstSymbol) { /@ First symbol in mString is a constant @/
-      if (firstSymbol != stmtMathPtr[0]) {
-        if (g_MathToken[stmtMathPtr[0]].tokenType == (char)con_) continue;
-      }
-    }
-    **** */
-
     schemeLen = nmbrLen(stmtMathPtr);
-
-    /* 22-Aug-2012 nm Now done with quickMatchFilter() ****
-    /@ ...Continuation of speedup @/
-    if (secondSymbol) { /@ Second symbol in mString is a constant @/
-      if (schemeLen > 1) {
-        if (secondSymbol != stmtMathPtr[1]) {
-          /@ Second symbol should be tested only if 1st symbol is a constant @/
-          if (g_MathToken[stmtMathPtr[0]].tokenType == (char)con_) {
-            if (g_MathToken[stmtMathPtr[1]].tokenType == (char)con_)
-                continue;
-          }
-        }
-      }
-    }
-    if (lastSymbol) { /@ Last symbol in mString is a constant @/
-      if (lastSymbol != stmtMathPtr[schemeLen - 1]) {
-        if (g_MathToken[stmtMathPtr[schemeLen - 1]].tokenType ==
-           (char)con_) continue;
-      }
-    }
-    **** */
-
-    /* 22-Aug-2012 nm Now done with quickMatchFilter() ****
-    /@ Speedup:  make sure all constants in scheme are in instance (i.e.
-       mString) @/
-    /@ First, set g_MathToken[].tmp for all symbols in scheme @/
-    for (sym = 0; sym < schemeLen; sym++) {
-      g_MathToken[stmtMathPtr[sym]].tmp = 1;
-    }
-    /@ Next, clear g_MathToken[].tmp for all symbols in instance @/
-    for (sym = 0; sym < mStringLen; sym++) {
-      g_MathToken[mString[sym]].tmp = 0;
-    }
-    /@ Finally, check that they got cleared for all constants in scheme @/
-    breakFlag = 0;
-    for (sym = 0; sym < schemeLen; sym++) {
-      if (g_MathToken[stmtMathPtr[sym]].tokenType == (char)con_) {
-        if (g_MathToken[stmtMathPtr[sym]].tmp) {
-          breakFlag = 1;
-          break;
-        }
-      }
-    }
-    if (breakFlag) continue; /@ To next stmt @/
-    **** */
-
-
     schReqHyps = g_Statement[stmt].numReqHyp;
     reqVars = nmbrLen(g_Statement[stmt].reqVarList);
 
@@ -2039,9 +1870,6 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
       if (breakFlag) {
        /* Proof is not possible for some hypothesis. */
 
-       /* 6-Feb-2007 Jason Orendorff - Patch to eliminate the duplicate
-          "Exceeded trial limit at step n" messages when the limit is
-          reached. */
        /* Perhaps the search limit was reached. */
        if (trials > g_userMaxProveFloat) {
          /* Deallocate hypothesis schemes and proofs */
@@ -2053,7 +1881,6 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
          nmbrLet(&proof, NULL_NMBRSTRING);
          goto returnPoint;
        }
-       /* End of 6-Feb-2007 patch */
 
        /* Speedup:  Move the hypothesis for which the proof was not found
           to the beginning of the hypothesis list, so it will be tried
@@ -2091,7 +1918,6 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
         } /* end switch (overrideFlag) */
       } /* end if (getMarkupFlag(stmt, USAGE_DISCOURAGED)) */
 
-      /* 8-Aug-2020 nm */
       /* TODO: Put this in proveByReplacement? */
       /* Notify mathbox user when other mathboxes are used */
       if (mathboxFlag != 0) {  /* Skip unless /INCLUDE_MATHBOXES was specified */
@@ -2140,7 +1966,6 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
   depth--; /* Restore backtracking depth */
 /*E*/if(db8)print2("%s\n", cat(space(depth+2), "Returned: ",
 /*E*/   nmbrCvtRToVString(proof,
-/*E*/                /* 25-Jan-2016 nm */
 /*E*/                0, /*explicitTargets*/
 /*E*/                0 /*statemNum, used only if explicitTargets*/), NULL));
 /*E*/if(db8){if(!depth)print2("Trials: %ld\n", trials);}
@@ -2154,8 +1979,8 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
    Return value 0 means it can't be unified, 1 means it might be unifiable. */
 INLINE flag quickMatchFilter(long trialStmt, nmbrString *mString,
     long dummyVarFlag /* 0 if no dummy vars in mString */) {
-  /* 22-Aug-2012 nm This function used to be part of proveFloating().  It
-     was separated out for reuse in other places */
+  /* This function used to be part of proveFloating().
+     It was separated out for reuse in other places */
   long sym;
   long firstSymbol, secondSymbol, lastSymbol;
   nmbrString *stmtMathPtr;
@@ -2258,12 +2083,11 @@ void minimizeProof(long repStatemNum, long prvStatemNum,
      even if it doesn't shorten the proof length */
 
   long plen, step, mlen, sym, sublen;
-  long startingPlen = 0; /* 25-Jun-2014 nm */
+  long startingPlen = 0;
   flag foundFlag, breakFlag;
   nmbrString *mString; /* Pointer only; not allocated */
   nmbrString *newSubProofPtr = NULL_NMBRSTRING; /* Pointer only; not allocated;
                 however initialize for nmbrLen function before it's assigned */
-  /* 25-Jun-2014 nm */
   if (allowGrowthFlag) startingPlen = nmbrLen(g_ProofInProgress.proof);
 
   while (1) {
@@ -2293,7 +2117,6 @@ void minimizeProof(long repStatemNum, long prvStatemNum,
          ALLOW_GROWTH mode) */
       if ((g_ProofInProgress.proof)[step] != repStatemNum
           /* || 1 */  /* For special replacement with same label; also below */
-          /* 3-Feb-06 nm */
           /* When not in ALLOW_GROWTH mode i.e. when an infinite loop can't
              occur, we _do_ let a label be tested against itself so that e.g. a
              do-nothing chain of bitr's/pm4.2's will be trimmed off with a
@@ -2346,10 +2169,9 @@ void minimizeProof(long repStatemNum, long prvStatemNum,
     } /* next step */
 
     if (!foundFlag) break; /* Done */
-    /* 25-Jun-2014 nm */
+
 #define MAX_GROWTH_FACTOR 2
     if (allowGrowthFlag && plen > MAX_GROWTH_FACTOR * startingPlen) {
-      /* 25-Jun-2014 nm */
       /* This will prevent an infinite loop in some cases with ALLOW_GROWTH,
          for example 'MINIMIZE_WITH idi/ALLOW_GROWTH' in 'PROVE a1i' */
       print2("Suppressed excessive ALLOW_GROWTH growth.\n");
@@ -2360,8 +2182,6 @@ void minimizeProof(long repStatemNum, long prvStatemNum,
   } /* end while */
 
 } /* minimizeProof */
-
-
 
 
 /* Initialize g_ProofInProgress.source of the step, and .target of all
@@ -2608,8 +2428,7 @@ void assignKnownSteps(long startStep, long sbProofLen)
       g_unifTrialCount = 0; /* Reset unification to no timeout */
       tmpFlag = unifyH(scheme, instance, &stateVector, 0);
       if (!tmpFlag) {
-        /*bug(1813);*/ /* Not poss. */
-        /* Actually this is possible if the starting proof had an error
+        /* This is possible if the starting proof had an error
            in it.  Give the user some information then give up */
         printLongLine(cat("?Error in step ", str((double)pos + 1),
             ":  Could not simultaneously unify the hypotheses of \"",
@@ -2751,7 +2570,7 @@ char interactiveUnify(nmbrString *schemeA, nmbrString *schemeB,
   nmbrString *nmbrTmp = NULL_NMBRSTRING;
   char returnValue;
 
-  /* 8/14/99 - present unifications in increasing order of the number
+  /* Present unifications in increasing order of the number
      of symbols in the unified result.  It seems that usually the unification
      with the fewest symbols in the correct one. */
   nmbrString *unifWeight = NULL_NMBRSTRING; /* Symbol count in unification */
@@ -2783,7 +2602,6 @@ char interactiveUnify(nmbrString *schemeA, nmbrString *schemeB,
 "The unification timed out.  Increase timeout (SET UNIFICATION_TIMEOUT) or\n");
       print2(
 "assign some variables (LET VARIABLE) or the step (LET STEP) manually.\n");
-      /*return (2);*/
       returnValue = 2;
       goto returnPoint;
     }
@@ -2791,26 +2609,24 @@ char interactiveUnify(nmbrString *schemeA, nmbrString *schemeB,
     reEntryFlag = 1;
 
 
-    /* 8/14/99 Compute heuristic "weight" of resulting unification */
+    /* Compute heuristic "weight" of resulting unification */
     /* The unification with the least "weight" is intended to be the
        most likely correct choice.  The heuristic was based on
        empirical observations of typical unification sets */
 
     stackTop = ((nmbrString *)((*stateVector)[11]))[1];
-    /* stackUnkVar = (nmbrString *)((*stateVector)[1]); */ /* 18-Sep-2013 -
-                                           This assignement is never used */
     stackUnkVarStart = (nmbrString *)((*stateVector)[2]);
     stackUnkVarLen = (nmbrString *)((*stateVector)[3]);
     unifiedScheme = (nmbrString *)((*stateVector)[8]);
 
-    /* 8/15/99 - Heuristic */
+    /* Heuristic */
     thisUnifWeight = stackTop * 2;
     onesCount = 0;
     unkCount = 0;
     for (var = 0; var <= stackTop; var++) {
-      /* 8/15/99 - Heuristic */
+      /* Heuristic */
       thisUnifWeight = thisUnifWeight + stackUnkVarLen[var];
-      /* 8/15/99 - Heuristic - Subtract for subst. of length 1 */
+      /* Heuristic - Subtract for subst. of length 1 */
       if (stackUnkVarLen[var] == 1) onesCount++;
 
       /* Count the number of unknown variables in substitution result */
@@ -2839,7 +2655,6 @@ char interactiveUnify(nmbrString *schemeA, nmbrString *schemeB,
 
   if (!unifCount) {
     printf("The unification is not possible.  The proof has an error.\n");
-    /*return(0);*/ /* Not possible */
     returnValue = 0;
     goto returnPoint;
   }
@@ -2854,7 +2669,7 @@ char interactiveUnify(nmbrString *schemeA, nmbrString *schemeB,
         "    ", " ");
   }
 
-  /* 8/14/99 Scan possible unifications in order of increasing unified scheme
+  /* Scan possible unifications in order of increasing unified scheme
      size.  This is not an optimal way to do it since the unification must
      be completely redone for each trial size, but since it is interactive
      the speed should be tolerable.  A faster method would be to save
@@ -2878,7 +2693,6 @@ char interactiveUnify(nmbrString *schemeA, nmbrString *schemeB,
 
       if (unifCount == 1) {
         print2("Step was successfully unified.\n");
-        /*return(1);*/ /* Always accept unique unification */
         returnValue = 1;
         goto returnPoint;
       }
@@ -2940,7 +2754,7 @@ char interactiveUnify(nmbrString *schemeA, nmbrString *schemeB,
   /* (The user should reject everything to test for this bug) */
   if (unifTrials != unifCount) bug(1829);
 
-  /*return (3);*/  /* No unification was selected */
+  /* No unification was selected */
   returnValue = 3;
   goto returnPoint;
 
@@ -2960,7 +2774,6 @@ void autoUnify(flag congrats)
 {
   long step, plen;
   char unifFlag;
-  /* flag stepChanged; */
   flag somethingChanged = 1;
   int pass;
   nmbrString *schemeAPtr; /* Pointer only; not allocated */
@@ -2986,9 +2799,9 @@ void autoUnify(flag congrats)
           case 0:
             /* Check target vs. user */
             schemeAPtr = (g_ProofInProgress.target)[step];
-            if (!nmbrLen(schemeAPtr)) print2(
- "?Bad unification selected:  A proof step should never be completely empty\n");
-      /*if (!nmbrLen(schemeAPtr)) bug (1820);*/ /* Target can never be empty */
+            if (!nmbrLen(schemeAPtr))
+              print2("?Bad unification selected:  "
+                "A proof step should never be completely empty\n");
             schemeBPtr = (g_ProofInProgress.user)[step];
             break;
           case 1:
@@ -3011,14 +2824,8 @@ void autoUnify(flag congrats)
               print2("A unification timeout occurred at step %ld.\n", step + 1);
             }
             if (!unifFlag) {
-              print2(
-              "Step %ld cannot be unified.  THERE IS AN ERROR IN THE PROOF.\n",
-                  (long)(step + 1));
-              /* 27-Sep-2010 nm No longer needed since this is now automatic
-              print2(
-"If your axioms allow empty substitutions, see HELP SET EMPTY_SUBSTITUTION.\n"
-                 );
-              */
+              print2("Step %ld cannot be unified.  "
+                "THERE IS AN ERROR IN THE PROOF.\n", (long)(step + 1));
               continue;
             }
             if (unifFlag == 1) {
@@ -3026,7 +2833,7 @@ void autoUnify(flag congrats)
               makeSubstAll(stateVector);
               somethingChanged = 1;
               g_proofChangedFlag = 1; /* Flag for undo stack */
-              /* 8-Apr-05 nm This message can be annoying. */
+              /* This message can be annoying. */
               /*
               print2("Step %ld was successfully unified.\n", (long)(step + 1));
               */
@@ -3084,7 +2891,7 @@ void makeSubstAll(pntrString *stateVector) {
     nmbrTmpPtr = (g_ProofInProgress.user)[step];
     if (nmbrLen(nmbrTmpPtr)) {
       (g_ProofInProgress.user)[step] = makeSubstUnif(&tmpFlag, nmbrTmpPtr,
-        stateVector); /* 16-Apr-06 nm Fixed bug here */
+        stateVector);
       nmbrLet(&nmbrTmpPtr, NULL_NMBRSTRING);
     }
 
@@ -3183,7 +2990,6 @@ long subproofLen(nmbrString *proof, long endStep)
 } /* subproofLen */
 
 
-/* 25-Aug-2012 nm Added this function */
 /* If testStep has no dummy variables, return 0;
    if testStep has isolated dummy variables (that don't affect rest of
    proof), return 1;
@@ -3284,7 +3090,6 @@ char checkDummyVarIsolation(long testStep) /* 0=1st step, 1=2nd, etc. */
 } /* checkDummyVarIsolation */
 
 
-/* 25-Aug-2012 nm Added this function */
 /* Given a starting step, find its parent (the step it is a hypothesis of) */
 /* If the starting step is the last proof step, just return it */
 long getParentStep(long startStep) /* 0=1st step, 1=2nd, etc. */
@@ -3365,7 +3170,6 @@ void declareDummyVars(long numNewVars)
 
 
 
-/* 20-May-2013 nm Added this function */
 /* Copy inProofStruct to outProofStruct.  A proof structure contains
    the state of the proof in the Proof Assistant MM-PA.  The one
    used by MM-PA is the global g_ProofInProgress.  This function lets
@@ -3407,7 +3211,6 @@ void copyProofStruct(struct pip_struct *outProofStruct,
 } /* copyProofStruct */
 
 
-/* 11-Sep-2016 nm Added this function */
 /* Create an initial proof structure needed for the Proof Assistant, given
    a starting proof.  Normally, proofStruct is the global g_ProofInProgress,
    although we've made it an argument to help modularize the function.  There
@@ -3448,7 +3251,6 @@ void initProofStruct(struct pip_struct *proofStruct, nmbrString *proof,
 } /* initProofStruct */
 
 
-/* 20-May-2013 nm Added this function */
 /* Deallocate memory used by a proof structure and set it to the initial
    state.  A proof structure contains the state of the proof in the Proof
    Assistant MM-PA.  It is assumed that proofStruct was declared with:
@@ -3474,7 +3276,6 @@ void deallocProofStruct(struct pip_struct *proofStruct)
 } /* deallocProofStruct */
 
 
-/* 1-Nov-2013 nm Added this function */
 #define DEFAULT_UNDO_STACK_SIZE 20
 /* This function handles the UNDO/REDO commands.  It is called
    with action PUS_INIT then with PUS_PUSH upon entering MM-PA.  It is

--- a/mmpfas.c
+++ b/mmpfas.c
@@ -345,7 +345,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
     flag searchMethod, /* 1 means to try proveFloating on $e's also */
     long improveDepth, /* Depth for proveFloating */
     flag overrideFlag,  /* 1 means to override statement usage locks */
-    flag mathboxFlag /* 1 means allow mathboxes */ /* 5-Aug-2020 nm */
+    flag mathboxFlag /* 1 means allow mathboxes */
     ) {
   nmbrString *prfMath; /* Pointer only */
   long reqHyps;
@@ -383,7 +383,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
   long scanLowerBound;
   vstring hasFloatingProof = "";  /* 'N' or 'Y' for $e hyps */
   vstring tryFloatingProofLater = "";  /* 'N' or 'Y' */
-  flag hasDummyVar;     /* 4-Sep-2012 nm */
+  flag hasDummyVar;
 
   /* If we are overriding discouraged usage, a warning has already been
      printed.  If we are not, then we should never get here. */
@@ -600,9 +600,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
            we will have an infinite loop.)  Note that for $f's, all
            variables will be known so there will only be one unification
            anyway. */
-        if (hyp >= schEHyps
-            || hasFloatingProof[hyp] == 'Y' /* 5-Sep-2012 nm */
-            ) {
+        if (hyp >= schEHyps || hasFloatingProof[hyp] == 'Y') {
           reenterFFlag = 1;
         }
       } else {
@@ -942,13 +940,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
     nmbrLet(&proof, nmbrAddElement(proof, replStatemNum));
                                                      /* Complete the proof */
 
-    /* Deallocate hypothesis schemes and proofs */
-    /* 25-Jun-2014 This is now done after returnPoint (why was it incomplete?)
-    for (hyp = 0; hyp < schReqHyps; hyp++) {
-      nmbrLet((nmbrString **)(&hypList[hyp]), NULL_NMBRSTRING);
-      nmbrLet((nmbrString **)(&hypProofList[hyp]), NULL_NMBRSTRING);
-    }
-    */
     goto returnPoint;
 
   } /* End while (next unifyH() call for main replacement statement) */
@@ -1249,7 +1240,6 @@ nmbrString *expandProof(
       nmbrLet(&expandedSubproof, NULL_NMBRSTRING);
       /* Scan the proof of the statement to be expanded */
       for (srcStep = 0; srcStep < sourcePLen; srcStep++) {
-        /* 14-Sep-2016 nm */
         if (sourceProof[srcStep] < 0) {
           if (sourceProof[srcStep] == -(long)'?') {
             /* It's an unknown step in the source proof; make it an
@@ -1847,10 +1837,7 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
 
         saveUnifTrialCount = g_unifTrialCount; /* Save unification timeout */
         hypProofPtr = proveFloating(makeSubstPtr, statemNum, maxEDepth, step,
-            noDistinct,
-            overrideFlag, /* 3-May-2016 nm */
-            mathboxFlag /* 5-Aug-2020 nm */
-            );
+            noDistinct, overrideFlag, mathboxFlag);
         g_unifTrialCount = saveUnifTrialCount; /* Restore unification timeout */
 
         nmbrLet(&makeSubstPtr, NULL_NMBRSTRING); /* Deallocate */
@@ -2138,7 +2125,7 @@ void minimizeProof(long repStatemNum, long prvStatemNum,
                                            /* Replacement was not successful */
 
       if (nmbrElementIn(1, newSubProofPtr, -(long)'?')) {
-        /* 8/28/99 Don't do a replacement if the replacement has unknown
+        /* Don't do a replacement if the replacement has unknown
            steps - this causes assignKnownSteps to abort, and it's not
            clear if we should do that anyway since it doesn't necessarily
            minimize the proof */
@@ -2150,10 +2137,10 @@ void minimizeProof(long repStatemNum, long prvStatemNum,
       sublen = subproofLen(g_ProofInProgress.proof, step);
       if (sublen > nmbrLen(newSubProofPtr) || allowGrowthFlag) {
         /* Success - proof length was reduced */
-        /* 7-Jun-2011 nm Delete the old subproof only if it is not an unknown
+        /* Delete the old subproof only if it is not an unknown
            step (since if it is an unknown step, it is already deleted) */
         if ((g_ProofInProgress.proof)[step] == -(long)'?') {
-          /* 7-Jun-2011 nm This can only occur in / ALLOW_GROWTH mode */
+          /* This can only occur in / ALLOW_GROWTH mode */
           if (!allowGrowthFlag) bug(1831);
         } else {
           deleteSubProof(step);

--- a/mmpfas.h
+++ b/mmpfas.h
@@ -48,8 +48,8 @@ nmbrString *proveByReplacement(long prfStmt,
     flag dummyVarFlag, /* 0 means no dummy vars are in prfStmt */
     flag searchMethod, /* 1 means to try proveFloating on $e's also */
     long improveDepth,
-    flag overrideFlag, /* 1 means to override usage locks */ /* 3-May-2016 nm */
-    flag mathboxFlag /* 1 means allow mathboxes */ /* 5-Aug-2020 nm */
+    flag overrideFlag, /* 1 means to override usage locks */
+    flag mathboxFlag /* 1 means allow mathboxes */
     );
 
 nmbrString *replaceStatement(long replStatemNum,
@@ -60,11 +60,10 @@ nmbrString *replaceStatement(long replStatemNum,
     flag noDistinct, /* 1 means don't try statements with $d's */
     flag searchMethod, /* 1 means to try proveFloating on $e's also */
     long improveDepth,
-    flag overrideFlag, /* 1 means to override usage locks */ /* 3-May-2016 nm */
-    flag mathboxFlag /* 1 means allow mathboxes */ /* 5-Aug-2020 nm */
+    flag overrideFlag, /* 1 means to override usage locks */
+    flag mathboxFlag /* 1 means allow mathboxes */
     );
 
-/* 22-Aug-2012 nm Added this function */
 /* This function identifies all steps in the proof in progress that (1) are
    independent of step refStep, (2) have no dummy variables, (3) are
    not $f's or $e's, and (4) have subproofs that are complete
@@ -74,7 +73,6 @@ nmbrString *replaceStatement(long replStatemNum,
    Note: The caller must deallocate the returned vstring. */
 vstring getIndepKnownSteps(long proofStmt, long refStep);
 
-/* 22-Aug-2012 nm Added this function */
 /* This function classifies each proof step in g_ProofInProgress.proof
    as known or unknown ('K' or 'U' in the returned string) depending
    on whether the step has a completely known subproof.
@@ -86,15 +84,13 @@ vstring getKnownSubProofs(void);
    .target of the deleted unknown step is retained). */
 void addSubProof(nmbrString *subProof, long step);
 
-/* 11-Sep-2016 nm */
 /* This function eliminates any occurrences of statement sourceStmtNum in the
    targetProof by substituting it with the proof of sourceStmtNum.  An empty
    nmbrString is returned if there was an error. */
 /* Normally, targetProof is the global g_ProofInProgress.proof.  However,
    we make it an argument in case in the future we'd like to do this
    outside of the proof assistant. */
-nmbrString *expandProof(nmbrString *targetProof,
-    long sourceStmtNum /*, long targetStmtNum*/);
+nmbrString *expandProof(nmbrString *targetProof, long sourceStmtNum);
 
 /* Delete a subproof starting (in reverse from) step.  The step is replaced
    with an unknown step, and its .target field is retained. */
@@ -115,14 +111,12 @@ char checkMStringMatch(nmbrString *mString, long step);
    considered.  A value of 0 means none are considered. */
 nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
     long step, flag noDistinct,
-    /* 3-May-2016 nm */
     flag overrideFlag, /* 0 means respect usage locks
                          1 means to override usage locks
                          2 means override silently */
-    flag mathboxFlag /* 1 means allow mathboxes */ /* 5-Aug-2020 nm */
+    flag mathboxFlag /* 1 means allow mathboxes */
 );
 
-/* 22-Aug-2012 nm Added this function */
 /* This function does quick check for some common conditions that prevent
    a trial statement (scheme) from being unified with a given instance.
    Return value 0 means it can't be unified, 1 means it might be unifiable. */
@@ -173,14 +167,12 @@ void replaceDummyVar(long dummyVar, nmbrString *mString);
 /* Get subproof length of a proof, starting at endStep and going backwards */
 long subproofLen(nmbrString *proof, long endStep);
 
-/* 25-Aug-2012 nm Added this function */
 /* If testStep has no dummy variables, return 0;
    if testStep has isolated dummy variables (that don't affect rest of
    proof), return 1;
    if testStep has dummy variables used elsewhere in proof, return 2 */
 char checkDummyVarIsolation(long testStep); /* 0=1st step, 1=2nd, etc. */
 
-/* 25-Aug-2012 nm Added this function */
 /* Given a starting step, find its parent (the step it is a hypothesis of) */
 /* If the starting step is the last proof step, just return it */
 long getParentStep(long startStep); /* 0=1st step, 1=2nd, etc. */

--- a/mmunif.c
+++ b/mmunif.c
@@ -113,7 +113,7 @@ Note:  i = 0 through g_hentyFilterSize-1 below.
 #include "mminou.h"
 #include "mmpars.h"
 #include "mmunif.h"
-#include "mmpfas.h" /* 8/28/99 For proveStatement global variable */
+#include "mmpfas.h" /* For proveStatement global variable */
 
 /*long g_minSubstLen = 0;*/ /* User-settable value - 0 or 1 */
 long g_minSubstLen = 1; /* It was decided to disallow empty subst. by default
@@ -147,9 +147,7 @@ void hentyAdd(nmbrString *hentyVars, nmbrString *hentyVarStart,
 int maxNestingLevel = -1;
 int nestingLevel = 0;
 
-/* 8/29/99 For improving rejection of impossible substitutions */
-/* 1-Oct-2017 nm Made g_firstConst global so eraseSource() can clear it */
-/* 2-Oct-2017 nm Made them all global so valgrind won't complain */
+/* For improving rejection of impossible substitutions */
 nmbrString *g_firstConst = NULL_NMBRSTRING;
 nmbrString *g_lastConst = NULL_NMBRSTRING;
 nmbrString *g_oneConst = NULL_NMBRSTRING;
@@ -343,12 +341,12 @@ char unify(
   flag timeoutAbortFlag = 0;
   vstring mToken; /* Pointer only; not allocated */
 
-  /* 8/28/99 For detection of simple impossible unifications */
+  /* For detection of simple impossible unifications */
   flag impossible;
   long stmt;
 
-  /* 26-Sep-2010 nm For bracket matching heuristic for set.mm */
-  static char bracketMatchOn; /* 26-Sep-2010 nm Default is 'on' */
+  /* For bracket matching heuristic for set.mm */
+  static char bracketMatchOn; /* Default is 'on' */
   /* static char g_bracketMatchInit = 0; */ /* Global so ERASE can init it */
   long bracketScanStart, bracketScanStop; /* For one-time $a scan */
   flag bracketMismatchFound;
@@ -393,10 +391,10 @@ char unify(
   nmbrLet(&schA, nmbrAddElement(schemeA, g_mathTokens));
   nmbrLet(&schB, nmbrAddElement(schemeB, g_mathTokens));
 
-  /* 8/29/99 Initialize the usage of constants as the first, last,
+  /* Initialize the usage of constants as the first, last,
      only constant in a $a statement - for rejecting some simple impossible
-     substitutions - Speed-up: this is now done once and never deallocated*/
-  /* 1-Oct-2017 nm g_firstConst is now cleared in eraseSource.c() (mmcmds.c)
+     substitutions - Speed-up: this is now done once and never deallocated */
+  /* g_firstConst is now cleared in eraseSource.c() (mmcmds.c)
      to trigger this initialization after "erase" */
   if (!nmbrLen(g_firstConst)) {
     /* nmbrSpace() sets all entries to 0, not 32 (ASCII space) */
@@ -777,10 +775,9 @@ char unify(
     goto backtrack;
   }
 
-  /************* Start of 26-Sep-2010 *************/
   /* Bracket matching is customized to set.mm to result in fewer ambiguous
      unifications. */
-  /* 26-Sep-2010 nm Automatically disable bracket matching if any $a has
+  /* Automatically disable bracket matching if any $a has
      unmatched brackets */
   /* The static variable g_bracketMatchInit tells us to check all $a's
      if it is 0; if 1, skip the $a checking.  Make sure that the RESET
@@ -848,7 +845,7 @@ char unify(
         break;
       }
 
-      /* Make sure left and right brackets match */  /* Added 12-Nov-05 nm */
+      /* Make sure left and right brackets match */
       pairingMismatches = 0; /* Counter of brackets: + for "[" and - for "]" */
       for (k = 0; k < j; k++) {
         mToken = g_MathToken[nmbrTmpPtr[k]].tokenName;
@@ -883,7 +880,7 @@ char unify(
         break;
       }
 
-      /* Make sure underlined brackets match */  /* Added 12-Nov-05 nm */
+      /* Make sure underlined brackets match */
       pairingMismatches = 0; /* Counter of brackets: + for "[_", - for "]_" */
       for (k = 0; k < j; k++) {
         mToken = g_MathToken[nmbrTmpPtr[k]].tokenName;
@@ -928,16 +925,15 @@ char unify(
   } /* next i */
 
   if (bracketMismatchFound) goto backtrack;
-  /************* End of 26-Sep-2010 *************/
 
   j = nmbrLen(substitution);
 
-  /* 8/29/99 - Quick scan to reject some impossible unifications: If the
+  /* Quick scan to reject some impossible unifications: If the
      first symbol in a substitution is a constant, it must match
      the 2nd constant of some earlier $a statement (e.g. "<" matches
      "class <", "Ord (/)" matches "class Ord A").  Same applies to
      last symbol. */
-  /* 10/12/02 - This prefilter is too aggressive when empty substitutions
+  /* This prefilter is too aggressive when empty substitutions
      are allowed.  Therefore added "g_minSubstLen > 0" to fix miu.mm theorem1
      Proof Assistant failure reported by Josh Purinton. */
   if (j/*subst len*/ > 0 && g_minSubstLen > 0) {

--- a/mmunif.h
+++ b/mmunif.h
@@ -17,12 +17,9 @@ extern long g_unifTrialCount;
 extern long g_unifTimeouts; /* Number of timeouts so far for this command */
 extern flag g_hentyFilter; /* Turns Henty filter on or off */
 
-/* 26-Sep-2010 nm */
-extern flag g_bracketMatchInit; /* So eraseSource() (mmcmds.c) can clr it */
-
-/* 1-Oct-2017 nm Made this global so eraseSource() (mmcmds.c) can clr it */
+/* Global so eraseSource() (mmcmds.c) can clr them */
+extern flag g_bracketMatchInit;
 extern nmbrString *g_firstConst;
-/* 2-Oct-2017 nm Made these global so eraseSource() (mmcmds.c) can clr them */
 extern nmbrString *g_lastConst;
 extern nmbrString *g_oneConst;
 

--- a/mmveri.c
+++ b/mmveri.c
@@ -461,7 +461,7 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
 /*E*/if(db7)print2("GOT TO DUMMY TOKEN\n");
               v--;
               contFlag = 1;
-              continue; /* 24-Sep-2010 nm Added missing trap to fix bug(2106) */
+              continue; /* Added missing trap to fix bug(2106) */
             }
             if (q >= bigSubstInstLen) {
               /* It overflowed the end of bigSubstInstAss; pop back a variable */
@@ -754,7 +754,7 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
                 /* Put missing $d requirement in new line so grep can find
                    them easily in log file */
                 printLongLine(cat("Variables \"",
-                    /* 30-Apr-04 nm Put in alphabetic order for easier use if
+                    /* Put in alphabetic order for easier use if
                        user sorts the list of errors */
                     /* strcmp returns <0 if 1st<2nd */
                     (strcmp(g_MathToken[aToken].tokenName,

--- a/mmvstr.h
+++ b/mmvstr.h
@@ -172,7 +172,7 @@ long rinstr(vstring string1, vstring string2);
 long ascii_(vstring c);
 double val(vstring s);
 
-/* Emulation of Progress 4GL string functions, added 11/25/98 */
+/* Emulation of Progress 4GL string functions */
 vstring entry(long element, vstring list);
 long lookup(vstring expression, vstring list);
 long numEntries(vstring list);

--- a/mmwtex.c
+++ b/mmwtex.c
@@ -1511,15 +1511,15 @@ void printTexHeader(flag texHeaderFlag)
 
       print2("      </FONT><FONT FACE=sans-serif SIZE=-2>\n");
 
-      /* ??? Is the closing </FONT> printed if there is no altHtml?
-         This should be tested.  8/9/03 ndm */
+      /* 8-Sep-03 nm - ??? Is the closing </FONT> printed if there is no
+         altHtml?  This should be tested. */
 
-      /* 15-Aug-04 nm Compute the theorem list page number.  ??? Temporarily
+      /* Compute the theorem list page number.  ??? Temporarily
          we assume it to be 100 (hardcoded).  Todo: This should be fixed to use
          the same as the THEOREMS_PER_PAGE in WRITE THEOREMS (have a SET
          global variable in place of THEOREMS_PER_PAGE?) */
       i = ((g_Statement[g_showStatement].pinkNumber - 1) / 100) + 1; /* Page # */
-      /* 18-Jul-2015 nm - all thm pages now have page num after mmtheorems
+      /* All thm pages now have page num after mmtheorems
          since mmtheorems.html is now just the table of contents */
       let(&tmpStr, cat("mmtheorems", str((double)i), ".html#",
           g_Statement[g_showStatement].labelName, NULL)); /* Link to page/stmt */
@@ -1553,7 +1553,6 @@ void printTexHeader(flag texHeaderFlag)
       print2("      </FONT>\n");
       print2("    </TD>\n");
       print2("    <TD COLSPAN=2 ALIGN=RIGHT VALIGN=TOP>\n");
-                              /* Change COLSPAN=1 -> 2 */ /* 27-Dec-2020 nm */
       print2("      <FONT SIZE=-2 FACE=sans-serif>\n");
 
       /* Add link(s) specified by htmlexturl in $t statement */
@@ -1666,7 +1665,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
              2 = process as if in <HTML>...</HTML> preformatted mode but
                  don't strip <HTML>...</HTML> tags
              3 = same as 2, but convert ONLY math symbols
-           (These new values were added instead of addina a new argument,
+           (These new values were added instead of adding a new argument,
            so as not to have to modify ~60 other calls to this function) */
 
     flag noFileCheck)  /* 1 = ignore missing external files (gifs, bib, etc.) */
@@ -1785,7 +1784,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         let(&tmpStrMasked, tmpStr);
       } else {
         let(&tmpStr, left(cmt, pos1));
-        /* 20-Aug-2014 nm */
         if (mode == -1) { /* Math mode */
           /* Replace math symbols with spaces to prevent confusing them
              with markup in sections below */
@@ -2093,9 +2091,8 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         /* The biblio tag should be in brackets e.g. "[Monk2]" */
         /* Only look at non-math part of comment */
         pos1 = instr(pos1 + 1, cmtMasked, "[");
-        if (!pos1) break; /* 3-Feb-2019 nm Moved this to before block below */
+        if (!pos1) break;
 
-        /* 9-Dec-2018 nm */
         /* Escape a double [[ */
         if (cmtMasked[pos1] == '[') {  /* This is the char after "[" above */
           /* Remove the first "[" */
@@ -2516,7 +2513,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                 "\".  Check that \"`\" inside of a math symbol is",
                 " escaped with \"``\".",
                 NULL), "", " ");
-            returnVal = 1; /* Error/warning printed */ /* 17-Nov-2015 nm */
+            returnVal = 1; /* Error/warning printed */
             g_outputToString = 1;
 
           }
@@ -2603,10 +2600,9 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                 "$", NULL));  /* edit = remove trailing spaces */
             }
           } else {
-            /* 10/25/02 Trim leading, trailing spaces in case punctuation
+            /* Trim leading, trailing spaces in case punctuation
                surrounds the math symbols in the comment */
             let(&tmpStr, edit(tmpStr, 8 + 128));
-            /* 14-Jan-2016 nm */
             /* Enclose math symbols in a span to be used for font selection */
             let(&tmpStr, cat(
                 (g_altHtmlFlag ? cat("<SPAN ", g_htmlFont, ">", NULL) : ""),
@@ -2629,8 +2625,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
             && convertToHtml == 1 /* Not MARKUP command */
             ) {  /* Make it a paragraph break */
           let(&outputLine,
-              /* "<P>"); */
-              /* 9-May-2015 nm Prevent space after last paragraph */
+              /* Prevent space after last paragraph */
               "<P STYLE=\"margin-bottom:0em\">");
         }
       }
@@ -2781,33 +2776,28 @@ void printTexLongMath(nmbrString *mathString,
          (as a cat, left, etc. argument) by caller */
     long hypStmt, /* hypStmt, if non-zero, is the statement number to be
                      referenced next to the hypothesis link in html */
-    long indentationLevel) /* nm 3-Feb-04 Indentation amount of proof step -
+    long indentationLevel) /* Indentation amount of proof step -
                               note that this is 0 for last step of proof */
 {
-/* 23-Apr-04 nm Changed "top" level from 0 to 1 - hopefully slightly less
-   confusing since before user had to scroll to bottom to know that it
-   started at 0 and not 1 */
 #define INDENTATION_OFFSET 1
   long i;
   long pos;
   vstring tex = "";
   vstring texLine = "";
-  vstring sPrefix = ""; /* 7/3/98 */
-  vstring htmStep = ""; /* 7/4/98 */
-  vstring htmStepTag = ""; /* 30-May-2015 nm */
-  vstring htmHyp = ""; /* 7/4/98 */
-  vstring htmRef = ""; /* 7/4/98 */
-  vstring htmLocLab = ""; /* 7/4/98 */
-  vstring tmp = "";  /* 10/10/02 */
-  vstring descr = ""; /* 19-Nov-2007 nm */
-  char refType = '?'; /* 14-Sep-2010 nm  'e' means $e, etc. */
+  vstring sPrefix = "";
+  vstring htmStep = "";
+  vstring htmStepTag = "";
+  vstring htmHyp = "";
+  vstring htmRef = "";
+  vstring htmLocLab = "";
+  vstring tmp = "";
+  vstring descr = "";
+  char refType = '?'; /* 'e' means $e, etc. */
 
-  let(&sPrefix, startPrefix); /* 7/3/98 Save it; it may be temp alloc */
+  let(&sPrefix, startPrefix); /* Save it; it may be temp alloc */
 
   if (!g_texDefsRead) return; /* TeX defs were not read (error was printed) */
   g_outputToString = 1; /* Redirect print2 and printLongLine to g_printString */
-  /* May have stuff to be printed 7/4/98 */
-  /*if (!g_htmlFlag) let(&g_printString, "");*/ /* Removed 6-Dec-03 */
 
   /* Note that the "tex" assignment below will be used only when !g_htmlFlag
      and g_oldTexFlag, or when g_htmlFlag and len(sPrefix)>0 */
@@ -2818,31 +2808,27 @@ void printTexLongMath(nmbrString *mathString,
       /*          tex = " 4 2,3 ax-qmp  $a " in g_htmlFlag mode */
   let(&texLine, "");
 
-  /* 14-Sep-2010 nm Get statement type of proof step reference */
+  /* Get statement type of proof step reference */
   i = instr(1, sPrefix, "$");
   if (i) refType = sPrefix[i]; /* Character after the "$" */
 
-  /* 14-Sep-2010 nm Moved this code from below to use for !g_oldTexFlag */
   if (g_htmlFlag || !g_oldTexFlag) {
 
     /* Process a proof step prefix */
     if (strlen(sPrefix)) { /* It's a proof step */
       /* Make each token a separate table column for HTML */
       /* This is a kludge that only works with /LEMMON style proofs! */
-      /* 14-Sep-2010 nm Note that asciiToTt() above puts "\ " when not in
+      /* Note that asciiToTt() above puts "\ " when not in
          g_htmlFlag mode, so use sPrefix instead of tex so it will work in
          !g_oldTexFlag mode */
 
-      /* 1-May-2017 nm Fix for non-/LEMMON format used by TeX mode */
       /* In HTML mode, sPrefix has two possible formats:
            "2 ax-1  $a "
            "3 1,2 ax-mp  $a "
          In LaTeX mode (!g_htmlFlag), sPrefix has one format:
            "8   maj=ax-1  $a "
            "9 a1i=ax-mp $a " */
-      /* Later on 1-May-2017: the LaTeX mode now returns same as HTML mode. */
 
-      /* let(&tex, edit(tex, 8 + 16 + 128)); */
       let(&tex, edit(sPrefix, 8/*no leading spaces*/
            + 16/*reduce spaces and tabs*/
            + 128/*no trailing spaces*/));
@@ -2852,21 +2838,12 @@ void printTexLongMath(nmbrString *mathString,
       while (pos) {
         pos = instr(1, tex, " ");
         if (pos) {
-          if (i > 3) { /* 2/8/02 - added for extra safety for the future */
+          if (i > 3) { /* added for extra safety for the future */
             bug(2316);
           }
-          /* Deleted 26-Jun-2017 nm - this check is too conservative; we
-             could have starting tex="2 1 a4s @2: $p" which will result
-             in pos=4, i=3.  "show proof drsb1/tex" triggered this bug. */
-          /*
-          if (!g_htmlFlag && i > 2) { /@ 1-May-2017 nm @/
-            bug(2341);
-          }
-          */
           if (i == 0) let(&htmStep, left(tex, pos - 1));
           if (i == 1) let(&htmHyp, left(tex, pos - 1));
           if (i == 2) let(&htmRef, left(tex, pos - 1));
-          /* 26-Jun-2017 nm */
           if (i == 3) let(&htmLocLab, left(tex, pos - 1));
 
           let(&tex, right(tex, pos + 1));
@@ -2874,7 +2851,6 @@ void printTexLongMath(nmbrString *mathString,
         }
       }
 
-      /* 26-Jun-2017 nm */
       if (i == 3 && htmRef[0] == '@') {
         /* The referenced statement has no hypotheses but has a local
            label e.g."2 a4s @2: $p" */
@@ -2889,46 +2865,26 @@ void printTexLongMath(nmbrString *mathString,
         let(&htmRef, htmHyp);
         let(&htmHyp, "");
 
-        /* 1-May-2017 nm Fix bug reported by Ari Ferrera*/
         /* Change "maj=ax-1" to "ax-1" so \ref{} produced by
            "show proof .../tex" will match \label{} produced by
            "show statement .../tex" */
-        /* Later on 1-May-2017:  earlier we set the noIndentFlag (Lemmon
+        /* Earlier we set the noIndentFlag (Lemmon
            proof) in the SHOW PROOF.../TEX call in metamath.c, so the
            hypothesis ref list will be available just like in the HTML
            output. */
-        /* 1-May-2017 nm - Delete the below if we keep the noIndentFlag solution. */
-        /*
-        if (!g_htmlFlag) {
-          pos = instr(1, htmRef, "=");
-          if (!pos) bug(2342);
-          let(&htmRef, right(htmRef, pos + 1));
-        }
-        */
         /* We now consider "=" a bug since the call via typeProof() in
            metamath.c now always has noIndentFlag = 1. */
         if (!g_htmlFlag) {
           pos = instr(1, htmRef, "=");
           if (pos) bug(2342);
         }
-
-
       }
     } /* if (strlen(sPrefix)) (end processing proof step prefix) */
   }
 
   if (!g_htmlFlag) {
-
-    /* 27-Jul-05 nm Added SIMPLE_TEX */
-    if (!g_oldTexFlag) {
-      /* 14-Sep-2010 nm Old 27-Jul-05 version commented out: */
-      /* printLongLine(cat("\\texttt{", tex, "}", NULL), "", " ");  */
-      /* let(&tex, ""); */ /* Deallocate */
-      /* tex = asciiToTt(contPrefix); */
-      /* printLongLine(cat("\\texttt{", tex, "}", NULL), "", " "); */
-      /* print2("\\begin{eqnarray}\n"); */
-    } else {
-      /* 9/2/99 Trim down long start prefixes so they won't overflow line,
+    if (g_oldTexFlag) {
+      /* Trim down long start prefixes so they won't overflow line,
          by putting their tokens into \m macros */
 #define TRIMTHRESHOLD 60
       i = (long)strlen(tex);
@@ -2957,12 +2913,9 @@ void printTexLongMath(nmbrString *mathString,
       if (htmHyp[0] == 0)
         let(&htmHyp, "&nbsp;");  /* Insert blank field for Lemmon ref w/out hyp */
 
-      /*** Start of 9-Sep-2010 ***/
-      /* 9-Sep-2010 Stefan Allen - put hyperlinks on hypothesis
+      /* Put hyperlinks on hypothesis
          label references in SHOW STATEMENT * /HTML, ALT_HTML output */
-      /*Add hyperlink references to the proof */
-      /* let(&htmStep, cat("<A NAME=\"",htmStep,"\">",htmStep,"</A>",NULL)); */
-      /* 30-May-2015 nm Use a separate tag to put into the math cell,
+      /* Use a separate tag to put into the math cell,
          so it will link to the top of the math cell */
       let(&htmStepTag, cat("<A NAME=\"", htmStep, "\">","</A>", NULL));
       i = 1;
@@ -2983,9 +2936,8 @@ void printTexLongMath(nmbrString *mathString,
         if (!instr(i, htmHyp, ",")) break;
         i = pos;
       }
-      /*** End of 9-Sep-2010 ***/
 
-      /* 2/8/02 Add a space after each comma so very long hypotheses
+      /* Add a space after each comma so very long hypotheses
          lists will wrap in an HTML table cell, e.g. gomaex3 in ql.mm */
       pos = instr(1, htmHyp, ",");
       while (pos) {
@@ -2993,22 +2945,19 @@ void printTexLongMath(nmbrString *mathString,
         pos = instr(pos + 1, htmHyp, ",");
       }
 
-      /* if (!strcmp(tex, "$e") || !strcmp(tex, "$f")) { */ /* Old */
-      if (refType == 'e' || refType == 'f') { /* 14-Sep-2010 nm Speedup */
+      if (refType == 'e' || refType == 'f') {
         /* A hypothesis - don't include link */
         printLongLine(cat("<TR ALIGN=LEFT><TD>", htmStep, "</TD><TD>",
             htmHyp, "</TD><TD>", htmRef,
             "</TD><TD>",
-            htmStepTag, /* 30-May-2015 nm */
-                /* Put the <A NAME=...></A> tag at start of math symbol cell */
+            htmStepTag, /* Put the <A NAME=...></A> tag at start of math symbol cell */
             NULL), "", "\"");
       } else {
         if (hypStmt <= 0) {
           printLongLine(cat("<TR ALIGN=LEFT><TD>", htmStep, "</TD><TD>",
               htmHyp, "</TD><TD><A HREF=\"", htmRef, ".html\">", htmRef,
               "</A></TD><TD>",
-              htmStepTag, /* 30-May-2015 nm */
-                /* Put the <A NAME=...></A> tag at start of math symbol cell */
+              htmStepTag, /* Put the <A NAME=...></A> tag at start of math symbol cell */
               NULL), "", "\"");
         } else {
           /* Include step number reference.  The idea is that this will
@@ -3017,18 +2966,8 @@ void printTexLongMath(nmbrString *mathString,
              after the hypothesis statement label. */
           let(&tmp, "");
           tmp = pinkHTML(hypStmt);
-          /* Special case for pink number here: to make table more compact,
-             we allow the pink number to break off of the href by changing
-             PINK_NBSP to a space.  Elsewhere we don't allow such line
-             breaks. */
-          /* 10/14/02 I decided I don't like it so I took it out. */
-          /*******
-          let(&tmp, cat(" ", right(tmp, (long)strlen(PINK_NBSP) + 1), NULL));
-          *******/
 
-#define TOOLTIP
-#ifdef TOOLTIP
-          /* 19-Nov-2007 nm Get description for mod below */
+          /* Get description for mod below */
           let(&descr, ""); /* Deallocate previous description */
           descr = getDescription(hypStmt);
           let(&descr, edit(descr, 4 + 16)); /* Discard lf/cr; reduce spaces */
@@ -3046,27 +2985,20 @@ void printTexLongMath(nmbrString *mathString,
             descr[i] = (char)(descr[i] == '"' ? '\'' : descr[i]);
             i++;
           }
-#endif
 
           printLongLine(cat("<TR ALIGN=LEFT><TD>", htmStep, "</TD><TD>",
               htmHyp, "</TD><TD><A HREF=\"", htmRef, ".html\"",
-
-#ifdef TOOLTIP
-              /* 19-Nov-2007 nm Put in a TITLE entry for mouseover tooltip,
+              /* Put in a TITLE entry for mouseover tooltip,
                  as suggested by Reinder Verlinde */
               " TITLE=\"", descr, "\"",
-#endif
-
               ">", htmRef,
               "</A>", tmp,
               "</TD><TD>",
-              htmStepTag, /* 30-May-2015 nm */
-                /* Put the <A NAME=...></A> tag at start of math symbol cell */
+              htmStepTag, /* Put the <A NAME=...></A> tag at start of math symbol cell */
               NULL), "", "\"");
         }
       }
-
-      /* nm 3-Feb-04 Experiment to indent web proof displays */
+      /* Indent web proof displays */
       let(&tmp, "");
       for (i = 1; i <= indentationLevel; i++) {
         let(&tmp, cat(tmp, ". ", NULL));
@@ -3083,13 +3015,11 @@ void printTexLongMath(nmbrString *mathString,
   let(&sPrefix, ""); /* Deallocate */
 
   let(&tex, "");
-  tex = getTexLongMath(mathString, hypStmt); /* 20-Sep-03 */
+  tex = getTexLongMath(mathString, hypStmt);
   let(&texLine, cat(texLine, tex, NULL));
 
   if (!g_htmlFlag) {  /* LaTeX */
-    /* 27-Jul-05 nm Added for new LaTeX (!g_oldTexFlag) */
     if (!g_oldTexFlag) {
-      /* 14-Sep-2010 nm */
       if (refType == 'e' || refType == 'f') {
         /* A hypothesis - don't include \ref{} */
         printLongLine(cat("  ",
@@ -3117,20 +3047,20 @@ void printTexLongMath(nmbrString *mathString,
             htmStep,  /* Step number */
             " && ",
 
-            /* Local label if any e.g. "@2:" */ /* 26-Jun-2017 nm */
+            /* Local label if any e.g. "@2:" */
             (htmLocLab[0] != 0) ? cat(htmLocLab, "\\ ", NULL) : "",
 
             " & ",
             texLine,
             /* Don't put space to help prevent bad line break */
 
-            /* 1-May-2017 nm Surround \ref with \mbox for non-math-mode
+            /* Surround \ref with \mbox for non-math-mode
                symbolic labels (due to \tag{..} in mmcmds.c).  Also,
                move hypotheses to after referenced label */
             "&",
             "(",
 
-            /* Don't make local label a \ref */ /* 26-Jun-2017 nm */
+            /* Don't make local label a \ref */
             (htmRef[0] != '@') ?
                 cat("\\mbox{\\ref{eq:", htmRef, "}}", NULL)
                 : htmRef,
@@ -3138,19 +3068,10 @@ void printTexLongMath(nmbrString *mathString,
             htmHyp[0] ? "," : "",
             htmHyp,
             ")\\notag", NULL),
-            /* before 1-May-2017:
-            "&", htmHyp, htmHyp[0] ? "," : "",
-            "(\\ref{eq:", htmRef, "})\\notag", NULL),
-            */
 
             "    \\notag \\\\ && & \\qquad ",  /* Continuation line prefix */
             " ");
       }
-      /* 14-Sep-2010 nm - commented out below */
-      /* printLongLine(texLine, "", " "); */
-      /* print2("\\end{eqnarray}\n"); */
-      /* 6 && \vdash& ( B \ton_3 B ) \ton_3 A & (\ref{eq:q2}),4,5 \notag \\ */
-      /*print2(" & (\\ref{eq:%s}%s \\notag\n",???,??? );*/
     } else {
       printLongLine(texLine, "", "\\");
       print2("\\endm\n");
@@ -3163,12 +3084,12 @@ void printTexLongMath(nmbrString *mathString,
   fprintf(g_texFilePtr, "%s", g_printString);
   let(&g_printString, "");
 
-  let(&descr, ""); /*Deallocate */  /* 17-Nov-2007 nm */
+  let(&descr, ""); /*Deallocate */
   let(&htmStep, ""); /* Deallocate */
   let(&htmStepTag, ""); /* Deallocate */
   let(&htmHyp, ""); /* Deallocate */
   let(&htmRef, ""); /* Deallocate */
-  let(&htmLocLab, ""); /* Deallocate */ /* 26-Jun-2017 nm */
+  let(&htmLocLab, ""); /* Deallocate */
   let(&tmp, ""); /* Deallocate */
   let(&texLine, ""); /* Deallocate */
   let(&tex, ""); /* Deallocate */
@@ -3179,51 +3100,22 @@ void printTexTrailer(flag texTrailerFlag) {
   if (texTrailerFlag) {
     g_outputToString = 1; /* Redirect print2 and printLongLine to g_printString */
     if (!g_htmlFlag) let(&g_printString, "");
-        /* May have stuff to be printed 7/4/98 */
+        /* May have stuff to be printed */
     if (!g_htmlFlag) {
       print2("\\end{document}\n");
     } else {
-      /*******  10/10/02 Moved to mmcmds.c so it can be printed immediately
-                after proof; made g_htmlVarColor global for this
-      print2("<FONT SIZE=-1 FACE=sans-serif>Colors of variables:\n");
-      printLongLine(cat(g_htmlVarColor, "</FONT>", NULL), "", " ");
-      *******/
       print2("</TABLE></CENTER>\n");
       print2("<TABLE BORDER=0 WIDTH=\"100%s\">\n", "%");
       print2("<TR><TD WIDTH=\"25%s\">&nbsp;</TD>\n", "%");
       print2("<TD ALIGN=CENTER VALIGN=BOTTOM>\n");
       print2("<FONT SIZE=-2 FACE=sans-serif>\n");
-      /*
-      print2("<A HREF=\"definitions.html\">Definition list</A> |\n");
-      print2("<A HREF=\"theorems.html\">Theorem list</A><BR>\n");
-      */
-      /*
-      print2("Copyright &copy; 2002 \n");
-      print2("The Metamath Home Page is\n");
-      */
-      /*
-      print2("<A HREF=\"http://metamath.org\">metamath.org mirrors</A>\n");
-      */
       print2("Copyright terms:\n");
       print2("<A HREF=\"../copyright.html#pd\">Public domain</A>\n");
-      print2("</FONT></TD><TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH=\"25%s\">\n",
-          "%");
+      print2("</FONT></TD><TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH=\"25%s\">\n", "%");
       print2("<FONT SIZE=-2 FACE=sans-serif>\n");
       print2("<A HREF=\"http://validator.w3.org/check?uri=referer\">\n");
       print2("W3C validator</A>\n");
       print2("</FONT></TD></TR></TABLE>\n");
-
-      /* Todo: Decide to use or not use this */
-      /*
-      print2("<SCRIPT SRC=\"http://www.google-analytics.com/urchin.js\"\n");
-      print2("  TYPE=\"text/javascript\">\n");
-      print2("</SCRIPT>\n");
-      print2("<SCRIPT TYPE=\"text/javascript\">\n");
-      print2("  _uacct = \"UA-1862729-1\";\n");
-      print2("  urchinTracker();\n");
-      print2("</SCRIPT>\n");
-      */
-
       print2("</BODY></HTML>\n");
     }
     g_outputToString = 0; /* Restore normal output */
@@ -3234,7 +3126,7 @@ void printTexTrailer(flag texTrailerFlag) {
 } /* printTexTrailer */
 
 
-/* Added 4-Dec-03 - WRITE THEOREM_LIST command:  Write out theorem list
+/* WRITE THEOREM_LIST command:  Write out theorem list
    into mmtheorems.html, mmtheorems1.html,... */
 void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
 {
@@ -3245,35 +3137,35 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
   vstring str3 = "";
   vstring str4 = "";
   vstring prevNextLinks = "";
-  long partCntr;        /* Counter for hugeHdr */ /* 21-Jun-2014 */
-  long sectionCntr;     /* Counter for bigHdr */ /* 21-Jun-2014 */
-  long subsectionCntr;  /* Counter for smallHdr */ /* 21-Jun-2014 */
-  long subsubsectionCntr;  /* Counter for tinyHdr */ /* 21-Aug-2017 */
+  long partCntr;        /* Counter for hugeHdr */
+  long sectionCntr;     /* Counter for bigHdr */
+  long subsectionCntr;  /* Counter for smallHdr */
+  long subsubsectionCntr;  /* Counter for tinyHdr */
   vstring outputFileName = "";
   FILE *outputFilePtr;
-  long passNumber; /* 18-Oct-2015 1/2 for summary/detailed table of contents */
+  long passNumber; /* for summary/detailed table of contents */
 
-  /* 31-Jul-2006 for table of contents mod */
-  vstring hugeHdr = ""; /* 21-Jun-2014 nm */
+  /* for table of contents */
+  vstring hugeHdr = "";
   vstring bigHdr = "";
   vstring smallHdr = "";
-  vstring tinyHdr = ""; /* 21-Aug-2017 nm */
-  vstring hugeHdrComment = ""; /* 8-May-2015 nm */
-  vstring bigHdrComment = ""; /* 8-May-2015 nm */
-  vstring smallHdrComment = ""; /* 8-May-2015 nm */
-  vstring tinyHdrComment = ""; /* 21-Aug-2017 nm */
+  vstring tinyHdr = "";
+  vstring hugeHdrComment = "";
+  vstring bigHdrComment = "";
+  vstring smallHdrComment = "";
+  vstring tinyHdrComment = "";
   long stmt, i;
   pntrString *pntrHugeHdr = NULL_PNTRSTRING;
   pntrString *pntrBigHdr = NULL_PNTRSTRING;
   pntrString *pntrSmallHdr = NULL_PNTRSTRING;
-  pntrString *pntrTinyHdr = NULL_PNTRSTRING; /* 21-Aug-2017 nm */
-  pntrString *pntrHugeHdrComment = NULL_PNTRSTRING; /* 8-May-2015 nm */
-  pntrString *pntrBigHdrComment = NULL_PNTRSTRING; /* 8-May-2015 nm */
-  pntrString *pntrSmallHdrComment = NULL_PNTRSTRING; /* 8-May-2015 nm */
-  pntrString *pntrTinyHdrComment = NULL_PNTRSTRING; /* 21-Aug-2017 nm */
-  vstring hdrCommentMarker = ""; /* 4-Aug-2018 nm */
-  vstring hdrCommentAnchor = ""; /* 20-Oct-2018 nm */
-  flag hdrCommentAnchorDone = 0; /* 20-Oct-2018 nm */
+  pntrString *pntrTinyHdr = NULL_PNTRSTRING;
+  pntrString *pntrHugeHdrComment = NULL_PNTRSTRING;
+  pntrString *pntrBigHdrComment = NULL_PNTRSTRING;
+  pntrString *pntrSmallHdrComment = NULL_PNTRSTRING;
+  pntrString *pntrTinyHdrComment = NULL_PNTRSTRING;
+  vstring hdrCommentMarker = "";
+  vstring hdrCommentAnchor = "";
+  flag hdrCommentAnchorDone = 0;
 
   /* Populate the statement map */
   /* ? ? ? Future:  is assertions same as g_Statement[g_statements].pinkNumber? */
@@ -3287,25 +3179,21 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
   }
   if (assertions != g_Statement[g_statements].pinkNumber) bug(2328);
 
-  /* 31-Jul-2006 nm Table of contents mod */
+  /* Table of contents */
   /* Allocate array for section headers found */
   pntrLet(&pntrHugeHdr, pntrSpace(g_statements + 1));
   pntrLet(&pntrBigHdr, pntrSpace(g_statements + 1));
   pntrLet(&pntrSmallHdr, pntrSpace(g_statements + 1));
-  pntrLet(&pntrTinyHdr, pntrSpace(g_statements + 1)); /* 21-Aug-2017 nm */
-  pntrLet(&pntrHugeHdrComment, pntrSpace(g_statements + 1)); /* 8-May-2015 nm */
-  pntrLet(&pntrBigHdrComment, pntrSpace(g_statements + 1)); /* 8-May-2015 nm */
-  pntrLet(&pntrSmallHdrComment, pntrSpace(g_statements + 1)); /* 8-May-2015 nm */
-  pntrLet(&pntrTinyHdrComment, pntrSpace(g_statements + 1)); /* 21-Aug-2017 nm */
+  pntrLet(&pntrTinyHdr, pntrSpace(g_statements + 1));
+  pntrLet(&pntrHugeHdrComment, pntrSpace(g_statements + 1));
+  pntrLet(&pntrBigHdrComment, pntrSpace(g_statements + 1));
+  pntrLet(&pntrSmallHdrComment, pntrSpace(g_statements + 1));
+  pntrLet(&pntrTinyHdrComment, pntrSpace(g_statements + 1));
 
   pages = ((assertions - 1) / theoremsPerPage) + 1;
-  /* for (page = 1; page <= pages; page++) { */
-  /* 8-May-2015 nm */
   for (page = 0; page <= pages; page++) {
     /* Open file */
     let(&outputFileName,
-        /* cat("mmtheorems", (page > 1) ? str(page) : "", ".html", NULL)); */
-        /* 8-May-2015 nm */
         cat("mmtheorems", (page > 0) ? str((double)page) : "", ".html", NULL));
     print2("Creating %s\n", outputFileName);
     outputFilePtr = fSafeOpen(outputFileName, "w", noVersioning);
@@ -3315,22 +3203,19 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     /* TODO 14-Jan-2016: why aren't we using printTexHeader? */
 
     g_outputToString = 1;
-    print2(
-        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n");
+    print2("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n");
     print2(     "    \"http://www.w3.org/TR/html4/loose.dtd\">\n");
     print2("<HTML LANG=\"EN-US\">\n");
     print2("<HEAD>\n");
     print2("%s%s\n", "<META HTTP-EQUIV=\"Content-Type\" ",
         "CONTENT=\"text/html; charset=iso-8859-1\">");
-    /* 13-Aug-2016 nm */
     /* Improve mobile device display per David A. Wheeler */
-    print2(
-"<META NAME=\"viewport\" CONTENT=\"width=device-width, initial-scale=1.0\">\n"
-        );
+    print2("<META NAME=\"viewport\" "
+      "CONTENT=\"width=device-width, initial-scale=1.0\">\n");
 
     print2("<STYLE TYPE=\"text/css\">\n");
     print2("<!--\n");
-    /* 15-Apr-2015 nm - align math symbol images to text */
+    /* align math symbol images to text */
     print2("img { margin-bottom: -4px }\n");
     /* Print style sheet for colored number that goes after statement label */
     print2(".r { font-family: \"Arial Narrow\";\n");
@@ -3346,16 +3231,8 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
         left(outputFileName, (long)strlen(outputFileName) - 5),
         "</TITLE>", NULL));
     */
-    /* 4-Jun-06 nm - Put page name before "Metamath Proof Explorer" etc. */
-    /* 15-Nov-2015 nm - Change print2() to printLongLine() */
+    /* Put page name before "Metamath Proof Explorer" etc. */
     printLongLine(cat("<TITLE>",
-        /* Strip off ".html" */
-        /*
-        left(outputFileName, (long)strlen(outputFileName) - 5),
-        */
-
-        /* "List p. ", str(page), */ /* 21-Jun-2014 */
-        /* 9-May-2015 nm */
         ((page == 0)
             ? "TOC of Theorem List"
             : cat("P. ", str((double)page), " of Theorem List", NULL)),
@@ -3368,30 +3245,20 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     print2("%s%s\n", "<LINK REL=\"shortcut icon\" HREF=\"favicon.ico\" ",
         "TYPE=\"image/x-icon\">");
 
-    /* 18-Oct-2015 nm Image alignment fix */
-    print2(
-        "<STYLE TYPE=\"text/css\">\n");
-    print2(
-        "<!--\n");
+    /* Image alignment fix */
+    print2("<STYLE TYPE=\"text/css\">\n");
+    print2("<!--\n");
     /* Optional information but takes unnecessary file space */
     /* (change @ to * if uncommenting)
-    print2(
-        "/@ Math symbol GIFs will be shifted down 4 pixels to align with\n");
-    print2(
-        "   normal text for compatibility with various browsers.  The old\n");
-    print2(
-        "   ALIGN=TOP for math symbol images did not align in all browsers\n");
-    print2(
-        "   and should be deleted.  All other images must override this\n");
-    print2(
-        "   shift with STYLE=\"margin-bottom:0px\". @/\n");
+    print2("/@ Math symbol GIFs will be shifted down 4 pixels to align with\n");
+    print2("   normal text for compatibility with various browsers.  The old\n");
+    print2("   ALIGN=TOP for math symbol images did not align in all browsers\n");
+    print2("   and should be deleted.  All other images must override this\n");
+    print2("   shift with STYLE=\"margin-bottom:0px\". @/\n");
     */
-    print2(
-        "img { margin-bottom: -4px }\n");
-    print2(
-        "-->\n");
-    print2(
-        "</STYLE>\n");
+    print2("img { margin-bottom: -4px }\n");
+    print2("-->\n");
+    print2("</STYLE>\n");
 
     print2("</HEAD>\n");
     print2("<BODY BGCOLOR=\"#FFFFFF\">\n");
@@ -3401,15 +3268,11 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     printLongLine(cat(
         "<TD NOWRAP ALIGN=CENTER ROWSPAN=2><FONT SIZE=\"+3\" COLOR=",
         GREEN_TITLE_COLOR, "><B>", htmlTitle, "</B></FONT>",
-        "<BR><FONT SIZE=\"+2\" COLOR=",      /* 21-Jun-2014 */
-        GREEN_TITLE_COLOR,                   /* 21-Jun-2014 */
-        /* "><B>Statement List (", */
-        /* 9-May-2015 nm */
+        "<BR><FONT SIZE=\"+2\" COLOR=",
+        GREEN_TITLE_COLOR,
         "><B>Theorem List (",
         ((page == 0)
             ? "Table of Contents"
-            /* : cat("(p. ", str(page), " of ", str(pages), NULL)), */
-            /* 9-May-2015 nm Remove stray "(" */
             : cat("p. ", str((double)page), " of ", str((double)pages), NULL)),
         ")</B></FONT>",
         NULL), "", "\"");
@@ -3423,20 +3286,12 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     /* Output previous and next */
 
 
-    /* 21-Jun-2014 nm Assign prevNextLinks once here since it is used 3 times */
+    /* Assign prevNextLinks once here since it is used 3 times */
     let(&prevNextLinks, cat("<A HREF=\"mmtheorems",
-        /*
-        (page > 1)
-            ? ((page - 1 > 1) ? str(page - 1) : "")
-            : ((pages > 1) ? str(pages) : ""),
-        */
-        /* 8-May-2015 */
         (page > 0)
             ? ((page - 1 > 0) ? str((double)page - 1) : "")
             : ((pages > 0) ? str((double)pages) : ""),
         ".html\">", NULL));
-    /* if (page > 1) { */
-    /* 8-May-2015 */
     if (page > 0) {
       let(&prevNextLinks, cat(prevNextLinks,
           "&lt; Previous</A>&nbsp;&nbsp;", NULL));
@@ -3457,59 +3312,23 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     printLongLine(prevNextLinks,
         " ",  /* Start continuation line with space */
         "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
-    /********* old code that the above printLongLine replaces
-    let(&str1, cat("<A HREF=\"mmtheorems",
-        (page > 1)
-            ? ((page - 1 > 1) ? str(page - 1) : "")
-            : ((pages > 1) ? str(pages) : ""),
-        ".html\">", NULL));
-    if (page > 1) {
-      print2("%s&lt; Previous</A>&nbsp;&nbsp;\n", str1);
-    } else {
-      print2("%s&lt; Wrap</A>&nbsp;&nbsp;\n", str1);
-    }
-    let(&str1, cat("<A HREF=\"mmtheorems",
-        (page < pages)
-            ? str(page + 1)
-            : "",
-        ".html\">", NULL));
-    if (page < pages) {
-      print2("%sNext &gt;</A>\n", str1);
-    } else {
-      print2("%sWrap &gt;</A>\n", str1);
-    }
-    ******************************/
-
 
     /* Finish up header */
     /* Print the GIF/Unicode Font choice, if directories are specified */
     if (htmlDir[0]) {
       if (g_altHtmlFlag) {
-        /* 4-Aug-2018 nm */
         print2("</FONT></TD></TR><TR><TD ALIGN=RIGHT><FONT FACE=sans-serif\n");
         print2("SIZE=-2>Bad symbols? Try the\n");
-        print2("<BR><A HREF=\"%s%s\">GIF\n",
-            htmlDir, outputFileName);
+        print2("<BR><A HREF=\"%s%s\">GIF\n", htmlDir, outputFileName);
         print2("version</A>.</FONT></TD>\n");
-        /* 4-Aug-2018 nm - removed Firefox and IE browser references
-        print2("</FONT></TD></TR><TR><TD ALIGN=RIGHT><FONT FACE=sans-serif\n");
-        print2("SIZE=-2>Bad symbols?\n");
-        print2("Use <A HREF=\"http://mozilla.org\">Firefox</A><BR>\n");
-        print2("(or <A HREF=\"%s%s\">GIF version</A> for IE).</FONT></TD>\n",
-            htmlDir, outputFileName);
-        */
       } else {
         print2("</FONT></TD></TR><TR><TD ALIGN=RIGHT><FONT FACE=sans-serif\n");
         print2("SIZE=-2>Browser slow? Try the\n");
-        print2("<BR><A HREF=\"%s%s\">Unicode\n",
-            altHtmlDir, outputFileName);
+        print2("<BR><A HREF=\"%s%s\">Unicode\n", altHtmlDir, outputFileName);
         print2("version</A>.</FONT></TD>\n");
       }
     }
-    /*print2("</TR></TABLE>\n");*/
-    /*print2("<HR NOSHADE SIZE=1>\n");*/
 
-    /* 4-Aug-2018 nm */
     /* Make breadcrumb font to match other pages */
     print2("<TR>\n");
     print2(
@@ -3517,20 +3336,15 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     print2("<BR>\n");  /* Add a little more vertical space */
 
     /* Print some useful links */
-    /* print2("<CENTER>\n"); */
     print2("<A HREF=\"../mm.html\">Mirrors</A>\n");
     print2("&nbsp;&gt;&nbsp;<A HREF=\"../index.html\">\n");
     print2("Metamath Home Page</A>\n");
 
-    /* print2("&nbsp;&gt;&nbsp;<A HREF=\"mmset.html\">\n"); */
-    /* 15-Apr-2015 nm */
     /* Normally, g_htmlBibliography in the .mm file will have the
        project home page, and we depend on this here rather than
        extracting from g_htmlHome */
     print2("&nbsp;&gt;&nbsp;<A HREF=\"%s\">\n", g_htmlBibliography);
 
-    /* print2("MPE Home Page</A>\n"); */
-    /* 15-Apr-2015 nm */
     /* Put a meaningful abbreviation for the project home page
        by extracting capital letters from title */
     let(&str1, "");
@@ -3542,31 +3356,14 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     }
     print2("%s Home Page</A>\n", str1);
 
-    /* if (page != 1) { */
-    /* 8-May-2015 nm */
     if (page != 0) {
       print2("&nbsp;&gt;&nbsp;<A HREF=\"mmtheorems.html\">\n");
-      /* print2("Statement List Contents</A>\n"); */
-      /* 9-May-2015 nm */
       print2("Theorem List Contents</A>\n");
     } else {
       print2("&nbsp;&gt;&nbsp;\n");
-      /* print2("Statement List Contents\n"); */
-      /* 9-May-2015 nm */
       print2("Theorem List Contents\n");
     }
 
-    /*****
-    /@ 15-Apr-2015 nm @/
-    /@ Use "g_extHtmlStmt <= g_statements" as an indicator that we're doing
-       Metamath Proof Explorer; the others don't have mmrecent.html pages @/
-    /@if (g_extHtmlStmt <= g_statements) {@/ /@ g_extHtmlStmt = g_statements + 1
-                                              unless mmset.html @/
-    /@ 8-Dec-2017 nm @/
-    if (g_extHtmlStmt < g_mathboxStmt) { /@ g_extHtmlStmt >= g_mathboxStmt
-                                              unless mmset.html @/
-    *****/
-    /* 30-Nov-2019 nm */
     /* Assume there is a Most Recent page when the .mm has a mathbox stmt
        (currently set.mm and iset.mm)  */
     if (g_mathboxStmt < g_statements + 1) {
@@ -3577,28 +3374,18 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
 
     print2("&nbsp; &nbsp; &nbsp; <B><FONT COLOR=%s>\n", GREEN_TITLE_COLOR);
     print2("This page:</FONT></B> \n");
-    /* 8-May-2015 nm Deleted, since ToC is now separate page: */
-    /*
-    if (page == 1) {
-      print2("<A HREF=\"#mmstmtlst\">Start of list</A>&nbsp; &nbsp; \n");
-    }
-    */
 
-    /* 18-Oct-2015 nm */
     if (page == 0) {
-      print2(
-          "&nbsp;<A HREF=\"#mmdtoc\">Detailed Table of Contents</A>&nbsp;\n");
+      print2("&nbsp;<A HREF=\"#mmdtoc\">Detailed Table of Contents</A>&nbsp;\n");
     }
 
     print2("<A HREF=\"#mmpglst\">Page List</A>\n");
 
-    /* 4-Aug-2018 nm */
     /* Change breadcrumb font to match other pages */
     print2("</FONT>\n");
     print2("</TD>\n");
     print2("</TR></TABLE>\n");
 
-    /* print2("</CENTER>\n"); */
     print2("<HR NOSHADE SIZE=1>\n");
 
     /* Write out HTML page so far */
@@ -3606,82 +3393,17 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     g_outputToString = 0;
     let(&g_printString, "");
 
-    /***** 21-Jun-2014 Moved to bottom of page ********
-    /@ Output links to the other pages @/
-    fprintf(outputFilePtr, "Jump to page: \n");
-    for (p = 1; p <= pages; p++) {
-
-      /@ Construct the pink number range @/
-      let(&str3, "");
-      str3 = pinkRangeHTML(
-          nmbrStmtNmbr[(p - 1) @ theoremsPerPage + 1],
-          (p < pages) ?
-            nmbrStmtNmbr[p @ theoremsPerPage] :
-            nmbrStmtNmbr[assertions]);
-
-      /@ 31-Jul-2006 nm Change "1" to "Contents + 1" @/
-      if (p == page) {
-        let(&str1,
-            (p == 1) ? "Contents + 1" : str(p) /@ 31-Jul-2006 nm @/
-            ); /@ Current page shouldn't have link to self @/
-      } else {
-        let(&str1, cat("<A HREF=\"mmtheorems",
-            (p == 1) ? "" : str(p),
-            /@ (p == 1) ? ".html#mmtc\">" : ".html\">", @/ /@ 31-Aug-2006 nm @/
-            ".html\">", /@ 8-Feb-2007 nm Friendlier, because you can start
-                  scrolling through the page before it finishes loading,
-                  without its jumping to #mmtc (start of Table of Contents)
-                  when it's done. @/
-            (p == 1) ? "Contents + 1" : str(p) /@ 31-Jul-2006 nm @/
-            , "</A>", NULL));
-      }
-      let(&str1, cat(str1, PINK_NBSP, str3, NULL));
-      fprintf(outputFilePtr, "%s\n", str1);
-    }
-    ******** end of 21-Jun-2014 move *******/
-
-    /* 31-Jul-2006 nm Add table of contents to first WRITE THEOREM page */
-    /* if (page == 1) { */ /* We're on page 1 */
-    /* 8-May-2015 nm */
+    /* Add table of contents to first WRITE THEOREM page */
     if (page == 0) {  /* We're on ToC page */
 
-      /* Pass 1: table of contents summary; pass 2: detail */ /* 18-Oct-2015 */
+      /* Pass 1: table of contents summary; pass 2: detail */
       for (passNumber = 1; passNumber <= 2; passNumber++) {
-
         g_outputToString = 1;
-
-        /* 18-Oct-2015 deleted
-        print2(
-        "<P><CENTER><A NAME=\"mmtc\"></A><B>Table of Contents</B></CENTER>\n");
-        */
-        /* 18-Oct-2015 nm */
         if (passNumber == 1) {
-
-/* 24-Oct-2018 nm Temporary hopefully */
-/* 31-Oct-2018 nm Implemented workaround; see below under this date */
-/*
-print2("<P><CENTER><B><FONT COLOR=RED>The Chrome browser has a\n");
-print2("bug that hyperlinks to incorrect anchors.\n");
-print2("If you click on PART 2 in the summary, it should go to PART 2 in\n");
-print2("the detailed section.  If it goes to PART 1, your browser has the bug.\n");
-print2("If your Chrome version works, let me (Norm Megill) know\n");
-print2("the version number so I can mention it here.  Otherwise you will\n");
-print2("need another browser to navigate. This page works with Firefox\n");
-print2("and Internet Explorer and passes validator.w3.org.\n");
-print2("</FONT></B></CENTER>\n");
-*/
-
-
-          print2(
-              "<P><CENTER><B>Table of Contents Summary</B></CENTER>\n");
+          print2("<P><CENTER><B>Table of Contents Summary</B></CENTER>\n");
         } else {
-          print2(
-  "<P><CENTER><A NAME=\"mmdtoc\"></A><B>Detailed Table of Contents</B><BR>\n");
-
-          /* 4-Aug-2018 nm */
-          print2(
-           "<B>(* means the section header has a description)</B></CENTER>\n");
-
+          print2("<P><CENTER><A NAME=\"mmdtoc\"></A><B>Detailed Table of Contents</B><BR>\n");
+          print2("<B>(* means the section header has a description)</B></CENTER>\n");
         }
 
         fprintf(outputFilePtr, "%s", g_printString);
@@ -3697,24 +3419,16 @@ print2("</FONT></B></CENTER>\n");
         let(&bigHdrComment, "");
         let(&smallHdrComment, "");
         let(&tinyHdrComment, "");
-        partCntr = 0;    /* Initialize counters */    /* 21-Jun-2014 */
+        partCntr = 0;    /* Initialize counters */
         sectionCntr = 0;
         subsectionCntr = 0;
-        subsubsectionCntr = 0; /* 21-Aug-2017 nm */
+        subsubsectionCntr = 0;
         for (stmt = 1; stmt <= g_statements; stmt++) {
-
-          /* 18-Dec-2016 nm moved to below the "if"
-          getSectionHeadings(stmt, &hugeHdr, &bigHdr, &smallHdr,
-              /@ 5-May-2015 nm @/
-              &hugeHdrComment, &bigHdrComment, &smallHdrComment);
-          */
-
           /* Output the headers for $a and $p statements */
           if (g_Statement[stmt].type == p_ || g_Statement[stmt].type == a_) {
-            hdrCommentAnchorDone = 0; /* 20-Oct-2018 nm */
+            hdrCommentAnchorDone = 0;
             getSectionHeadings(stmt, &hugeHdr, &bigHdr, &smallHdr,
-                &tinyHdr, /* 21-Aug-2017 nm */
-                /* 5-May-2015 nm */
+                &tinyHdr,
                 &hugeHdrComment, &bigHdrComment, &smallHdrComment,
                 &tinyHdrComment,
                 0, /* fineResolution */
@@ -3726,37 +3440,31 @@ print2("</FONT></B></CENTER>\n");
                   + 1; /* Page # */
               /* let(&str3, cat("mmtheorems", (i == 1) ? "" : str(i), ".html#", */
                           /* Note that page 1 has no number after mmtheorems */
-              /* 8-May-2015 nm */
               let(&str3, cat("mmtheorems", str((double)i), ".html#",
                   /* g_Statement[stmt].labelName, NULL)); */
                   "mm", str((double)(g_Statement[stmt].pinkNumber)), NULL));
                      /* Link to page/location - no theorem can be named "mm*" */
               let(&str4, "");
               str4 = pinkHTML(stmt);
-              /*let(&str4, right(str4, (long)strlen(PINK_NBSP) + 1));*/
-                                                          /* Discard "&nbsp;" */
-              if (hugeHdr[0]) {    /* 21-Jun-2014 nm */
+              if (hugeHdr[0]) {
 
                 /* Create part number */
                 partCntr++;
                 sectionCntr = 0;
                 subsectionCntr = 0;
-                subsubsectionCntr = 0; /* 21-Aug-2017 nm */
+                subsubsectionCntr = 0;
                 let(&hugeHdr, cat("PART ", str((double)partCntr), "&nbsp;&nbsp;",
                     hugeHdr, NULL));
 
-                /* 4-Aug-2018 nm */
-                /* Put an asterisk before the header if the header has
-                   a comment */
+                /* Put an asterisk before the header if the header has a comment */
                 if (hugeHdrComment[0] != 0 && passNumber == 2) {
                   let(&hdrCommentMarker, "*");
-                  /* 20-Oct-2018 nm */
                   if (hdrCommentAnchorDone == 0) {
                     let(&hdrCommentAnchor, cat(
                         "<A NAME=\"",
                         g_Statement[stmt].labelName, "\"></A>",
 
-                        /* 27-Aug-2019 nm "&#8203;" is a "zero-width" space to
+                        /* "&#8203;" is a "zero-width" space to
                            workaround Chrome bug that jumps to wrong anchor. */
                         "&#8203;",
 
@@ -3771,57 +3479,44 @@ print2("</FONT></B></CENTER>\n");
                 }
 
                 printLongLine(cat(
-
-                    /* 18-Oct-2015 nm */
                     /* In detailed section, add an anchor to reach it from
                        summary section */
                     (passNumber == 2) ?
                         cat("<A NAME=\"dtl:", str((double)partCntr),
                             "\"></A>",
-
-                            /* 27-Aug-2019 nm "&#8203;" is a "zero-width" space to
+                            /* "&#8203;" is a "zero-width" space to
                                workaround Chrome bug that jumps to wrong anchor. */
                             "&#8203;",
-
                             NULL) : "",
 
-                    /* 29-Jul-2008 nm Add an anchor to the "sandbox" theorem
+                    /* Add an anchor to the "sandbox" theorem
                        for use by mmrecent.html */
-                    /* 21-Jun-2014 nm We use "sandbox:bighdr" for both here and
+                    /* We use "sandbox:bighdr" for both here and
                        below so that either huge or big header type could
                        be used to start mathbox sections */
                     (stmt == g_mathboxStmt && bigHdr[0] == 0
-                          /* 4-Aug-2018 nm */
                           && passNumber == 1 /* Only in summary TOC */
                           ) ?
                         /* Note the colon so it won't conflict w/ theorem
                            name anchor */
-                        /*"<A NAME=\"sandbox:bighdr\"></A>" : "",*/
-                        /* 27-Aug-2019 nm "&#8203;" is a "zero-width" space to
+                        /* "&#8203;" is a "zero-width" space to
                            workaround Chrome bug that jumps to wrong anchor. */
                         "<A NAME=\"sandbox:bighdr\"></A>&#8203;" : "",
 
-                    hdrCommentAnchor, /* 20-Oct-2018 nm */
+                    hdrCommentAnchor,
                     "<A HREF=\"",
 
-                    /* 18-Oct-2015 nm */
                     (passNumber == 1) ?
                         cat("#dtl:", str((double)partCntr), NULL)  /* Link to detailed toc */
                         : cat(str3, "h", NULL), /* Link to thm list */
 
                     "\"><B>",
-                    hdrCommentMarker, /* 4-Aug-2018 nm */
+                    hdrCommentMarker,
                     hugeHdr, "</B></A>",
-                    /*
-                    " &nbsp; <A HREF=\"",
-                    g_Statement[stmt].labelName, ".html\">",
-                    g_Statement[stmt].labelName, "</A>",
-                    str4,
-                    */
                     "<BR>", NULL),
                     " ",  /* Start continuation line with space */
                     "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
-                if (passNumber == 2) { /* 18-Oct-2015 nm */
+                if (passNumber == 2) {
                   /* Assign to array for use during theorem output */
                   let((vstring *)(&pntrHugeHdr[stmt]), hugeHdr);
                   let((vstring *)(&pntrHugeHdrComment[stmt]), hugeHdrComment);
@@ -3831,26 +3526,24 @@ print2("</FONT></B></CENTER>\n");
               }
               if (bigHdr[0]) {
 
-                /* Create section number */  /* 21-Jun-2014 */
+                /* Create section number */
                 sectionCntr++;
                 subsectionCntr = 0;
-                subsubsectionCntr = 0; /* 21-Aug-2017 nm */
+                subsubsectionCntr = 0;
                 let(&bigHdr, cat(str((double)partCntr), ".", str((double)sectionCntr),
                     "&nbsp;&nbsp;",
                     bigHdr, NULL));
 
-                /* 4-Aug-2018 nm */
                 /* Put an asterisk before the header if the header has
                    a comment */
                 if (bigHdrComment[0] != 0 && passNumber == 2) {
                   let(&hdrCommentMarker, "*");
-                  /* 20-Oct-2018 nm */
                   if (hdrCommentAnchorDone == 0) {
                     let(&hdrCommentAnchor, cat(
                         "<A NAME=\"",
                         g_Statement[stmt].labelName, "\"></A>",
 
-                        /* 27-Aug-2019 nm "&#8203;" is a "zero-width" space to
+                        /* "&#8203;" is a "zero-width" space to
                            workaround Chrome bug that jumps to wrong anchor. */
                         "&#8203;",
 
@@ -3867,36 +3560,32 @@ print2("</FONT></B></CENTER>\n");
                 printLongLine(cat(
                     "&nbsp; &nbsp; &nbsp; ", /* Indentation spacing */
 
-                    /* 18-Oct-2015 nm */
                     /* In detailed section, add an anchor to reach it from
                        summary section */
                     (passNumber == 2) ?
                         cat("<A NAME=\"dtl:", str((double)partCntr), ".",
                             str((double)sectionCntr), "\"></A>",
 
-                            /* 27-Aug-2019 nm "&#8203;" is a "zero-width" space to
+                            /* "&#8203;" is a "zero-width" space to
                                workaround Chrome bug that jumps to wrong anchor. */
                             "&#8203;",
 
                             NULL)
                         : "",
 
-                    /* 29-Jul-2008 nm Add an anchor to the "sandbox" theorem
+                    /* Add an anchor to the "sandbox" theorem
                        for use by mmrecent.html */
                     (stmt == g_mathboxStmt
-                          /* 4-Aug-2018 nm */
                           && passNumber == 1 /* Only in summary TOC */
                           ) ?
                         /* Note the colon so it won't conflict w/ theorem
                            name anchor */
-                        /*"<A NAME=\"sandbox:bighdr\"></A>" : "",*/
-                        /* 27-Aug-2019 nm "&#8203;" is a "zero-width" space to
+                        /* "&#8203;" is a "zero-width" space to
                            workaround Chrome bug that jumps to wrong anchor. */
                         "<A NAME=\"sandbox:bighdr\"></A>&#8203;" : "",
-                    hdrCommentAnchor, /* 20-Oct-2018 nm */
+                    hdrCommentAnchor,
                     "<A HREF=\"",
 
-                    /* 18-Oct-2015 nm */
                     (passNumber == 1) ?
                          cat("#dtl:", str((double)partCntr), ".",
                              str((double)sectionCntr),
@@ -3904,18 +3593,12 @@ print2("</FONT></B></CENTER>\n");
                         : cat(str3, "b", NULL), /* Link to thm list */
 
                     "\"><B>",
-                    hdrCommentMarker, /* 4-Aug-2018 */
+                    hdrCommentMarker,
                     bigHdr, "</B></A>",
-                    /*
-                    " &nbsp; <A HREF=\"",
-                    g_Statement[stmt].labelName, ".html\">",
-                    g_Statement[stmt].labelName, "</A>",
-                    str4,
-                    */
                     "<BR>", NULL),
                     " ",  /* Start continuation line with space */
                     "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
-                if (passNumber == 2) { /* 18-Oct-2015 nm */
+                if (passNumber == 2) {
                   /* Assign to array for use during theorem list output */
                   let((vstring *)(&pntrBigHdr[stmt]), bigHdr);
                   let((vstring *)(&pntrBigHdrComment[stmt]), bigHdrComment);
@@ -3926,25 +3609,23 @@ print2("</FONT></B></CENTER>\n");
               if (smallHdr[0]
                   && passNumber == 2) {  /* Skip in pass 1 (summary) */
 
-                /* Create subsection number */  /* 21-Jun-2014 */
+                /* Create subsection number */
                 subsectionCntr++;
-                subsubsectionCntr = 0; /* 21-Aug-2017 nm */
+                subsubsectionCntr = 0;
                 let(&smallHdr, cat(str((double)partCntr), ".",
                     str((double)sectionCntr),
                     ".", str((double)subsectionCntr), "&nbsp;&nbsp;",
                     smallHdr, NULL));
 
-                /* 4-Aug-2018 nm */
                 /* Put an asterisk before the header if the header has
                    a comment */
                 if (smallHdrComment[0] != 0 && passNumber == 2) {
                   let(&hdrCommentMarker, "*");
-                  /* 20-Oct-2018 nm */
                   if (hdrCommentAnchorDone == 0) {
                     let(&hdrCommentAnchor, cat("<A NAME=\"",
                         g_Statement[stmt].labelName, "\"></A>",
 
-                        /* 27-Aug-2019 nm "&#8203;" is a "zero-width" space to
+                        /* "&#8203;" is a "zero-width" space to
                            workaround Chrome bug that jumps to wrong anchor. */
                         "&#8203;",
 
@@ -3959,17 +3640,9 @@ print2("</FONT></B></CENTER>\n");
                 }
 
                 printLongLine(cat("&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; ",
-
-                    /* 23-May-2008 nm Add an anchor to the "sandbox" theorem
-                       for use by mmrecent.html */
-                    /*
-                    !strcmp(g_Statement[stmt].labelName, "sandbox") ?
-                        "<A NAME=\"sandbox:smallhdr\"></A>&#8203;" : "",
-                    */
-
-                    hdrCommentAnchor, /* 20-Oct-2018 nm */
+                    hdrCommentAnchor,
                     "<A HREF=\"", str3, "s\">",
-                    hdrCommentMarker, /* 4-Aug-2018 */
+                    hdrCommentMarker,
                     smallHdr, "</A>",
                     " &nbsp; <A HREF=\"",
                     g_Statement[stmt].labelName, ".html\">",
@@ -3985,11 +3658,9 @@ print2("</FONT></B></CENTER>\n");
                 let(&smallHdrComment, "");
               }
 
-              /* Added 21-Aug-2017 nm */
-              if (tinyHdr[0]
-                  && passNumber == 2) {  /* Skip in pass 1 (summary) */
+              if (tinyHdr[0] && passNumber == 2) {  /* Skip in pass 1 (summary) */
 
-                /* Create subsection number */  /* 21-Jun-2014 */
+                /* Create subsection number */
                 subsubsectionCntr++;
                 let(&tinyHdr, cat(str((double)partCntr), ".",
                     str((double)sectionCntr),
@@ -3997,17 +3668,15 @@ print2("</FONT></B></CENTER>\n");
                     ".", str((double)subsubsectionCntr), "&nbsp;&nbsp;",
                     tinyHdr, NULL));
 
-                /* 4-Aug-2018 nm */
                 /* Put an asterisk before the header if the header has
                    a comment */
                 if (tinyHdrComment[0] != 0 && passNumber == 2) {
                   let(&hdrCommentMarker, "*");
-                  /* 20-Oct-2018 nm */
                   if (hdrCommentAnchorDone == 0) {
                     let(&hdrCommentAnchor, cat("<A NAME=\"",
                         g_Statement[stmt].labelName, "\"></A> ",
 
-                        /* 27-Aug-2019 nm "&#8203;" is a "zero-width" space to
+                        /* "&#8203;" is a "zero-width" space to
                            workaround Chrome bug that jumps to wrong anchor. */
                         "&#8203;",
 
@@ -4022,17 +3691,10 @@ print2("</FONT></B></CENTER>\n");
                 }
 
                 printLongLine(cat(
-         "&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; ",
-                    /* 23-May-2008 nm Add an anchor to the "sandbox" theorem
-                       for use by mmrecent.html */
-                    /*
-                    !strcmp(g_Statement[stmt].labelName, "sandbox") ?
-                        "<A NAME=\"sandbox:tinyhdr\"></A>&#8203;" : "",
-                    */
-
-                    hdrCommentAnchor, /* 20-Oct-2018 nm */
+                    "&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; ",
+                    hdrCommentAnchor,
                     "<A HREF=\"", str3, "s\">",
-                    hdrCommentMarker, /* 4-Aug-2018 */
+                    hdrCommentMarker,
                     tinyHdr, "</A>",
                     " &nbsp; <A HREF=\"",
                     g_Statement[stmt].labelName, ".html\">",
@@ -4047,7 +3709,6 @@ print2("</FONT></B></CENTER>\n");
                 let((vstring *)(&pntrTinyHdrComment[stmt]), tinyHdrComment);
                 let(&tinyHdrComment, "");
               }
-              /* (End of 21-Aug-2017 addition) */
 
               fprintf(outputFilePtr, "%s", g_printString);
               g_outputToString = 0;
@@ -4058,20 +3719,18 @@ print2("</FONT></B></CENTER>\n");
         /* 8-May-2015 nm Do we need the HR below? */
         fprintf(outputFilePtr, "<HR NOSHADE SIZE=1>\n");
 
-      } /* next passNumber */ /* 18-Oct-2015 nm */
+      } /* next passNumber */
 
     } /* if page 0 */
-    /* End of 31-Jul-2006 added code for table of contents mod */
+    /* End table of contents */
 
-    /* 8-May-2015 nm Just skip over instead of a big if indent */
+    /* Just skip over instead of a big if indent */
     if (page == 0) goto SKIP_LIST;
 
 
     /* Put in color key */
     g_outputToString = 1;
     print2("<A NAME=\"mmstmtlst\"></A>\n");
-    /*if (g_extHtmlStmt <= g_statements) {*/ /* g_extHtmlStmt = g_statements + 1 in ql.mm */
-    /* 8-Dec-2017 nm */
     if (g_extHtmlStmt < g_mathboxStmt) { /* g_extHtmlStmt >= g_mathboxStmt in ql.mm */
       /* ?? Currently this is customized for set.mm only!! */
       print2("<P>\n");
@@ -4105,7 +3764,6 @@ print2("</FONT></B></CENTER>\n");
       print2("&nbsp;Hilbert Space Explorer</A>\n");
 
       let(&str3, "");
-      /* str3 = pinkRangeHTML(g_extHtmlStmt, nmbrStmtNmbr[assertions]); */
       if (g_Statement[g_mathboxStmt].pinkNumber <= 0) bug(2333);
       str3 = pinkRangeHTML(g_extHtmlStmt,
          nmbrStmtNmbr[g_Statement[g_mathboxStmt].pinkNumber - 1]);
@@ -4119,18 +3777,10 @@ print2("</FONT></B></CENTER>\n");
       print2("\n");
 
 
-      /* 29-Jul-2008 nm Sandbox stuff */
+      /* Mathbox stuff */
       print2("<TD BGCOLOR=%s NOWRAP><A\n", SANDBOX_COLOR);
-      print2(
-   /*" HREF=\"mmtheorems.html#sandbox:bighdr\"><IMG SRC=\"_sandbox.gif\"\n");*/
-      /* 24-Jul-2009 nm Changed name of sandbox to "mathbox" */
-       " HREF=\"mathbox.html\"><IMG SRC=\"_sandbox.gif\"\n");
-      print2(
-     /*"BORDER=0 ALT=\"User Sandboxes\" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE>\n");*/
-         /* 24-Jul-2009 nm Changed name of sandbox to "mathbox" */
-         "BORDER=0 ALT=\"Users' Mathboxes\" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE>\n");
-      /*print2("&nbsp;User Sandboxes</A>\n");*/
-      /* 24-Jul-2009 nm Changed name of sandbox to "mathbox" */
+      print2(" HREF=\"mathbox.html\"><IMG SRC=\"_sandbox.gif\"\n");
+      print2("BORDER=0 ALT=\"Users' Mathboxes\" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE>\n");
       print2("&nbsp;Users' Mathboxes</A>\n");
 
       let(&str3, "");
@@ -4160,8 +3810,6 @@ print2("</FONT></B></CENTER>\n");
     print2("<P><CENTER>\n");
     print2("<TABLE BORDER CELLSPACING=0 CELLPADDING=3 BGCOLOR=%s\n",
         MINT_BACKGROUND_COLOR);
-    /* print2("SUMMARY=\"Statement List for %s\">\n", htmlTitle); */
-    /* 9-May-2015 nm */
     print2("SUMMARY=\"Theorem List for %s\">\n", htmlTitle);
     let(&str3, "");
     if (page < 1) bug(2335); /* Page 0 ToC should have been skipped */
@@ -4172,17 +3820,8 @@ print2("</FONT></B></CENTER>\n");
         nmbrStmtNmbr[page * theoremsPerPage] :
         nmbrStmtNmbr[assertions]);
     let(&str4, right(str4, (long)strlen(PINK_NBSP) + 1)); /* Discard "&nbsp;" */
-    /* printLongLine(cat("<CAPTION><B>Statement List for ", htmlTitle, */
-    /* 9-May-2015 nm */
     printLongLine(cat("<CAPTION><B>Theorem List for ", htmlTitle,
         " - </B>", str3, "<B>-</B>", str4,
-        /* 21-Jun-2014 - redundant, since it's in the title now
-        "<B>",
-        " - Page ",
-        str(page), " of ",
-        str(pages),
-        "</B>",
-        */
         " &nbsp; *Has distinct variable group(s)"
         "</CAPTION>",NULL),
         " ",  /* Start continuation line with space */
@@ -4204,17 +3843,6 @@ print2("</FONT></B></CENTER>\n");
         assertion <= page * theoremsPerPage; assertion++) {
       if (assertion > assertions) break; /* We're beyond the end */
 
-      /* nm 22-Jan-04 Don't count statements whose names begin with "xxx"
-         because they will not be output */
-      /* 9-May-2015 nm Can this be deleted?  Do we need it anymore? */
-      /* Deleted 4-Aug-2018 nm
-      if (strcmp("xxx", left(g_Statement[s].labelName, 3))) {
-        lastAssertion = assertion;
-      }
-      let(&str1, ""); /@ Purge string stack if too many left()'s @/
-      */
-
-      /* 4-Aug-2018 nm The above was replaced with: */
       lastAssertion = assertion;
     }
 
@@ -4224,17 +3852,6 @@ print2("</FONT></B></CENTER>\n");
       if (assertion > assertions) break; /* We're beyond the end */
 
       s = nmbrStmtNmbr[assertion]; /* Statement number */
-      /* Output only $p's, not $a's */
-      /*if (g_Statement[s].type != p_) continue;*/ /* Now do everything */
-
-      /********* Deleted 3-May-2017 nm
-      /@ nm 22-Jan-04 Skip statements whose labels begin "xxx" - this
-         means they are temporary placeholders created by
-         WRITE SOURCE / CLEAN in writeSource() in mmcmds.c @/
-      let(&str1, ""); /@ Purge string stack if too many left()'s @/
-      /@ 9-May-2015 nm Can this be deleted?  Do we need it anymore? @/
-      if (!strcmp("xxx", left(g_Statement[s].labelName, 3))) continue;
-      ******/
 
       /* Construct the statement type label */
       if (g_Statement[s].type == p_) {
@@ -4273,31 +3890,25 @@ print2("</FONT></B></CENTER>\n");
       g_outputToString = 1;
       print2("\n"); /* Blank line for HTML source human readability */
 
-      /* 31-Jul-2006 nm Table of contents mod */
+      /* Table of contents */
       if (((vstring)(pntrHugeHdr[s]))[0]) { /* There is a major part break */
-        printLongLine(cat(                                  /* 21-Jun-2014 */
+        printLongLine(cat(
                  /* The header */
                  "<TR BGCOLOR=\"#FFFFF2\"><TD COLSPAN=3",
-                 /* " ALIGN=CENTER><FONT SIZE=\"+1\"><B>", */
-                 /* 9-May-2015 nm */
                  "><CENTER><FONT SIZE=\"+1\"><B>",
                  "<A NAME=\"mm", str((double)(g_Statement[s].pinkNumber)),
                      "h\"></A>",   /* Anchor for table of contents */
                  (vstring)(pntrHugeHdr[s]),
-                 /* "</B></FONT></TD></TR>", */
-                 /* 9-May-2015 nm */
                  "</B></FONT></CENTER>",
                  NULL),
             " ",  /* Start continuation line with space */
             "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
 
-        /* 8-May-2015 nm */
         /* The comment part of the header, if any */
         if (((vstring)(pntrHugeHdrComment[s]))[0]) {
 
           /* Open the table row */
-          /* print2("%s\n", "<TR BGCOLOR=\"#FFFFF2\"><TD COLSPAN=3>"); */\
-          /* 9-May-2015 nm - keep comment in same table cell */
+          /* keep comment in same table cell */
           print2("%s\n", "<P STYLE=\"margin-bottom:0em\">");
 
           /* We are currently printing to g_printString to allow use of
@@ -4314,26 +3925,19 @@ print2("</FONT></B></CENTER>\n");
           let(&g_printString, "");
           g_showStatement = s; /* For printTexComment */
           g_texFilePtr = outputFilePtr; /* For printTexComment */
-          /* 8-May-2015 ???Future - make this just return a string??? */
-          /* printTexComment((vstring)(pntrHugeHdrComment[s]), 0); */
-          /* 17-Nov-2015 nm Add 3rd & 4th arguments */
           printTexComment(  /* Sends result to g_texFilePtr */
               (vstring)(pntrHugeHdrComment[s]),
               0, /* 1 = htmlCenterFlag */
-              PROCESS_EVERYTHING, /* actionBits */ /* 13-Dec-2018 nm */
+              PROCESS_EVERYTHING, /* actionBits */
               0 /* 1 = noFileCheck */);
           g_texFilePtr = NULL;
           g_outputToString = 1; /* Restore after printTexComment */
-
-          /* Close the table row */
-          /* print2("%s\n", "</TD></TR>"); */ /* 9-May-2015 nm */
         }
 
-        /* 9-May-2015 nm */
         /* Close the table row */
         print2("%s\n", "</TD></TR>");
 
-        printLongLine(cat(                                  /* 21-Jun-2014 */
+        printLongLine(cat(
                  /* Separator row */
                  "<TR BGCOLOR=white><TD COLSPAN=3>",
                  "<FONT SIZE=-3>&nbsp;</FONT></TD></TR>",
@@ -4345,26 +3949,20 @@ print2("</FONT></B></CENTER>\n");
         printLongLine(cat(
                  /* The header */
                  "<TR BGCOLOR=\"#FFFFF2\"><TD COLSPAN=3",
-                 /* " ALIGN=CENTER><FONT SIZE=\"+1\"><B>", */
-                 /* 9-May-2015 nm */
                  "><CENTER><FONT SIZE=\"+1\"><B>",
                  "<A NAME=\"mm", str((double)(g_Statement[s].pinkNumber)),
                      "b\"></A>",      /* Anchor for table of contents */
                  (vstring)(pntrBigHdr[s]),
-                 /* "</B></FONT></TD></TR>", */
-                 /* 9-May-2015 nm */
                  "</B></FONT></CENTER>",
                  NULL),
             " ",  /* Start continuation line with space */
             "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
 
-        /* 8-May-2015 nm */
         /* The comment part of the header, if any */
         if (((vstring)(pntrBigHdrComment[s]))[0]) {
 
           /* Open the table row */
-          /* print2("%s\n", "<TR BGCOLOR=\"#FFFFF2\"><TD COLSPAN=3>"); */\
-          /* 9-May-2015 nm - keep comment in same table cell */
+          /* keep comment in same table cell */
           print2("%s\n", "<P STYLE=\"margin-bottom:0em\">");
 
           /* We are currently printing to g_printString to allow use of
@@ -4381,26 +3979,19 @@ print2("</FONT></B></CENTER>\n");
           let(&g_printString, "");
           g_showStatement = s; /* For printTexComment */
           g_texFilePtr = outputFilePtr; /* For printTexComment */
-          /* 8-May-2015 ???Future - make this just return a string??? */
-          /* printTexComment((vstring)(pntrBigHdrComment[s]), 0); */
-          /* 17-Nov-2015 nm Add 3rd & 4th arguments */
           printTexComment(  /* Sends result to g_texFilePtr */
               (vstring)(pntrBigHdrComment[s]),
               0, /* 1 = htmlCenterFlag */
-              PROCESS_EVERYTHING, /* actionBits */ /* 13-Dec-2018 nm */
+              PROCESS_EVERYTHING, /* actionBits */
               0  /* 1 = noFileCheck */);
           g_texFilePtr = NULL;
           g_outputToString = 1; /* Restore after printTexComment */
-
-          /* Close the table row */
-          /* print2("%s\n", "</TD></TR>"); */ /* 9-May-2015 nm */
         }
 
-        /* 9-May-2015 nm */
         /* Close the table row */
         print2("%s\n", "</TD></TR>");
 
-        printLongLine(cat(                                  /* 21-Jun-2014 */
+        printLongLine(cat(
                  /* Separator row */
                  "<TR BGCOLOR=white><TD COLSPAN=3>",
                  "<FONT SIZE=-3>&nbsp;</FONT></TD></TR>",
@@ -4412,26 +4003,20 @@ print2("</FONT></B></CENTER>\n");
         printLongLine(cat(
                  /* The header */
                  "<TR BGCOLOR=\"#FFFFF2\"><TD COLSPAN=3",
-                 /* " ALIGN=CENTER><B>", */
-                 /* 9-May-2015 nm */
                  "><CENTER><B>",
                  "<A NAME=\"mm", str((double)(g_Statement[s].pinkNumber)),
                      "s\"></A>",    /* Anchor for table of contents */
                  (vstring)(pntrSmallHdr[s]),
-                 /* "</B></TD></TR>", */
-                 /* 9-May-2015 nm */
                  "</B></CENTER>",
                  NULL),
             " ",  /* Start continuation line with space */
             "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
 
-        /* 8-May-2015 nm */
         /* The comment part of the header, if any */
         if (((vstring)(pntrSmallHdrComment[s]))[0]) {
 
           /* Open the table row */
-          /* print2("%s\n", "<TR BGCOLOR=\"#FFFFF2\"><TD COLSPAN=3>"); */\
-          /* 9-May-2015 nm - keep comment in same table cell */
+          /* keep comment in same table cell */
           print2("%s\n", "<P STYLE=\"margin-bottom:0em\">");
 
           /* We are currently printing to g_printString to allow use of
@@ -4448,26 +4033,19 @@ print2("</FONT></B></CENTER>\n");
           let(&g_printString, "");
           g_showStatement = s; /* For printTexComment */
           g_texFilePtr = outputFilePtr; /* For printTexComment */
-          /* 8-May-2015 ???Future - make this just return a string??? */
-          /* printTexComment((vstring)(pntrSmallHdrComment[s]), 0); */
-          /* 17-Nov-2015 nm Add 3rd & 4th arguments */
           printTexComment(  /* Sends result to g_texFilePtr */
               (vstring)(pntrSmallHdrComment[s]),
               0, /* 1 = htmlCenterFlag */
-              PROCESS_EVERYTHING, /* actionBits */ /* 13-Dec-2018 nm */
+              PROCESS_EVERYTHING, /* actionBits */
               0  /* 1 = noFileCheck */);
           g_texFilePtr = NULL;
           g_outputToString = 1; /* Restore after printTexComment */
-
-          /* Close the table row */
-          /* print2("%s\n", "</TD></TR>"); */ /* 9-May-2015 nm */
         }
 
-        /* 9-May-2015 nm */
         /* Close the table row */
         print2("%s\n", "</TD></TR>");
 
-        printLongLine(cat(                                  /* 21-Jun-2014 */
+        printLongLine(cat(
                  /* Separator row */
                  "<TR BGCOLOR=white><TD COLSPAN=3>",
                  "<FONT SIZE=-3>&nbsp;</FONT></TD></TR>",
@@ -4476,31 +4054,24 @@ print2("</FONT></B></CENTER>\n");
             "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
       }
 
-      /* Added 21-Aug-2017 nm */
       if (((vstring)(pntrTinyHdr[s]))[0]) { /* There is a subsubsection break */
         printLongLine(cat(
                  /* The header */
                  "<TR BGCOLOR=\"#FFFFF2\"><TD COLSPAN=3",
-                 /* " ALIGN=CENTER><B>", */
-                 /* 9-May-2015 nm */
                  "><CENTER><B>",
                  "<A NAME=\"mm", str((double)(g_Statement[s].pinkNumber)),
                      "s\"></A>",    /* Anchor for table of contents */
                  (vstring)(pntrTinyHdr[s]),
-                 /* "</B></TD></TR>", */
-                 /* 9-May-2015 nm */
                  "</B></CENTER>",
                  NULL),
             " ",  /* Start continuation line with space */
             "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
 
-        /* 8-May-2015 nm */
         /* The comment part of the header, if any */
         if (((vstring)(pntrTinyHdrComment[s]))[0]) {
 
           /* Open the table row */
-          /* print2("%s\n", "<TR BGCOLOR=\"#FFFFF2\"><TD COLSPAN=3>"); */\
-          /* 9-May-2015 nm - keep comment in same table cell */
+          /* keep comment in same table cell */
           print2("%s\n", "<P STYLE=\"margin-bottom:0em\">");
 
           /* We are currently printing to g_printString to allow use of
@@ -4517,26 +4088,19 @@ print2("</FONT></B></CENTER>\n");
           let(&g_printString, "");
           g_showStatement = s; /* For printTexComment */
           g_texFilePtr = outputFilePtr; /* For printTexComment */
-          /* 8-May-2015 ???Future - make this just return a string??? */
-          /* printTexComment((vstring)(pntrTinyHdrComment[s]), 0); */
-          /* 17-Nov-2015 nm Add 3rd & 4th arguments */
           printTexComment(  /* Sends result to g_texFilePtr */
               (vstring)(pntrTinyHdrComment[s]),
               0, /* 1 = htmlCenterFlag */
-              PROCESS_EVERYTHING, /* actionBits */ /* 13-Dec-2018 nm */
+              PROCESS_EVERYTHING, /* actionBits */
               0  /* 1 = noFileCheck */);
           g_texFilePtr = NULL;
           g_outputToString = 1; /* Restore after printTexComment */
-
-          /* Close the table row */
-          /* print2("%s\n", "</TD></TR>"); */ /* 9-May-2015 nm */
         }
 
-        /* 9-May-2015 nm */
         /* Close the table row */
         print2("%s\n", "</TD></TR>");
 
-        printLongLine(cat(                                  /* 21-Jun-2014 */
+        printLongLine(cat(
                  /* Separator row */
                  "<TR BGCOLOR=white><TD COLSPAN=3>",
                  "<FONT SIZE=-3>&nbsp;</FONT></TD></TR>",
@@ -4544,14 +4108,12 @@ print2("</FONT></B></CENTER>\n");
             " ",  /* Start continuation line with space */
             "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
       }
-      /* (End of 21-Aug-2017 addition) */
 
       printLongLine(cat(
             (s < g_extHtmlStmt)
                ? "<TR>"
                : (s < g_mathboxStmt)
                    ? cat("<TR BGCOLOR=", PURPLISH_BIBLIO_COLOR, ">", NULL)
-                   /* 29-Jul-2008 nm Sandbox stuff */
                    : cat("<TR BGCOLOR=", SANDBOX_COLOR, ">", NULL),
             "<TD NOWRAP>",  /* IE breaks up the date */
             str1, /* Date */
@@ -4560,12 +4122,11 @@ print2("</FONT></B></CENTER>\n");
             g_Statement[s].labelName, "</A>",
             str4,
 
-            /* 5-Jan-2014 nm */
             /* Add asterisk if statement has distinct var groups */
             (nmbrLen(g_Statement[s].reqDisjVarsA) > 0) ? "*" : "",
 
             "</TD><TD ALIGN=LEFT>",
-            /* 15-Aug-04 nm - Add anchor for hyperlinking to the table row */
+            /* Add anchor for hyperlinking to the table row */
             "<A NAME=\"", g_Statement[s].labelName, "\"></A>",
 
             NULL),  /* Description */
@@ -4575,13 +4136,10 @@ print2("</FONT></B></CENTER>\n");
       g_showStatement = s; /* For printTexComment */
       g_outputToString = 0; /* For printTexComment */
       g_texFilePtr = outputFilePtr; /* For printTexComment */
-      /* 18-Sep-03 ???Future - make this just return a string??? */
-      /* printTexComment(str3, 0); */ /* Sends result to g_texFilePtr */
-      /* 17-Nov-2015 nm Add 3rd & 4th arguments */
       printTexComment(  /* Sends result to g_texFilePtr */
           str3,
           0, /* 1 = htmlCenterFlag */
-          PROCESS_EVERYTHING, /* actionBits */ /* 13-Dec-2018 nm */
+          PROCESS_EVERYTHING, /* actionBits */
           0  /* 1 = noFileCheck */);
       g_texFilePtr = NULL;
       g_outputToString = 1; /* Restore after printTexComment */
@@ -4590,38 +4148,21 @@ print2("</FONT></B></CENTER>\n");
       let(&str4, "");
       str4 = getTexOrHtmlHypAndAssertion(s); /* In mmwtex.c */
 
-      /* 19-Aug-05 nm Suppress the math content of lemmas, which can
+      /* Suppress the math content of lemmas, which can
          be very big and not interesting */
-      if (!strcmp(left(str3, 10), "Lemma for ")
-          && !showLemmas) {  /* 10-Oct-2012 nm */
+      if (!strcmp(left(str3, 10), "Lemma for ") && !showLemmas) {
         /* Suppress the table row with the math content */
         print2(" <I>[Auxiliary lemma - not displayed.]</I></TD></TR>\n");
       } else {
         /* Output the table row with the math content */
         printLongLine(cat("</TD></TR><TR",
-
-              /*
-              (s < g_extHtmlStmt) ?
-                   ">" :
-                   cat(" BGCOLOR=", PURPLISH_BIBLIO_COLOR, ">", NULL),
-              */
-
-              /* 29-Jul-2008 nm Sandbox stuff */
               (s < g_extHtmlStmt)
-                 ? ">"
-                 : (s < g_mathboxStmt)
-                     ? cat(" BGCOLOR=", PURPLISH_BIBLIO_COLOR, ">", NULL)
-                     : cat(" BGCOLOR=", SANDBOX_COLOR, ">", NULL),
-
-
-            /*** old
-            "<TD BGCOLOR=white>&nbsp;</TD><TD COLSPAN=2 ALIGN=CENTER>",
-            str4, "</TD></TR>", NULL),
-            ****/
-            /* 27-Oct-03 nm */
-            "<TD COLSPAN=3 ALIGN=CENTER>",
-            str4, "</TD></TR>", NULL),
-
+                ? ">"
+                : (s < g_mathboxStmt)
+                  ? cat(" BGCOLOR=", PURPLISH_BIBLIO_COLOR, ">", NULL)
+                  : cat(" BGCOLOR=", SANDBOX_COLOR, ">", NULL),
+              "<TD COLSPAN=3 ALIGN=CENTER>",
+              str4, "</TD></TR>", NULL),
             " ",  /* Start continuation line with space */
             "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
       }
@@ -4648,22 +4189,15 @@ print2("</FONT></B></CENTER>\n");
     print2("</TABLE></CENTER>\n");
     print2("\n");
 
-    /* 8-May-2015 */
    SKIP_LIST: /* (skipped when page == 0) */
     g_outputToString = 1; /* To compensate for skipped assignment above */
 
 
-    /* 21-Jun-2014 nm Put extra Prev/Next hyperlinks here for convenience */
+    /* Put extra Prev/Next hyperlinks here for convenience */
     print2("<TABLE BORDER=0 WIDTH=\"100%c\">\n", '%');
     print2("  <TR>\n");
     print2("    <TD ALIGN=LEFT VALIGN=TOP WIDTH=\"25%c\">\n", '%');
     print2("      &nbsp;\n");
-    /*
-    print2("      <FONT SIZE=-1 FACE=sans-serif>\n");
-    print2("      <A HREF=\"mmset.html\">MPE Home</A>&nbsp;&nbsp;\n");
-    print2(
-  "      <A HREF=\"mmtheorems.html#mmtc\">Table of contents</A></FONT>\n");
-    */
     print2("    </TD>\n");
     print2("    <TD NOWRAP ALIGN=CENTER>&nbsp;</TD>\n");
     print2("    <TD NOWRAP ALIGN=RIGHT VALIGN=TOP WIDTH=\"25%c\"><FONT\n", '%');
@@ -4690,16 +4224,13 @@ print2("</FONT></B></CENTER>\n");
     fprintf(outputFilePtr, "</CENTER>\n");
 
 
-    /* 21-Jun-2014 nm Moved page list to bottom */
     /* Output links to the other pages */
     fprintf(outputFilePtr, "Jump to page: \n");
-    /* for (p = 1; p <= pages; p++) { */
-    /* 8-May-2015 */
     for (p = 0; p <= pages; p++) {
 
       /* Construct the pink number range */
       let(&str3, "");
-      if (p > 0) {   /* 8-May-2015 */
+      if (p > 0) {
         str3 = pinkRangeHTML(
             nmbrStmtNmbr[(p - 1) * theoremsPerPage + 1],
             (p < pages) ?
@@ -4707,115 +4238,48 @@ print2("</FONT></B></CENTER>\n");
               nmbrStmtNmbr[assertions]);
       }
 
-      /* 31-Jul-2006 nm Change "1" to "Contents + 1" */
       if (p == page) {
-        let(&str1,
-            /* (p == 1) ? "Contents + 1" : str(p) */ /* 31-Jul-2006 nm */
-            /* 8-May-2015 nm */
-            (p == 0) ? "Contents" : str((double)p)
-            ); /* Current page shouldn't have link to self */
+        /* Current page shouldn't have link to self */
+        let(&str1, (p == 0) ? "Contents" : str((double)p));
       } else {
         let(&str1, cat("<A HREF=\"mmtheorems",
-            /* (p == 1) ? "" : str(p), */
-            /* 8-May-2015 nm */
             (p == 0) ? "" : str((double)p),
-            /* (p == 1) ? ".html#mmtc\">" : ".html\">", */ /* 31-Aug-2006 nm */
-            ".html\">", /* 8-Feb-2007 nm Friendlier, because you can start
-                  scrolling through the page before it finishes loading,
-                  without its jumping to #mmtc (start of Table of Contents)
-                  when it's done. */
-            /* (p == 1) ? "Contents + 1" : str(p) */ /* 31-Jul-2006 nm */
-            /* 8-May-2015 nm */
-            (p == 0) ? "Contents" : str((double)p)
-            , "</A>", NULL));
+
+            /* Friendlier, because you can start
+              scrolling through the page before it finishes loading,
+              without its jumping to #mmtc (start of Table of Contents)
+              when it's done. */
+            /* (p == 1) ? ".html#mmtc\">" : ".html\">", */
+            ".html\">",
+
+            (p == 0) ? "Contents" : str((double)p),
+            "</A>", NULL));
       }
       let(&str1, cat(str1, PINK_NBSP, str3, NULL));
       fprintf(outputFilePtr, "%s\n", str1);
     }
-    /* End of 21-Jun-2014 */
 
 
     g_outputToString = 1;
     print2("<HR NOSHADE SIZE=1>\n");
-    /* nm 22-Jan-04 Take out date because it causes an unnecessary incremental
-       site update */
-    /*
-    print2(" <CENTER><I>\n");
-    print2("This page was last updated on %s.\n", date());
-    print2("</I></CENTER>\n");
-    */
-
-    /*
-    print2("<CENTER><FONT SIZE=-2 FACE=ARIAL>\n");
-    print2("<A HREF=\"http://metamath.org\">metamath.org mirrors</A>\n");
-    print2("</FONT></CENTER>\n");
-    */
-    /* Add a "Previous" and "Next" links to bottom of page for convenience */
-    /************ 21-Jun-2014 nm Done above, put into prevNextLinks string
-    let(&str1, cat("<A HREF=\"mmtheorems",
-        (page > 1)
-            ? ((page - 1 > 1) ? str(page - 1) : "")
-            : ((pages > 1) ? str(pages) : ""),
-        ".html\">", NULL));
-    if (page > 1) {
-      let(&str1, cat(str1, "&lt; Previous</A>&nbsp;&nbsp;", NULL));
-    } else {
-      let(&str1, cat(str1, "&lt; Wrap</A>&nbsp;&nbsp;", NULL));
-    }
-    let(&str1, cat(str1, "<A HREF=\"mmtheorems",
-        (page < pages)
-            ? str(page + 1)
-            : "",
-        ".html\">", NULL));
-    if (page < pages) {
-      let(&str1, cat(str1, "Next &gt;</A>", NULL));
-    } else {
-      let(&str1, cat(str1, "Wrap &gt;</A>", NULL));
-    }
-    *************/
-
     print2("<TABLE BORDER=0 WIDTH=\"100%c\">\n", '%');
     print2("  <TR>\n");
-  /*print2("    <TD ALIGN=LEFT VALIGN=TOP WIDTH=\"25%c\">&nbsp;</TD>\n", '%');*/
-    /* 31-Aug-2006 nm Changed above line to the 4 following lines: */
     print2("    <TD ALIGN=LEFT VALIGN=TOP WIDTH=\"25%c\">\n", '%');
     print2("      &nbsp;\n");
-    /*
-    print2("      <FONT SIZE=-1 FACE=sans-serif>\n");
-    print2("      <A HREF=\"mmset.html\">MPE Home</A>&nbsp;&nbsp;\n");
-    print2(
-  "      <A HREF=\"mmtheorems.html#mmtc\">Table of contents</A></FONT>\n");
-    */
     print2("    </TD>\n");
     print2("    <TD NOWRAP ALIGN=CENTER><FONT SIZE=-2\n");
     print2("      FACE=ARIAL>\n");
-    /*
-    print2("      <A HREF=\"http://metamath.org\">metamath.org mirrors</A>\n");
-    */
     print2("Copyright terms:\n");
     print2("<A HREF=\"../copyright.html#pd\">Public domain</A>\n");
     print2("      </FONT></TD>\n");
     print2("    <TD NOWRAP ALIGN=RIGHT VALIGN=TOP WIDTH=\"25%c\"><FONT\n", '%');
     print2("      SIZE=-1 FACE=sans-serif>\n");
-    /*printLongLine(cat("      ", str1, NULL),*/
-    printLongLine(cat("      ", prevNextLinks, NULL), /* 21-Jun-2014 */
+    printLongLine(cat("      ", prevNextLinks, NULL),
         " ",  /* Start continuation line with space */
         "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
     print2("      </FONT></TD>\n");
     print2("  </TR>\n");
     print2("</TABLE>\n");
-
-    /* Todo: Decide to use or not use this */
-    /*
-    print2("<SCRIPT SRC=\"http://www.google-analytics.com/urchin.js\"\n");
-    print2("  TYPE=\"text/javascript\">\n");
-    print2("</SCRIPT>\n");
-    print2("<SCRIPT TYPE=\"text/javascript\">\n");
-    print2("  _uacct = \"UA-1862729-1\";\n");
-    print2("  urchinTracker();\n");
-    print2("</SCRIPT>");
-    */
-
     print2("</BODY></HTML>\n");
     g_outputToString = 0;
     fprintf(outputFilePtr, "%s", g_printString);
@@ -4835,38 +4299,20 @@ print2("</FONT></B></CENTER>\n");
   let(&hugeHdr, "");
   let(&bigHdr, "");
   let(&smallHdr, "");
-  let(&tinyHdr, ""); /* 21-Aug-2017 nm */
-  let(&hdrCommentMarker, ""); /* 4-Aug-2018 */
+  let(&tinyHdr, "");
+  let(&hdrCommentMarker, "");
   for (i = 0; i <= g_statements; i++) let((vstring *)(&pntrHugeHdr[i]), "");
   pntrLet(&pntrHugeHdr, NULL_PNTRSTRING);
   for (i = 0; i <= g_statements; i++) let((vstring *)(&pntrBigHdr[i]), "");
   pntrLet(&pntrBigHdr, NULL_PNTRSTRING);
   for (i = 0; i <= g_statements; i++) let((vstring *)(&pntrSmallHdr[i]), "");
   pntrLet(&pntrSmallHdr, NULL_PNTRSTRING);
-  /* 21-Aug-2017 nm */
   for (i = 0; i <= g_statements; i++) let((vstring *)(&pntrTinyHdr[i]), "");
   pntrLet(&pntrTinyHdr, NULL_PNTRSTRING);
 
 } /* writeTheoremList */
 
 
-/* 12-Sep-2020 nm - added fullComment, which puts the entire header
-   (including any comment and $( $) keywords) into xxxHdrTitle and
-   xxxHdrComment.  If there is no comment below header, xxxHdrComment
-   will be "$)".   No \n follows "$)".  Any leading whitespace will
-   be prefixed before the "$(".  This mode is used for /EXTRACT
-   and was added to make white space match original source. */
-/* 24-Aug-2020 nm - added fineResolution flag, where "header area" is
-   just the labelSection (text before statement) instead of all of the
-   content between a $a/$p and next $a/$p.  This is used by
-   WRITE SOURCE ... /EXTRACT. */
-/* 18-Dec-2016 nm - use true "header area" as described below, and
-   ensure statement argument is $p or $a */
-/* 2-Aug-2009 nm - broke this function out from writeTheoremList() */
-/* 21-Jun-2014 nm - added hugeHdrTitle */
-/* 21-Aug-2017 nm - added tinyHdrTitle */
-/* 8-May-2015 nm - added hugeHdrComment, bigHdrComment, smallHdrComment */
-/* 21-Aug-2017 nm - added tinyHdrComment */
 /* This function extracts any section headers in the comment sections
    prior to the label of statement stmt.   If a huge (####...) header isn't
    found, *hugeHdrTitle will be set to the empty string.
@@ -4884,17 +4330,17 @@ print2("</FONT></B></CENTER>\n");
 20-Jun-2015 metamath Google group email:
 https://groups.google.com/g/metamath/c/QE0lwg9f5Ho/m/J8ekl_lH1I8J
 
-There are 3 kinds of section headers, big (####...), medium (#*#*#*...),
-and small (=-=-=-).
+There are 4 kinds of section headers, big (####...), medium (#*#*#*...),
+small (=-=-=-), and tiny (-.-.-.).
 
 Call the collection of (outside-of-statement) comments between two
 successive $a/$p statements (i.e. those statements that generate web
 pages) a "header area".  The algorithm scans the header area for the
-_last_ header of each type (big, medium, small) and discards all others.
-Then, if there is a medium and it appears before a big, the medium is
-discarded.  If there is a small and it appears before a big or medium,
-the small is discarded.  In other words, a maximum of one header of
-each type is kept, in the order big, medium, and small.
+_last_ header of each type (big, medium, small, tiny) and discards all
+others. Then, if there is a medium and it appears before a big, the
+medium is discarded.  If there is a small and it appears before a big or
+medium, the small is discarded.  In other words, a maximum of one header
+of each type is kept, in the order big, medium, small, and tiny.
 
 There are two reasons for doing this:  (1) it disregards headers used
 for other purposes such as the headers for the set.mm-specific
@@ -4902,40 +4348,30 @@ information at the top that is not of general interest and (2) it
 ignores headers for empty sections; for example, a mathbox user might
 have a bunch of headers for sections planned for the future, but we
 ignore them if those sections are empty (no $a or $p in them).
-
- 6-Aug-2019 nm: added error checking; added error checking
-21-Aug-2017 nm: added "tiny" to "big, medium, small".
-
 */
-/*void getSectionHeadings(long stmt, vstring *hugeHdrTitle, vstring *bigHdrTitle,*/
-/* Return 1 if error found, 0 otherwise */ /* 6-Aug-2019 nm */
+/* Return 1 if error found, 0 otherwise */
 flag getSectionHeadings(long stmt,
     vstring *hugeHdrTitle,
     vstring *bigHdrTitle,
     vstring *smallHdrTitle,
-    vstring *tinyHdrTitle,  /* 21-Aug-2017 nm */
-    /* 8-May-2015 nm Added huge,big,smallHdrComment */
+    vstring *tinyHdrTitle,
     vstring *hugeHdrComment,
     vstring *bigHdrComment,
     vstring *smallHdrComment,
-    vstring *tinyHdrComment,  /* 21-Aug-2017 nm */
-    flag fineResolution,  /* 24-Aug-2020 nm */
-    flag fullComment  /* 12-Sep-2020 nm */
-    )
-{  /* 21-Aug-2017 nm */
+    vstring *tinyHdrComment,
+    flag fineResolution,
+    flag fullComment) {
 
-  /* 31-Jul-2006 for table of contents mod */
+  /* for table of contents */
   vstring labelStr = "";
   long pos, pos1, pos2, pos3, pos4;
-  flag errorFound = 0; /* 6-Aug-2019 nm */
-  flag saveOutputToString; /* 6-Aug-2019 nm */
+  flag errorFound = 0;
+  flag saveOutputToString;
 
-  /* 6-Aug-2019 nm */
   /* Print any error messages to screen */
   saveOutputToString = g_outputToString; /* To restore when returning */
   g_outputToString = 0;
 
-  /* 24-Aug-2020 nm */
   /* (This initialization seems to be done redundantly by caller elsewhere,
      but for  WRITE SOURCE ... / EXTRACT we need to do it explicitly.) */
   let(&(*hugeHdrTitle), "");
@@ -4947,13 +4383,11 @@ flag getSectionHeadings(long stmt,
   let(&(*smallHdrComment), "");
   let(&(*tinyHdrComment), "");
 
-  /* 18-Dec-2016 nm */
   /* We now process only $a or $p statements */
-  if (fineResolution == 0) { /* 24-Aug-2020 nm */
+  if (fineResolution == 0) {
     if (g_Statement[stmt].type != a_ && g_Statement[stmt].type != p_) bug(2340);
   }
 
-  /* 18-Dec-2016 nm */
   /* Get header area between this statement and the statement after the
      previous $a or $p statement */
   /* pos3 and pos4 are used temporarily here; not related to later use */
@@ -4962,7 +4396,6 @@ flag getSectionHeadings(long stmt,
                 previous $a or $p statement (will be this statement if previous
                 statement is $a or $p) */
   } else {
-    /* 24-Aug-2020 nm */
     pos3 = stmt; /* For WRITE SOURCE ... / EXTRACT, we want every statement
                     treated equally */
   }
@@ -4974,13 +4407,6 @@ flag getSectionHeadings(long stmt,
   memcpy(labelStr, g_Statement[pos3].labelSectionPtr,
       (size_t)(pos4));
 
-  /* Old code before 18-Dec-2016
-  /@ Get headers from comment section between statements @/
-  let(&labelStr, space(g_Statement[stmt].labelSectionLen));
-  memcpy(labelStr, g_Statement[stmt].labelSectionPtr,
-      (size_t)(g_Statement[stmt].labelSectionLen));
-  */
-
   pos = 0;
   pos2 = 0;
   while (1) {  /* Find last "huge" header, if any */
@@ -4990,7 +4416,7 @@ flag getSectionHeadings(long stmt,
        this (and for the #*#* and =-=- matches below) would take a little work
        and perhaps slow things down, and I don't think it is worth it.  I
        put a note in HELP WRITE THEOREM_LIST. */
-    pos1 = pos; /* 23-May-2008 */
+    pos1 = pos;
     pos = instr(pos + 1, labelStr, "$(\n" HUGE_DECORATION);
 
     /* 23-May-2008 nm Tolerate one space after "$(", to handle case of
@@ -5004,11 +4430,11 @@ flag getSectionHeadings(long stmt,
     if (pos) pos2 = pos;
   } /* while(1) */
   if (pos2) { /* Extract "huge" header */
-    pos1 = pos2; /* Save "$(" position */ /* 12-Sep-2020 nm */
+    pos1 = pos2; /* Save "$(" position */
     pos = instr(pos2 + 4, labelStr, "\n"); /* Get to end of #### line */
     pos2 = instr(pos + 1, labelStr, "\n"); /* Find end of title line */
 
-    /* Error check - can't have more than 1 title line */ /* 6-Aug-2019 nm */
+    /* Error check - can't have more than 1 title line */
     if (strcmp(mid(labelStr, pos2 + 1, 4), HUGE_DECORATION)) {
       print2(
        "?Warning: missing closing \"%s\" decoration above statement \"%s\".\n",
@@ -5019,7 +4445,7 @@ flag getSectionHeadings(long stmt,
     pos3 = instr(pos2 + 1, labelStr, "\n"); /* Get to end of 2nd #### line */
     while (labelStr[(pos3 - 1) + 1] == '\n') pos3++; /* Skip 1st blank lines */
     pos4 = instr(pos3, labelStr, "$)"); /* Get to end of title comment */
-    if (fullComment == 0) {  /* 12-Sep-2020 nm */
+    if (fullComment == 0) {
       let(&(*hugeHdrTitle), seg(labelStr, pos + 1, pos2 - 1));
       let(&(*hugeHdrTitle), edit((*hugeHdrTitle), 8 + 128));
                                                 /* Trim leading, trailing sp */
@@ -5027,7 +4453,6 @@ flag getSectionHeadings(long stmt,
       let(&(*hugeHdrComment), edit((*hugeHdrComment), 8 + 16384));
           /* Trim leading sp, trailing sp & lf */
     } else {
-      /* 12-Sep-2020 nm */
       /* Put entire comment in hugeHdrTitle and hugeHdrComment for /EXTRACT */
       /* Search backwards for non-space or beginning of string: */
       pos = pos1; /* pos1 is the "$" in "$(" */
@@ -5048,19 +4473,8 @@ flag getSectionHeadings(long stmt,
                     to ignore any earlier "tiny" or "small" or "big" header */
   pos2 = 0;
   while (1) {  /* Find last "big" header, if any */
-    /* nm 4-Nov-2007:  Obviously, the match below will not work if the
-       $( line has a trailing space, which some editors might insert.
-       The symptom is a missing table of contents entry.  But to detect
-       this (and for the =-=- match below) would take a little work and
-       perhaps slow things down, and I don't think it is worth it.  I
-       put a note in HELP WRITE THEOREM_LIST. */
-    pos1 = pos; /* 23-May-2008 */
+    pos1 = pos;
     pos = instr(pos + 1, labelStr, "$(\n" BIG_DECORATION);
-
-    /* 23-May-2008 nm Tolerate one space after "$(", to handle case of
-      one space added to the end of each line with TOOLS to make global
-      label changes are easier (still a kludge; this should be made
-      white-space insensitive some day) */
     pos1 = instr(pos1 + 1, labelStr, "$( \n" BIG_DECORATION);
     if (pos1 > pos) pos = pos1;
 
@@ -5068,11 +4482,11 @@ flag getSectionHeadings(long stmt,
     if (pos) pos2 = pos;
   }
   if (pos2) { /* Extract "big" header */
-    pos1 = pos2; /* Save "$(" position */ /* 12-Sep-2020 nm */
+    pos1 = pos2; /* Save "$(" position */
     pos = instr(pos2 + 4, labelStr, "\n"); /* Get to end of #*#* line */
     pos2 = instr(pos + 1, labelStr, "\n"); /* Find end of title line */
 
-    /* Error check - can't have more than 1 title line */ /* 6-Aug-2019 nm */
+    /* Error check - can't have more than 1 title line */
     if (strcmp(mid(labelStr, pos2 + 1, 4), BIG_DECORATION)) {
       print2(
        "?Warning: missing closing \"%s\" decoration above statement \"%s\".\n",
@@ -5083,7 +4497,7 @@ flag getSectionHeadings(long stmt,
     pos3 = instr(pos2 + 1, labelStr, "\n"); /* Get to end of 2nd #*#* line */
     while (labelStr[(pos3 - 1) + 1] == '\n') pos3++; /* Skip 1st blank lines */
     pos4 = instr(pos3, labelStr, "$)"); /* Get to end of title comment */
-    if (fullComment == 0) {  /* 12-Sep-2020 nm */
+    if (fullComment == 0) {
       let(&(*bigHdrTitle), seg(labelStr, pos + 1, pos2 - 1));
       let(&(*bigHdrTitle), edit((*bigHdrTitle), 8 + 128));
                                                   /* Trim leading, trailing sp */
@@ -5091,7 +4505,6 @@ flag getSectionHeadings(long stmt,
       let(&(*bigHdrComment), edit((*bigHdrComment), 8 + 16384));
           /* Trim leading sp, trailing sp & lf */
     } else {
-      /* 12-Sep-2020 nm */
       /* Put entire comment in bigHdrTitle and bigHdrComment for /EXTRACT */
       /* Search backwards for non-space or beginning of string: */
       pos = pos1; /* pos1 is the "$" in "$(" */
@@ -5112,13 +4525,8 @@ flag getSectionHeadings(long stmt,
                     to ignore any earlier "tiny" or "small" header */
   pos2 = 0;
   while (1) {  /* Find last "small" header, if any */
-    pos1 = pos; /* 23-May-2008 */
+    pos1 = pos;
     pos = instr(pos + 1, labelStr, "$(\n" SMALL_DECORATION);
-
-    /* 23-May-2008 nm Tolerate one space after "$(", to handle case of
-      one space added to the end of each line with TOOLS to make global
-      label changes are easier (still a kludge; this should be made
-      white-space insensitive some day) */
     pos1 = instr(pos1 + 1, labelStr, "$( \n" SMALL_DECORATION);
     if (pos1 > pos) pos = pos1;
 
@@ -5126,11 +4534,11 @@ flag getSectionHeadings(long stmt,
     if (pos) pos2 = pos;
   }
   if (pos2) { /* Extract "small" header */
-    pos1 = pos2; /* Save "$(" position */ /* 12-Sep-2020 nm */
+    pos1 = pos2; /* Save "$(" position */
     pos = instr(pos2 + 4, labelStr, "\n"); /* Get to end of =-=- line */
     pos2 = instr(pos + 1, labelStr, "\n"); /* Find end of title line */
 
-    /* Error check - can't have more than 1 title line */ /* 6-Aug-2019 nm */
+    /* Error check - can't have more than 1 title line */
     if (strcmp(mid(labelStr, pos2 + 1, 4), SMALL_DECORATION)) {
       print2(
        "?Warning: missing closing \"%s\" decoration above statement \"%s\".\n",
@@ -5141,7 +4549,7 @@ flag getSectionHeadings(long stmt,
     pos3 = instr(pos2 + 1, labelStr, "\n"); /* Get to end of 2nd =-=- line */
     while (labelStr[(pos3 - 1) + 1] == '\n') pos3++; /* Skip 1st blank lines */
     pos4 = instr(pos3, labelStr, "$)"); /* Get to end of title comment */
-    if (fullComment == 0) {  /* 12-Sep-2020 nm */
+    if (fullComment == 0) {
       let(&(*smallHdrTitle), seg(labelStr, pos + 1, pos2 - 1));
       let(&(*smallHdrTitle), edit((*smallHdrTitle), 8 + 128));
                                                 /* Trim leading, trailing sp */
@@ -5149,7 +4557,6 @@ flag getSectionHeadings(long stmt,
       let(&(*smallHdrComment), edit((*smallHdrComment), 8 + 16384));
           /* Trim leading sp, trailing sp & lf */
     } else {
-      /* 12-Sep-2020 nm */
       /* Put entire comment in smallHdrTitle and smallHdrComment for /EXTRACT */
       /* Search backwards for non-space or beginning of string: */
       pos = pos1; /* pos1 is the "$" in "$(" */
@@ -5167,18 +4574,12 @@ flag getSectionHeadings(long stmt,
     }
   }
 
-  /* Added 21-Aug-2017 nm */
   /* pos = 0; */ /* Leave pos alone so that we start with "small" header pos,
                     to ignore any earlier "tiny" header */
   pos2 = 0;
   while (1) {  /* Find last "tiny" header, if any */
-    pos1 = pos; /* 23-May-2008 */
+    pos1 = pos;
     pos = instr(pos + 1, labelStr, "$(\n" TINY_DECORATION);
-
-    /* 23-May-2008 nm Tolerate one space after "$(", to handle case of
-      one space added to the end of each line with TOOLS to make global
-      label changes are easier (still a kludge; this should be made
-      white-space insensitive some day) */
     pos1 = instr(pos1 + 1, labelStr, "$( \n" TINY_DECORATION);
     if (pos1 > pos) pos = pos1;
 
@@ -5186,11 +4587,11 @@ flag getSectionHeadings(long stmt,
     if (pos) pos2 = pos;
   }
   if (pos2) { /* Extract "tiny" header */
-    pos1 = pos2; /* Save "$(" position */ /* 12-Sep-2020 nm */
+    pos1 = pos2; /* Save "$(" position */
     pos = instr(pos2 + 4, labelStr, "\n"); /* Get to end of -.-. line */
     pos2 = instr(pos + 1, labelStr, "\n"); /* Find end of title line */
 
-    /* Error check - can't have more than 1 title line */ /* 6-Aug-2019 nm */
+    /* Error check - can't have more than 1 title line */
     if (strcmp(mid(labelStr, pos2 + 1, 4), TINY_DECORATION)) {
       print2(
        "?Warning: missing closing \"%s\" decoration above statement \"%s\".\n",
@@ -5201,7 +4602,7 @@ flag getSectionHeadings(long stmt,
     pos3 = instr(pos2 + 1, labelStr, "\n"); /* Get to end of 2nd -.-. line */
     while (labelStr[(pos3 - 1) + 1] == '\n') pos3++; /* Skip 1st blank lines */
     pos4 = instr(pos3, labelStr, "$)"); /* Get to end of title comment */
-    if (fullComment == 0) {  /* 12-Sep-2020 nm */
+    if (fullComment == 0) {
       let(&(*tinyHdrTitle), seg(labelStr, pos + 1, pos2 - 1));
       let(&(*tinyHdrTitle), edit((*tinyHdrTitle), 8 + 128));
                                                   /* Trim leading, trailing sp */
@@ -5209,7 +4610,6 @@ flag getSectionHeadings(long stmt,
       let(&(*tinyHdrComment), edit((*tinyHdrComment), 8 + 16384));
           /* Trim leading sp, trailing sp & lf */
     } else {
-      /* 12-Sep-2020 nm */
       /* Put entire comment in tinyHdrTitle and tinyHdrComment for /EXTRACT */
       /* Search backwards for non-space or beginning of string: */
       pos = pos1; /* pos1 is the "$" in "$(" */
@@ -5226,9 +4626,7 @@ flag getSectionHeadings(long stmt,
       let(&(*tinyHdrComment), seg(labelStr, pos3 + 1, pos4 + 1));
     }
   }
-  /* (End of 21-Aug-2017 addition) */
 
-  /* 6-Aug-2019 nm */
   if (errorFound == 1) {
     print2("  (Note that section titles may not be longer than one line.)\n");
   }
@@ -5236,34 +4634,10 @@ flag getSectionHeadings(long stmt,
   g_outputToString = saveOutputToString;
 
   let(&labelStr, "");  /* Deallocate string memory */
-  return errorFound;  /* 6-Aug-2019 nm */
+  return errorFound;
 } /* getSectionHeadings */
 
 
-/* Returns the pink number printed next to statement labels in HTML output */
-/* The pink number only counts $a and $p statements, unlike the statement
-   number which also counts $f, $e, $c, $v, ${, $} */
-/* 10/10/02 This is no longer used? */
-#ifdef DUMMY  /* For commenting it out */
-long pinkNumber(long statemNum)
-{
-  long statemMap = 0;
-  long i;
-  /* Statement map for number of g_showStatement - this makes the statement
-     number more meaningful, by counting only $a and $p. */
-  /* ???This could be done once if we want to speed things up, but
-     be careful because it will have to be redone if ERASE then READ.
-     For the future it could be added to the g_Statement[] structure. */
-  statemMap = 0;
-  for (i = 1; i <= statemNum; i++) {
-    if (g_Statement[i].type == a_ || g_Statement[i].type == p_)
-      statemMap++;
-  }
-  return statemMap;
-} /* pinkNumber */
-#endif
-
-/* Added 10/10/02 */
 /* Returns HTML for the pink number to print after the statement labels
    in HTML output.  (Note that "pink" means "rainbow colored" number now.) */
 /* Warning: The caller must deallocate the returned vstring (i.e. this
@@ -5275,16 +4649,6 @@ vstring pinkHTML(long statemNum)
   vstring htmlCode = "";
   vstring hexValue = "";
 
-  /* The pink number only counts $a and $p statements, unlike the statement
-     number which also counts $f, $e, $c, $v, ${, $} */
-  /* 10/25/02 Added pinkNumber to the g_Statement[] structure for speedup. */
-  /*
-  statemMap = 0;
-  for (i = 1; i <= statemNum; i++) {
-    if (g_Statement[i].type == a_ || g_Statement[i].type == p_)
-      statemMap++;
-  }
-  */
   if (statemNum > 0) {
     statemMap = g_Statement[statemNum].pinkNumber;
   } else {
@@ -5295,14 +4659,7 @@ vstring pinkHTML(long statemNum)
   /* Note: we put "(future)" when the label wasn't found (an error message
      was also generated previously) */
 
-  /* Without style sheet */
-  /*
-  let(&htmlCode, cat(PINK_NBSP,
-      "<FONT FACE=\"Arial Narrow\" SIZE=-2 COLOR=", PINK_NUMBER_COLOR, ">",
-      (statemMap != -1) ? str(statemMap) : "(future)", "</FONT>", NULL));
-  */
-
-  /* ndm 10-Jan-04 With style sheet and explicit color */
+  /* With style sheet and explicit color */
   let(&hexValue, "");
   hexValue = spectrumToRGB(statemMap, g_Statement[g_statements].pinkNumber);
   let(&htmlCode, cat(PINK_NBSP,
@@ -5314,13 +4671,11 @@ vstring pinkHTML(long statemNum)
 } /* pinkHTML */
 
 
-/* Added 25-Aug-04 */
 /* Returns HTML for a range of pink numbers separated by a "-". */
 /* Warning: The caller must deallocate the returned vstring (i.e. this
    function cannot be used in let statements but must be assigned to
    a local vstring for local deallocation) */
-vstring pinkRangeHTML(long statemNum1, long statemNum2)
-{
+vstring pinkRangeHTML(long statemNum1, long statemNum2) {
   vstring htmlCode = "";
   vstring str3 = "";
   vstring str4 = "";
@@ -5339,26 +4694,22 @@ vstring pinkRangeHTML(long statemNum1, long statemNum2)
 } /* pinkRangeHTML */
 
 
-/* 20-Aug-2006 nm This section was revised so that all colors have
-   the same grayscale brightness. */
-
 /* This function converts a "spectrum" color (1 to maxColor) to an
    RBG value in hex notation for HTML.  The caller must deallocate the
    returned vstring to prevent memory leaks.  color = 1 (red) to maxColor
    (violet).  A special case is the color -1, which just returns black. */
-/* ndm 10-Jan-04 */
 vstring spectrumToRGB(long color, long maxColor) {
   vstring str1 = "";
   double fraction, fractionInPartition;
   long j, red, green, blue, partition;
 /* Change PARTITIONS whenever the table below has entries added or removed! */
 #define PARTITIONS 28
-  static double redRef[PARTITIONS +  1];    /* 20-Aug-2006 nm Made these */
-  static double greenRef[PARTITIONS +  1];  /*                static for */
-  static double blueRef[PARTITIONS +  1];   /*                speedup */
-  static long i = -1;                       /*                below */
+  static double redRef[PARTITIONS +  1];    /* Made these */
+  static double greenRef[PARTITIONS +  1];  /* static for */
+  static double blueRef[PARTITIONS +  1];   /* speedup */
+  static long i = -1;                       /* below */
 
-  if (i > -1) goto SKIP_INIT; /* 20-Aug-2006 nm - Speedup */
+  if (i > -1) goto SKIP_INIT;
   i = -1; /* For safety */
 
   /* Here, we use the maximum saturation possible for a fixed L*a*b color L
@@ -5470,8 +4821,6 @@ vstring spectrumToRGB(long color, long maxColor) {
 } /* spectrumToRGB */
 
 
-/* Added 20-Sep-03 (broken out of printTexLongMath() for better
-   modularization) */
 /* Returns the HTML code for GIFs (!g_altHtmlFlag) or Unicode (g_altHtmlFlag),
    or LaTeX when !g_htmlFlag, for the math string (hypothesis or conclusion) that
    is passed in. */
@@ -5506,18 +4855,15 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
       if (!strcmp(left(lastTex, 10), "\\mbox{\\rm ")) { /* Token not in table*/
         unknownold = 1;
       }
-      /*if ((alphold && alphnew) || unknownold || (unknownnew && pos > 0)) {*/
-      /* Put thin space only between letters and/or unknowns  11/3/94 */
+      /* Put thin space only between letters and/or unknowns */
       if ((alphold || unknownold) && (alphnew || unknownnew)) {
         /* Put additional thin space between two letters */
-        /* 27-Jul-05 nm Added for new LaTeX output */
         if (!g_oldTexFlag) {
           let(&texLine, cat(texLine, "\\,", tex, " ", NULL));
         } else {
           let(&texLine, cat(texLine, "\\m{\\,", tex, "}", NULL));
         }
       } else {
-        /* 27-Jul-05 nm Added for new LaTeX output */
         if (!g_oldTexFlag) {
           let(&texLine, cat(texLine, "", tex, " ", NULL));
         } else {
@@ -5526,7 +4872,7 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
       }
     } else {  /* HTML */
 
-      /* 7/27/03 When we have something like "E. x e. om x = y", the lack of
+      /* When we have something like "E. x e. om x = y", the lack of
          space between om and x looks ugly in HTML.  This kludge adds it in
          for restricted quantifiers not followed by parenthesis, in order
          to make the web page look a little nicer.  E.g. onminex. */
@@ -5535,28 +4881,19 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
         if (!strcmp(g_MathToken[mathString[pos - 2]].tokenName, "e.")
             && (!strcmp(g_MathToken[mathString[pos - 4]].tokenName, "E.")
               || !strcmp(g_MathToken[mathString[pos - 4]].tokenName, "A.")
-
-              /* 20-Oct-2018 nm per Benoit's 3-Sep, 18-Sep, 9-Oct emails */
               || !strcmp(g_MathToken[mathString[pos - 4]].tokenName, "prod_")
               || !strcmp(g_MathToken[mathString[pos - 4]].tokenName, "E*")
               || !strcmp(g_MathToken[mathString[pos - 4]].tokenName, "iota_")
               || !strcmp(g_MathToken[mathString[pos - 4]].tokenName, "Disj_")
-
-              /* 6-Apr-04 nm - indexed E! */
               || !strcmp(g_MathToken[mathString[pos - 4]].tokenName, "E!")
-              /* 12-Nov-05 nm - finite sums */
               || !strcmp(g_MathToken[mathString[pos - 4]].tokenName, "sum_")
-              /* 30-Sep-06 nm - infinite cartesian product */
               || !strcmp(g_MathToken[mathString[pos - 4]].tokenName, "X_")
-              /* 23-Jan-04 nm - indexed union, intersection */
               || !strcmp(g_MathToken[mathString[pos - 4]].tokenName, "U_")
               || !strcmp(g_MathToken[mathString[pos - 4]].tokenName, "|^|_"))
-            /* 23-Jan-04 nm - add space even for parenthesized arg */
-            /*&& strcmp(g_MathToken[mathString[pos]].tokenName, "(")*/
             && strcmp(g_MathToken[mathString[pos]].tokenName, ")")
             /* It also shouldn't be restricted _to_ an expression in parens. */
             && strcmp(g_MathToken[mathString[pos - 1]].tokenName, "(")
-            /* ...or restricted _to_ a union or intersection 1-Feb-05 */
+            /* ...or restricted _to_ a union or intersection */
             && strcmp(g_MathToken[mathString[pos - 1]].tokenName, "U.")
             && strcmp(g_MathToken[mathString[pos - 1]].tokenName, "|^|")
             /* ...or restricted _to_ an expression in braces */
@@ -5572,7 +4909,6 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
           /* and make sure its length is 1 */
           if (!(g_MathToken[mathString[pos]].tokenName[1])) {
 
-            /* 20-Sep-2017 nm */
             /* Make sure previous token is a letter also, to prevent unneeded
                space in "ran ( A ..." (e.g. rncoeq, dfiun3g) */
             /* Match a token starting with a letter */
@@ -5583,25 +4919,21 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
                 /* See if it's 1st letter in a quantified expression */
                 if (!strcmp(g_MathToken[mathString[pos - 2]].tokenName, "E.")
                     || !strcmp(g_MathToken[mathString[pos - 2]].tokenName, "A.")
-                    /* 26-Dec-2016 nm - "not free in" binder */
                     || !strcmp(g_MathToken[mathString[pos - 2]].tokenName, "F/")
-                    /* 6-Apr-04 nm added E!, E* */
                     || !strcmp(g_MathToken[mathString[pos - 2]].tokenName, "E!")
-      /* 4-Jun-06 nm added dom, ran for space btwn A,x in "E! x e. dom A x A y" */
+                    /* space btwn A,x in "E! x e. dom A x A y" */
                     || !strcmp(g_MathToken[mathString[pos - 2]].tokenName, "ran")
                     || !strcmp(g_MathToken[mathString[pos - 2]].tokenName, "dom")
                     || !strcmp(g_MathToken[mathString[pos - 2]].tokenName, "E*")) {
                   let(&texLine, cat(texLine, " ", NULL)); /* Add a space */
                 }
-
-              } /* 20-Sep-2017 nm */
-            } /* 20-Sep-2017 nm */
-
+              }
+            }
           }
         }
       }
       /* This one puts a space after a letter followed by a word token
-         e.g. "A" and "suc" in "A. x e. U. A suc" in limuni2  1-Feb-05 */
+         e.g. "A" and "suc" in "A. x e. U. A suc" in limuni2 */
       if (pos >= 1) {
         /* See if the next token is "suc" */
         if (!strcmp(g_MathToken[mathString[pos]].tokenName, "suc")) {
@@ -5624,7 +4956,7 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
           let(&texLine, cat(texLine, " ", NULL)); /* Add a space */
         }
       }
-      /* nm 9-Feb-04 This one puts a space between "S" and "(" in df-iso. */
+      /* This one puts a space between "S" and "(" in df-iso. */
       if (pos >=4) {
         if (!strcmp(g_MathToken[mathString[pos - 4]].tokenName, "Isom")
             && !strcmp(g_MathToken[mathString[pos - 2]].tokenName, ",")
@@ -5632,8 +4964,7 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
           let(&texLine, cat(texLine, " ", NULL)); /* Add a space */
         }
       }
-      /* nm 11-Aug-04 This one puts a space between "}" and "(" in
-         funcnvuni proof. */
+      /* This one puts a space between "}" and "(" in funcnvuni proof. */
       if (pos >=1) {
         /* See if we have "}" followed by "(" */
         if (!strcmp(g_MathToken[mathString[pos - 1]].tokenName, "}")
@@ -5641,8 +4972,7 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
           let(&texLine, cat(texLine, " ", NULL)); /* Add a space */
         }
       }
-      /* 7-Mar-2016 nm This one puts a space between "}" and "{" in
-         konigsberg proof. */
+      /* This one puts a space between "}" and "{" in konigsberg proof. */
       if (pos >=1) {
         /* See if we have "}" followed by "(" */
         if (!strcmp(g_MathToken[mathString[pos - 1]].tokenName, "}")
@@ -5650,17 +4980,15 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
           let(&texLine, cat(texLine, " ", NULL)); /* Add a space */
         }
       }
-      /* 7/27/03 end */
 
       let(&texLine, cat(texLine, tex, NULL));
     } /* if !g_htmlFlag */
     let(&lastTex, tex); /* Save for next pass */
   } /* Next pos */
 
-  /* 8/9/03 Discard redundant white space to reduce HTML file size */
+  /*x Discard redundant white space to reduce HTML file size */
   let(&texLine, edit(texLine, 8 + 16 + 128));
 
-  /* 1-Feb-2016 nm */
   /* Enclose math symbols in a span to be used for font selection */
   let(&texLine, cat(
       (g_altHtmlFlag ? cat("<SPAN ", g_htmlFont, ">", NULL) : ""),
@@ -5673,15 +5001,13 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
 } /* getTexLongMath */
 
 
-/* Added 18-Sep-03 (broken out of metamath.c for better modularization) */
 /* Returns the TeX, or HTML code for GIFs (!g_altHtmlFlag) or Unicode
    (g_altHtmlFlag), for a statement's hypotheses and assertion in the form
    hyp & ... & hyp => assertion */
 /* Warning: The caller must deallocate the returned vstring (i.e. this
    function cannot be used in let statements but must be assigned to
    a local vstring for local deallocation) */
-vstring getTexOrHtmlHypAndAssertion(long statemNum)
-{
+vstring getTexOrHtmlHypAndAssertion(long statemNum) {
   long reqHyps, essHyps, n;
   nmbrString *nmbrTmpPtr; /* Pointer only; not allocated directly */
   vstring texOrHtmlCode = "";
@@ -5704,11 +5030,9 @@ vstring getTexOrHtmlHypAndAssertion(long statemNum)
           if (g_altHtmlFlag) {
             /* Hard-coded for set.mm! */
             let(&texOrHtmlCode, cat(texOrHtmlCode,
-                /* 8/8/03 - Changed from Symbol to Unicode */
-/* "&nbsp;&nbsp;&nbsp;<FONT FACE=\"Symbol\"> &#38;</FONT>&nbsp;&nbsp;&nbsp;" */
-                "<SPAN ", g_htmlFont, ">",  /* 1-Feb-2016 nm */
+                "<SPAN ", g_htmlFont, ">",
                 "&nbsp;&nbsp;&nbsp; &amp;&nbsp;&nbsp;&nbsp;",
-                "</SPAN>",   /* 1-Feb-2016 nm */
+                "</SPAN>",
                 NULL));
           } else {
             /* Hard-coded for set.mm! */
@@ -5736,19 +5060,16 @@ vstring getTexOrHtmlHypAndAssertion(long statemNum)
       if (g_altHtmlFlag) {
         /* Hard-coded for set.mm! */
         let(&texOrHtmlCode, cat(texOrHtmlCode,
-            /* 8/8/03 - Changed from Symbol to Unicode */
-/* "&nbsp;&nbsp;&nbsp;<FONT FACE=\"Symbol\"> &#222;</FONT>&nbsp;&nbsp;&nbsp;" */
- /* 29-Aug-2008 nm - added sans-serif to work around FF3 bug that produces
-      huge character heights otherwise */
-          /*  "&nbsp;&nbsp;&nbsp; &#8658;&nbsp;&nbsp;&nbsp;" */
-      "&nbsp;&nbsp;&nbsp; <FONT FACE=sans-serif>&#8658;</FONT>&nbsp;&nbsp;&nbsp;"
-            ,NULL));
+            /* sans-serif to work around FF3 bug that produces
+                huge character heights otherwise */
+            "&nbsp;&nbsp;&nbsp; <FONT FACE=sans-serif>&#8658;</FONT>&nbsp;&nbsp;&nbsp;",
+            NULL));
       } else {
         /* Hard-coded for set.mm! */
         let(&texOrHtmlCode, cat(texOrHtmlCode,
-          "&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'"
-            ," ALIGN=TOP>&nbsp;&nbsp;&nbsp;"
-            ,NULL));
+            "&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'",
+            " ALIGN=TOP>&nbsp;&nbsp;&nbsp;",
+            NULL));
       }
     }
   }
@@ -5766,7 +5087,6 @@ vstring getTexOrHtmlHypAndAssertion(long statemNum)
 
 
 
-/* Added 17-Nov-2015 (broken out of metamath.c for better modularization) */
 /* Called by the WRITE BIBLIOGRPAHY command and also by VERIFY MARKUP
    for error checking */
 /* Returns 0 if OK, 1 if warning(s), 2 if any error */
@@ -5783,12 +5103,12 @@ flag writeBibliography(vstring bibFile,
   pntrString *pntrTmp = NULL_PNTRSTRING;
   flag warnFlag;
 
-  n = 0; /* 14-Jan-2016 nm Old gcc 4.6.3 wrongly says may be uninit ln 5506 */
-  pass1refs = 0; /* 25-Jan-2016 gcc 4.5.3 wrongly says may be uninit */
+  n = 0; /* Old gcc 4.6.3 wrongly says may be uninit ln 5506 */
+  pass1refs = 0; /* gcc 4.5.3 wrongly says may be uninit */
   if (noFileCheck == 1 && errorsOnly == 0) {
     bug(2336); /* If we aren't opening files, a non-error run can't work */
   }
-  /* 10/10/02 */
+
   /* This utility builds the bibliographical cross-references to various
      textbooks and updates the user-specified file normally called
      mmbiblio.html. */
@@ -5818,11 +5138,6 @@ flag writeBibliography(vstring bibFile,
   }
   if (!g_texDefsRead) {
     g_htmlFlag = 1;
-    /* Now done in readTexDefs() *
-    if (errorsOnly == 0 ) {
-      print2("Reading definitions from $t statement of %s...\n", g_input_fn);
-    }
-    */
     if (2/*error*/ == readTexDefs(errorsOnly, noFileCheck)) {
       errFlag = 2; /* Error flag to recover input file */
       goto BIB_ERROR; /* An error occurred */
@@ -5833,8 +5148,7 @@ flag writeBibliography(vstring bibFile,
   if (noFileCheck == 0) {
     while (1) {
       if (!linput(list1_fp, NULL, &str1)) {
-        print2(
-  "?Error: Could not find \"<!-- #START# -->\" line in input file \"%s\".\n",
+        print2("?Error: Could not find \"<!-- #START# -->\" line in input file \"%s\".\n",
             bibFile);
         errFlag = 2; /* Error flag to recover input file */
         break;
@@ -5862,7 +5176,6 @@ flag writeBibliography(vstring bibFile,
       if (g_Statement[i].type != (char)p_ &&
         g_Statement[i].type != (char)a_) continue;
 
-      /* 13-Dec-2016 nm */
       /* Normally labelMatch is *, but may be more specific for
          use by verifyMarkup() */
       if (!matchesList(g_Statement[i].labelName, labelMatch, '*', '?')) {
@@ -5882,7 +5195,6 @@ flag writeBibliography(vstring bibFile,
       }
       let(&str1, edit(str1, 8 + 128 + 16)); /* Reduce & trim whitespace */
 
-      /* 15-Apr-2015 nm */
       /* Clear out math symbols in backquotes to prevent false matches
          to [reference] bracket */
       k = 0; /* Math symbol mode if 1 */
@@ -5932,7 +5244,7 @@ flag writeBibliography(vstring bibFile,
         j = instr(j + 1, str1, "["); /* Find reference (not robust) */
         if (!j) break;
 
-        /* 13-Dec-2016 nm Fix mmbiblio.html corruption caused by
+        /* Fix mmbiblio.html corruption caused by
            "[Copying an angle]" in df-ibcg in
            set.mm.2016-09-18-JB-mbox-cleanup */
         /* Skip if there is no trailing "]" */
@@ -5946,7 +5258,6 @@ flag writeBibliography(vstring bibFile,
            for space since we already reduced \n \t to space (\f is probably
            overkill, and any \r's are removed during the READ command) */
         if (instr(1, seg(str1, j, jend), " ")) continue;
-        /* 22-Feb-2019 nm */
         /* Skip escaped bracket "[[" */
         if (str1[j] == '[') {  /* (j+1)th character in str1 */
           j++; /* Skip over 2nd "[" */
@@ -5964,12 +5275,6 @@ flag writeBibliography(vstring bibFile,
           /* **IMPORTANT** Make sure to update mmhlpb.c HELP WRITE BIBLIOGRAPHY
              if new items are added to this list. */
           if (0
-              /* 3-Jun-2018 nm Added PROOF, STATEMENT */
-              /* 12-Apr-2020 nm Added CLAIM */
-              /* 8-Aug-2020 nm Added CONJECTURE, RESULT */
-              /* 23-Aug-2020 nm Added CONCLUSION FACT INTRODUCTION PARAGRAPH
-                      SCOLIA SCOLION SUBSECTION TABLE */
-              /* Do not add SCHEMA but use AXIOM SCHEMA or THEOREM SCHEMA */
               /* Put the most frequent ones first to speed up search;
                  TODO: count occurrences in mmbiblio.html to find optimal order */
               || !strcmp(mid(str2, k, (long)strlen("THEOREM")), "THEOREM")
@@ -6031,12 +5336,11 @@ flag writeBibliography(vstring bibFile,
           continue; /* Not a bib ref - ignore */
         }
         /* m is at the start of a keyword */
-        p = instr(m, str1, "["); /* Start of bibliograpy reference */
+        p = instr(m, str1, "["); /* Start of bibliography reference */
         q = instr(p, str1, "]"); /* End of bibliography reference */
         if (q == 0) {
           if (p2 == 1) {
-            print2(
-        "?Warning: Bibliography reference not found in HTML file in \"%s\".\n",
+            print2("?Warning: Bibliography reference not found in HTML file in \"%s\".\n",
               g_Statement[i].labelName);
             warnFlag = 1;
           }
@@ -6045,8 +5349,7 @@ flag writeBibliography(vstring bibFile,
         s = instr(q, str1, "###"); /* Page number marker */
         if (!s) {
           if (p2 == 1) {
-            print2(
-          "?Warning: No page number after [<author>] bib ref in \"%s\".\n",
+            print2("?Warning: No page number after [<author>] bib ref in \"%s\".\n",
               g_Statement[i].labelName);
             warnFlag = 1;
           }
@@ -6088,14 +5391,6 @@ flag writeBibliography(vstring bibFile,
             "&&&",  /* &&& means end of statement href */
             /* Construct actual HTML table row (without ending tag
                so duplicate references can be added) */
-
-            /*
-            (i < g_extHtmlStmt) ?
-               "<TR>" :
-               cat("<TR BGCOLOR=", PURPLISH_BIBLIO_COLOR, ">", NULL),
-            */
-
-            /* 29-Jul-2008 nm Sandbox stuff */
             (i < g_extHtmlStmt)
                ? "<TR>"
                : (i < g_mathboxStmt)
@@ -6104,13 +5399,6 @@ flag writeBibliography(vstring bibFile,
 
             "<TD NOWRAP>[<A HREF=\"",
 
-            /*
-            (i < g_extHtmlStmt) ?
-               g_htmlBibliography :
-               extHtmlBibliography,
-            */
-
-            /* 29-Jul-2008 nm Sandbox stuff */
             (i < g_extHtmlStmt)
                ? g_htmlBibliography
                : (i < g_mathboxStmt)
@@ -6158,7 +5446,6 @@ flag writeBibliography(vstring bibFile,
     j = instr(1, (vstring)(pntrTmp[i]), "|||");
     let(&str2, left((vstring)(pntrTmp[i]), j - 1));
     if (!strcmp(str1, str2)) {
-      /* n++; */ /* 17-Nov-2015 nm Deleted - why was this here? */
       /* Combine last with this */
       k = instr(j, (vstring)(pntrTmp[i]), "&&&");
       /* Extract statement href */
@@ -6258,7 +5545,6 @@ flag writeBibliography(vstring bibFile,
 }  /* writeBibliography */
 
 
-/* 5-Aug-2020 nm */
 /* Returns 1 if stmt1 and stmt2 are in different mathboxes, 0 if
    they are in the same mathbox or if one of them is not in a mathbox. */
 flag inDiffMathboxes(long stmt1, long stmt2) {
@@ -6270,7 +5556,6 @@ flag inDiffMathboxes(long stmt1, long stmt2) {
   return 0;
 }
 
-/* 5-Aug-2020 nm */
 /* Returns the user of the mathbox that a statement is in, or ""
    if the statement is not in a mathbox. */
 /* Caller should NOT deallocate returned string (it points directly to
@@ -6282,7 +5567,6 @@ vstring getMathboxUser(long stmt) {
   return g_mathboxUser[mbox - 1];
 }
 
-/* 5-Aug-2020 nm */
 /* Given a statement number, find out what mathbox it's in (numbered starting
    at 1) mainly for error messages; if it's not in a mathbox, return 0. */
 /* We assume the number of mathboxes is small enough that a linear search
@@ -6297,7 +5581,6 @@ long getMathboxNum(long stmt) {
 } /* getMathboxNum */
 
 
-/* 5-Aug-2020 nm */
 /* Assign the global variable g_mathboxStmt, the statement number with the
    label "mathbox", as well as g_mathboxes, g_mathboxStart[], g_mathboxEnd[],
    and g_mathboxUser[].  For speed, we do the lookup only if it hasn't been
@@ -6321,10 +5604,6 @@ void assignMathboxInfo(void) {
 } /* assignMathboxInfo */
 
 
-/* 5-Aug-2020 nm */ /* (This was originally written to be able to deal with
-   local mathboxStart,End,User, which were later made global.  But there should
-   be no significant slowdown so we've kept this ability.) */
-/* 17-Jul-2020 nm */
 /* Returns the number of mathboxes, while assigning start statement, end
    statement, and mathbox name. */
 #define MB_TAG "Mathbox for "

--- a/mmwtex.c
+++ b/mmwtex.c
@@ -19,7 +19,7 @@
 #include "mmwtex.h"
 #include "mmcmdl.h" /* For g_texFileName */
 
-/* 6/27/99 - Now, all LaTeX and HTML definitions are taken from the source
+/* All LaTeX and HTML definitions are taken from the source
    file (read in the by READ... command).  In the source file, there should
    be a single comment $( ... $) containing the keyword $t.  The definitions
    start after the $t and end at the $).  Between $t and $), the definition
@@ -38,7 +38,6 @@ long g_extHtmlStmt = 0; /* At this statement and above, use the exthtmlxxx
     generation of the Hilbert Space Explorer extension to the set.mm
     database. */
 
-/* 5-Aug-2020 nm */
 /* Globals to hold mathbox information.  They should be re-initialized
    by the ERASE command (eraseSource()).  g_mathboxStmt = 0 indicates
    it and the other variables haven't been initialized. */
@@ -64,34 +63,25 @@ pntrString *g_mathboxUser = NULL_PNTRSTRING; /* User name vs. mathbox # */
 FILE *g_texFilePtr = NULL;
 flag g_texFileOpenFlag = 0;
 
-/********* 15-Aug-2020 nm Obsolete
-/@ Tex dictionary @/
-FILE *tex_dict_fp;
-vstring tex_dict_fn = "";
-********/
-
 /* Global variables */
 flag g_texDefsRead = 0;
-struct texDef_struct *g_TexDefs; /* 27-Oct-2012 nm Made global for "erase" */
+struct texDef_struct *g_TexDefs;
 
 /* Variables local to this module (except some $t variables) */
 long numSymbs;
 #define DOLLAR_SUBST 2
-/*char dollarSubst = 2;*/
     /* Substitute character for $ in converting to obsolete $l,$m,$n
        comments - Use '$' instead of non-printable ASCII 2 for debugging */
 
 /* Variables set by the language in the set.mm etc. $t statement */
 /* Some of these are global; see mmwtex.h */
-vstring g_htmlCSS = ""; /* Set by g_htmlCSS commands */  /* 14-Jan-2016 nm */
-vstring g_htmlFont = ""; /* Set by htmlfont commands */  /* 14-Jan-2016 nm */
+vstring g_htmlCSS = ""; /* Set by g_htmlCSS commands */
+vstring g_htmlFont = ""; /* Set by htmlfont commands */
 vstring g_htmlVarColor = ""; /* Set by htmlvarcolor commands */
 vstring htmlExtUrl = ""; /* Set by htmlexturl command */
 vstring htmlTitle = ""; /* Set by htmltitle command */
-  /* 16-Aug-2016 nm */
   vstring htmlTitleAbbr = ""; /* Extracted from htmlTitle */
 vstring g_htmlHome = ""; /* Set by htmlhome command */
-  /* 16-Aug-2016 nm */
   /* Future - assign these in the $t set.mm comment instead of g_htmlHome */
   vstring g_htmlHomeHREF = ""; /* Extracted from g_htmlHome */
   vstring g_htmlHomeIMG = ""; /* Extracted from g_htmlHome */
@@ -100,7 +90,6 @@ vstring extHtmlLabel = ""; /* Set by exthtmllabel command - where extHtml starts
 vstring g_extHtmlTitle = ""; /* Set by exthtmltitle command (global!) */
   vstring g_extHtmlTitleAbbr = ""; /* Extracted from htmlTitle */
 vstring extHtmlHome = ""; /* Set by exthtmlhome command */
-  /* 16-Aug-2016 nm */
   /* Future - assign these in the $t set.mm comment instead of g_htmlHome */
   vstring extHtmlHomeHREF = ""; /* Extracted from extHtmlHome */
   vstring extHtmlHomeIMG = ""; /* Extracted from extHtmlHome */
@@ -109,12 +98,11 @@ vstring htmlDir = ""; /* Directory for GIF version, set by htmldir command */
 vstring altHtmlDir = ""; /* Directory for Unicode Font version, set by
                             althtmldir command */
 
-/* 29-Jul-2008 nm Sandbox stuff */
+/* Sandbox stuff */
 vstring sandboxHome = "";
   vstring sandboxHomeHREF = ""; /* Extracted from extHtmlHome */
   vstring sandboxHomeIMG = ""; /* Extracted from extHtmlHome */
 vstring sandboxTitle = "";
-  /* 16-Aug-2016 nm */
   vstring sandboxTitleAbbr = "";
 
 /* Variables holding all HTML <a name..> tags from bibiography pages  */
@@ -122,9 +110,8 @@ vstring g_htmlBibliographyTags = "";
 vstring extHtmlBibliographyTags = "";
 
 
-/* 17-Nov-2015 nm Added */
 void eraseTexDefs(void) {
-  /* Deallocate the texdef/htmldef storage */ /* Added 27-Oct-2012 nm */
+  /* Deallocate the texdef/htmldef storage */
   long i;
   if (g_texDefsRead) {  /* If not (already deallocated or never allocated) */
     g_texDefsRead = 0;
@@ -160,22 +147,20 @@ flag readTexDefs(
   long cmd;
   long parsePass;
   vstring token = "";
-  vstring partialToken = ""; /* 6-Aug-2011 nm */
+  vstring partialToken = "";
   FILE *tmpFp;
-  static flag saveHtmlFlag = -1; /* -1 to force 1st read */  /* 17-Nov-2015 nm */
-  static flag saveAltHtmlFlag = 1; /* -1 to force 1st read */ /* 17-Nov-2015 nm */
+  static flag saveHtmlFlag = -1; /* -1 to force 1st read */
+  static flag saveAltHtmlFlag = 1; /* -1 to force 1st read */
   flag warningFound = 0; /* 1 if a warning was found */
   char *dollarTStmtPtr = NULL; /* Pointer to label section of statement with
-                              the $t comment */ /* 2-Feb-2018 nm */
+                              the $t comment */
 
   /* bsearch returned values for use in error-checking */
   void *g_mathKeyPtr; /* bsearch returned value for math symbol lookup */
   void *texDefsPtr; /* For binary search */
 
-  /* 17-Nov-2015 nm */
-  /* if (g_texDefsRead) { */
   if (saveHtmlFlag != g_htmlFlag || saveAltHtmlFlag != g_altHtmlFlag
-      || !g_texDefsRead) {   /* 3-Jan-2016 nm */
+      || !g_texDefsRead) {
     /* One or both changed - we need to erase and re-read */
     eraseTexDefs();
     saveHtmlFlag = g_htmlFlag; /* Save for next call to readTexDefs() */
@@ -187,14 +172,11 @@ flag readTexDefs(
     /* Nothing changed; don't need to read again */
     return 0; /* No errors */
   }
-  /* } */
 
   /* Initial values below will be overridden if a user assignment exists in the
      $t comment of the xxx.mm input file */
   let(&htmlTitle, "Metamath Test Page"); /* Set by htmltitle command in $t
                                                  comment */
-  /* let(&g_htmlHome, "<A HREF=\"http://metamath.org\">Home</A>"); */
-  /* 16-Aug-2016 nm */
   let(&g_htmlHome, cat("<A HREF=\"mmset.html\"><FONT SIZE=-2 FACE=sans-serif>",
     "<IMG SRC=\"mm.gif\" BORDER=0 ALT=",
     "\"Home\" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE STYLE=\"margin-bottom:0px\">",
@@ -204,7 +186,7 @@ flag readTexDefs(
   if (errorsOnly == 0) {
     print2("Reading definitions from $t statement of %s...\n", g_input_fn);
   }
-  /******* 10/14/02 Rewrote this section so xxx.mm is not read again *******/
+
   /* Find the comment with the $t */
   fileBuf = ""; /* This used to point to the input file buffer of an external
                    latex.def file; now it's from the xxx.mm $t comment, so we
@@ -236,7 +218,7 @@ flag readTexDefs(
       }
       let(&fileBuf, tmpPtr);
       tmpPtr[j] = zapChar;
-      dollarTStmtPtr = g_Statement[i].labelSectionPtr; /* 2-Feb-2018 nm */
+      dollarTStmtPtr = g_Statement[i].labelSectionPtr;
       /* break; */ /* Continue to end to detect double $t */
     }
     tmpPtr[j] = zapChar; /* Restore the xxx.mm input file buffer */
@@ -248,7 +230,6 @@ flag readTexDefs(
   for (i = 0; i < j; i++) {
     if (fileBuf[i] == '\n') lineNumOffset--;
   }
-  /******* End of 10/14/02 rewrite *******/
 
 
 #define LATEXDEF 1
@@ -256,25 +237,21 @@ flag readTexDefs(
 #define HTMLVARCOLOR 3
 #define HTMLTITLE 4
 #define HTMLHOME 5
-/* Added 12/27/01 */
 #define ALTHTMLDEF 6
 #define EXTHTMLTITLE 7
 #define EXTHTMLHOME 8
 #define EXTHTMLLABEL 9
 #define HTMLDIR 10
 #define ALTHTMLDIR 11
-/* Added 10/9/02 */
 #define HTMLBIBLIOGRAPHY 12
 #define EXTHTMLBIBLIOGRAPHY 13
-/* Added 14-Jan-2016 nm */
 #define HTMLCSS 14
 #define HTMLFONT 15
-/* Added 26-Dec-2020 nm */
 #define HTMLEXTURL 16
 
   startPtr = fileBuf;
 
-  /* 6/27/99 Find $t command */
+  /* Find $t command */
   while (1) {
     if (startPtr[0] == '$') {
       if (startPtr[1] == 't') {
@@ -290,12 +267,12 @@ flag readTexDefs(
     print2(
 "The file should have exactly one comment of the form $(...$t...$) with\n");
     print2("the LaTeX and HTML definitions between $t and $).\n");
-    let(&fileBuf, "");  /* was: free(fileBuf); */
+    let(&fileBuf, "");
     return 2;
   }
   startPtr++; /* Move to 1st char after $t */
 
-  /* 6/27/99 Search for the ending $) and zap the $) to be end-of-string */
+  /* Search for the ending $) and zap the $) to be end-of-string */
   tmpPtr = startPtr;
   while (1) {
     if (tmpPtr[0] == '$') {
@@ -310,11 +287,11 @@ flag readTexDefs(
     print2(
   "?Error: There is no $) comment closure after the $t keyword in \"%s\".\n",
         g_input_fn);
-    let(&fileBuf, "");  /* was: free(fileBuf); */
+    let(&fileBuf, "");
     return 2;
   }
 
-  /* 10/9/02 Make sure there aren't two comments with $t commands */
+  /* Make sure there aren't two comments with $t commands */
   tmpPtr2 = tmpPtr;
   while (1) {
     if (tmpPtr2[0] == '$') {
@@ -322,7 +299,7 @@ flag readTexDefs(
         print2(
   "?Error: There are two comments containing a $t keyword in \"%s\".\n",
             g_input_fn);
-        let(&fileBuf, "");  /* was: free(fileBuf); */
+        let(&fileBuf, "");
         return 2;
       }
     }
@@ -356,7 +333,7 @@ flag readTexDefs(
           "latexdef,htmldef,htmlvarcolor,htmltitle,htmlhome"
           ",althtmldef,exthtmltitle,exthtmlhome,exthtmllabel,htmldir"
           ",althtmldir,htmlbibliography,exthtmlbibliography"
-          ",htmlcss,htmlfont,htmlexturl"   /* 26-Dec-2020 nm */
+          ",htmlcss,htmlfont,htmlexturl"
           );
       fbPtr[tokenLength] = zapChar;
       if (cmd == 0) {
@@ -364,19 +341,17 @@ flag readTexDefs(
         for (i = 0; i < (fbPtr - fileBuf); i++) {
           if (fileBuf[i] == '\n') lineNum++;
         }
-        rawSourceError(/*fileBuf*/g_sourcePtr,  /* 2-Feb-2018 nm */
+        rawSourceError(/*fileBuf*/g_sourcePtr,
             /*fbPtr*/dollarTStmtPtr + (fbPtr - fileBuf), tokenLength,
-            /*lineNum, g_input_fn,*/   /* 2-Feb-2018 nm These arguments are now
-                computed in rawSourceError() */
             cat("Expected \"latexdef\", \"htmldef\", \"htmlvarcolor\",",
             " \"htmltitle\", \"htmlhome\", \"althtmldef\",",
             " \"exthtmltitle\", \"exthtmlhome\", \"exthtmllabel\",",
             " \"htmldir\", \"althtmldir\",",
             " \"htmlbibliography\", \"exthtmlbibliography\",",
-            " \"htmlcss\", \"htmlfont\",",    /* 14-Jan-2016 nm */
-            " or \"htmlexturl\" here.",       /* 26-Dec-2020 nm */
+            " \"htmlcss\", \"htmlfont\",",
+            " or \"htmlexturl\" here.",
             NULL));
-        let(&fileBuf, "");  /* was: free(fileBuf); */
+        let(&fileBuf, "");
         return 2;
       }
       fbPtr = fbPtr + tokenLength;
@@ -385,10 +360,7 @@ flag readTexDefs(
           && cmd != EXTHTMLTITLE && cmd != EXTHTMLHOME && cmd != EXTHTMLLABEL
           && cmd != HTMLDIR && cmd != ALTHTMLDIR
           && cmd != HTMLBIBLIOGRAPHY && cmd != EXTHTMLBIBLIOGRAPHY
-          && cmd != HTMLCSS /* 14-Jan-2016 nm */
-          && cmd != HTMLFONT /* 14-Jan-2016 nm */
-          && cmd != HTMLEXTURL /* 26-Dec-2020 nm */
-          ) {
+          && cmd != HTMLCSS && cmd != HTMLFONT && cmd != HTMLEXTURL) {
          /* Get next token - string in quotes */
         fbPtr = fbPtr + texDefWhiteSpaceLen(fbPtr);
         tokenLength = texDefTokenLen(fbPtr);
@@ -403,11 +375,11 @@ flag readTexDefs(
           for (i = 0; i < (fbPtr - fileBuf); i++) {
             if (fileBuf[i] == '\n') lineNum++;
           }
-          rawSourceError(/*fileBuf*/g_sourcePtr,  /* 2-Feb-2018 nm */
+          rawSourceError(/*fileBuf*/g_sourcePtr,
             /*fbPtr*/dollarTStmtPtr + (fbPtr - fileBuf),
-              tokenLength, /*lineNum, g_input_fn,*/
+              tokenLength,
               "Expected a quoted string here.");
-          let(&fileBuf, "");  /* was: free(fileBuf); */
+          let(&fileBuf, "");
           return 2;
         }
         if (parsePass == 2) {
@@ -418,7 +390,7 @@ flag readTexDefs(
           fbPtr[tokenLength - 1] = zapChar;
 
           /* Change double internal quotes to single quotes */
-          /* 6-Aug-2011 nm Do this only for double quotes matching the
+          /* Do this only for double quotes matching the
              outer quotes.  fbPtr[0] is the quote character. */
           if (fbPtr[0] != '\"' && fbPtr[0] != '\'') bug(2329);
           j = (long)strlen(token);
@@ -446,10 +418,7 @@ flag readTexDefs(
           && cmd != EXTHTMLTITLE && cmd != EXTHTMLHOME && cmd != EXTHTMLLABEL
           && cmd != HTMLDIR && cmd != ALTHTMLDIR
           && cmd != HTMLBIBLIOGRAPHY && cmd != EXTHTMLBIBLIOGRAPHY
-          && cmd != HTMLCSS /* 14-Jan-2016 nm */
-          && cmd != HTMLFONT /* 14-Jan-2016 nm */
-          && cmd != HTMLEXTURL /* 26-Dec-2020 nm */
-          ) {
+          && cmd != HTMLCSS && cmd != HTMLFONT && cmd != HTMLEXTURL) {
         /* Get next token -- "as" */
         fbPtr = fbPtr + texDefWhiteSpaceLen(fbPtr);
         tokenLength = texDefTokenLen(fbPtr);
@@ -464,11 +433,11 @@ flag readTexDefs(
           for (i = 0; i < (fbPtr - fileBuf); i++) {
             if (fileBuf[i] == '\n') lineNum++;
           }
-          rawSourceError(/*fileBuf*/g_sourcePtr,  /* 2-Feb-2018 nm */
+          rawSourceError(/*fileBuf*/g_sourcePtr,
             /*fbPtr*/dollarTStmtPtr + (fbPtr - fileBuf),
-              tokenLength, /*lineNum, g_input_fn,*/
+              tokenLength,
               "Expected the keyword \"as\" here.");
-          let(&fileBuf, "");  /* was: free(fileBuf); */
+          let(&fileBuf, "");
           return 2;
         }
         fbPtr[tokenLength] = zapChar;
@@ -495,23 +464,20 @@ flag readTexDefs(
           for (i = 0; i < (fbPtr - fileBuf); i++) {
             if (fileBuf[i] == '\n') lineNum++;
           }
-          rawSourceError(/*fileBuf*/g_sourcePtr,  /* 2-Feb-2018 nm */
+          rawSourceError(/*fileBuf*/g_sourcePtr,
             /*fbPtr*/dollarTStmtPtr + (fbPtr - fileBuf),
-              tokenLength, /*lineNum, g_input_fn,*/
+              tokenLength,
               "Expected a quoted string here.");
-          let(&fileBuf, "");  /* was: free(fileBuf); */
+          let(&fileBuf, "");
           return 2;
         }
         if (parsePass == 2) {
           zapChar = fbPtr[tokenLength - 1]; /* Chr to restore after zapping src */
           fbPtr[tokenLength - 1] = 0; /* Create end of string */
-          /* let(&token, cat(token, fbPtr + 1, NULL)); old before 6-Aug-2011 */
-           /* 6-Aug-2011 nm */
           let(&partialToken, fbPtr + 1); /* Get ASCII token; note that leading
               and trailing quotes are omitted. */
           fbPtr[tokenLength - 1] = zapChar;
 
-          /* 6-Aug-2011 nm */
           /* Change double internal quotes to single quotes */
           /* Do this only for double quotes matching the
              outer quotes.  fbPtr[0] is the quote character. */
@@ -526,25 +492,20 @@ flag readTexDefs(
             }
           }
 
-          /* 6-Aug-2011 nm */
           /* Check that string is on a single line */
           tmpPtr2 = strchr(partialToken, '\n');
           if (tmpPtr2 != NULL) {
-
-            /* 26-Dec-2011 nm - added to initialize lineNum */
             lineNum = lineNumOffset;
             for (i = 0; i < (fbPtr - fileBuf); i++) {
               if (fileBuf[i] == '\n') lineNum++;
             }
 
-            rawSourceError(/*fileBuf*/g_sourcePtr,  /* 2-Feb-2018 nm */
+            rawSourceError(/*fileBuf*/g_sourcePtr,
                 /*fbPtr*/dollarTStmtPtr + (fbPtr - fileBuf),
                 tmpPtr2 - partialToken + 1 /*tokenLength on current line*/,
-                /*lineNum, g_input_fn,*/
                 "String should be on a single line.");
           }
 
-          /* 6-Aug-2011 nm */
           /* Combine the string part to the main token we're building */
           let(&token, cat(token, partialToken, NULL));
 
@@ -567,11 +528,11 @@ flag readTexDefs(
               lineNum++;
             }
           }
-          rawSourceError(/*fileBuf*/g_sourcePtr,  /* 2-Feb-2018 nm */
+          rawSourceError(/*fileBuf*/g_sourcePtr,
             /*fbPtr*/dollarTStmtPtr + (fbPtr - fileBuf),
               tokenLength, /*lineNum, g_input_fn,*/
               "Expected \"+\" or \";\" here.");
-          let(&fileBuf, "");  /* was: free(fileBuf); */
+          let(&fileBuf, "");
          return 2;
         }
         fbPtr = fbPtr + tokenLength;
@@ -582,27 +543,6 @@ flag readTexDefs(
 
 
       if (parsePass == 2) {
-
-        /* 6-Aug-2011 nm This was moved above (and modified) because
-           each string part may have different outer quotes, so we can't
-           do the whole string at once like the attempt below. */
-        /* old before 6-Aug-2011 */
-        /* Change double internal quotes to single quotes */
-        /*
-        j = (long)strlen(token);
-        for (i = 0; i < j - 1; i++) {
-          if ((token[i] == '\"' &&
-              token[i + 1] == '\"') ||
-              (token[i] == '\'' &&
-              token[i + 1] == '\'')) {
-            let(&token, cat(left(token,
-                i + 1), right(token, i + 3), NULL));
-            j--;
-          }
-        }
-        */
-        /* end of old before 6-Aug-2011 */
-
         if ((cmd == LATEXDEF && !g_htmlFlag)
             || (cmd == HTMLDEF && g_htmlFlag && !g_altHtmlFlag)
             || (cmd == ALTHTMLDEF && g_htmlFlag && g_altHtmlFlag)) {
@@ -641,7 +581,7 @@ flag readTexDefs(
         }
         if (cmd == HTMLCSS) {
           let(&g_htmlCSS, token);
-          /* 14-Jan-2016 nm User's CSS */ /* 13-Dec-2018 nm Moved up to here */
+          /* User's CSS */
           /* Convert characters "\n" to new line - maybe do for other fields too? */
           do {
             p = instr(1, g_htmlCSS, "\\n");
@@ -655,7 +595,7 @@ flag readTexDefs(
           let(&g_htmlFont, token);
         }
         if (cmd == HTMLEXTURL) {
-          let(&htmlExtUrl, token);  /* 26-Dec-2020 nm */
+          let(&htmlExtUrl, token);
         }
       }
 
@@ -690,7 +630,7 @@ flag readTexDefs(
       printLongLine(cat("?Warning: Token ", g_TexDefs[i].tokenName,
           " is defined more than once in ",
           g_htmlFlag
-            ? (g_altHtmlFlag ? "an althtmldef" : "an htmldef") /* 4-Jul-2020 nm */
+            ? (g_altHtmlFlag ? "an althtmldef" : "an htmldef")
             : "a latexdef",
           " statement.", NULL),
           "", " ");
@@ -708,7 +648,7 @@ flag readTexDefs(
       printLongLine(cat("?Warning: The token \"", g_TexDefs[i].tokenName,
           "\", which was defined in ",
           g_htmlFlag
-            ? (g_altHtmlFlag ? "an althtmldef" : "an htmldef")  /* 4-Jul-2020 nm */
+            ? (g_altHtmlFlag ? "an althtmldef" : "an htmldef")
             : "a latexdef",
           " statement, was not declared in any $v or $c statement.", NULL),
           "", " ");
@@ -724,7 +664,7 @@ flag readTexDefs(
       printLongLine(cat("?Warning: The token \"", g_MathToken[i].tokenName,
        "\", which was defined in a $v or $c statement, was not declared in ",
           g_htmlFlag
-            ? (g_altHtmlFlag ? "an althtmldef" : "an htmldef") /* 4-Jul-2020 nm */
+            ? (g_altHtmlFlag ? "an althtmldef" : "an htmldef")
             : "a latexdef",
           " statement.", NULL),
           "", " ");
@@ -732,7 +672,6 @@ flag readTexDefs(
     }
   }
 
-  /* 26-Jun-2011 nm Added this check */
   /* Check to make sure all GIFs are present */
   if (g_htmlFlag) {
     for (i = 0; i < numSymbs; i++) {
@@ -752,7 +691,7 @@ flag readTexDefs(
                                      trailing quote" warning */
            /* (We test k after the let() so that the temporary string stack
               entry created by mid() is emptied and won't overflow */
-        if (noGifCheck == 0) { /* 17-Nov-2015 nm */
+        if (noGifCheck == 0) {
           tmpFp = fopen(token, "r"); /* See if it exists */
           if (!tmpFp) {
             printLongLine(cat("?Warning: The file \"", token,
@@ -787,29 +726,7 @@ flag readTexDefs(
     g_extHtmlStmt = g_statements + 1;
   }
 
-  /* 29-Jul-2008 nm Sandbox stuff */
-  /* 24-Jul-2009 nm Changed name of sandbox to "mathbox" */
-  /* 28-Jun-2011 nm Use lookupLabel for speedup */
-  /* replaced w/ function call 17-Jul-2020
-  if (g_mathboxStmt == 0) { /@ Look up "mathbox" label if it hasn't been @/
-    g_mathboxStmt = lookupLabel("mathbox");
-    if (g_mathboxStmt == -1)
-      g_mathboxStmt = g_statements + 1;  /@ Default beyond db end if none @/
-  }
-  */
-  assignMathboxInfo(); /* 17-Jul-2020 nm */
-  /*
-  for (i = 1; i <= g_statements; i++) {
-    /@ For now (and probably forever) the sandbox start theorem is
-       hardcoded to "sandbox", like in set.mm @/
-    /@ if (!strcmp("sandbox", g_Statement[i].labelName)) { @/
-    /@ 24-Jul-2009 nm Changed name of sandbox to "mathbox" @/
-    if (!strcmp("mathbox", g_Statement[i].labelName)) {
-      g_mathboxStmt = i;
-      break;
-    }
-  }
-  */
+  assignMathboxInfo();
   /* In case there is not extended (Hilbert Space Explorer) section,
      but there is a sandbox section, make the extended section "empty". */
   if (g_extHtmlStmt == g_statements + 1) g_extHtmlStmt = g_mathboxStmt;
@@ -821,18 +738,8 @@ flag readTexDefs(
   let(&sandboxHomeHREF, "mmtheorems.html#sandbox:bighdr");
   let(&sandboxHomeIMG, "_sandbox.gif");
   let(&sandboxTitleAbbr, "Users' Mathboxes");
-  /*let(&sandboxTitle, "User Sandbox");*/
-  /* 24-Jul-2009 nm Changed name of sandbox to "mathbox" */
   let(&sandboxTitle, "Users' Mathboxes");
 
-  /* 16-Aug-2016 nm */
-  /*
-  let(&sandboxHomeHREF, "mmtheorems.html#sandbox:bighdr");
-  let(&sandboxHomeIMG, "_sandbox.gif");
-  let(&sandboxTitleAbbr, "Mathboxes");
-  */
-
-  /* 16-Aug-2016 nm */
   /* Extract derived variables from the $t variables */
   /* (In the future, it might be better to do this directly in the $t.) */
   i = instr(1, g_htmlHome, "HREF=\"") + 5;
@@ -853,7 +760,6 @@ flag readTexDefs(
   let(&g_htmlHomeIMG, seg(g_htmlHome, i + 1, j - 1));
 
 
-  /* 16-Aug-2016 nm */
   /* Compose abbreviated title from capital letters */
   j = (long)strlen(htmlTitle);
   let(&htmlTitleAbbr, "");
@@ -864,9 +770,7 @@ flag readTexDefs(
   }
   let(&htmlTitleAbbr, cat(htmlTitleAbbr, " Home", NULL));
 
-  /* 18-Aug-2016 nm Added conditional test for extended section */
   if (g_extHtmlStmt < g_statements + 1 /* If extended section exists */
-      /* nm 8-Dec-2017 nm */
       && g_extHtmlStmt != g_mathboxStmt) { /* and is not an empty dummy section */
     i = instr(1, extHtmlHome, "HREF=\"") + 5;
     if (i == 5) {
@@ -896,17 +800,10 @@ flag readTexDefs(
     let(&g_extHtmlTitleAbbr, cat(g_extHtmlTitleAbbr, " Home", NULL));
   }
 
-  /* 16-Aug-2016 nm For debugging - remove later */
-  /*
-  printf("h=%s i=%s a=%s\n",g_htmlHomeHREF,g_htmlHomeIMG,htmlTitleAbbr);
-  printf("eh=%s ei=%s ea=%s\n",extHtmlHomeHREF,extHtmlHomeIMG,g_extHtmlTitleAbbr);
-  */
-
-
 
   let(&token, ""); /* Deallocate */
-  let(&partialToken, ""); /* Deallocate */  /* 6-Aug-2011 nm */
-  let(&fileBuf, "");  /* was: free(fileBuf); */
+  let(&partialToken, ""); /* Deallocate */
+  let(&fileBuf, "");
   g_texDefsRead = 1;  /* Set global flag that it's been read in */
   return warningFound; /* Return indicator that parsing passed (0) or
                            had warning(s) (1) */
@@ -924,18 +821,8 @@ long texDefWhiteSpaceLen(char *ptr)
   char *ptr1;
   while (1) {
     tmpchr = ptr[i];
-    if (!tmpchr) return (i); /* End of string */
-    if (isalnum((unsigned char)(tmpchr))) return (i); /* Alphanumeric string */
-
-    /* 6-Aug-2011 nm Removed this undocumented feature */
-    /*
-    if (ptr[i] == '!') { /@ Comment to end-of-line @/
-      ptr1 = strchr(ptr + i + 1, '\n');
-      if (!ptr1) bug(2306);
-      i = ptr1 - ptr + 1;
-      continue;
-    }
-    */
+    if (!tmpchr) return i; /* End of string */
+    if (isalnum((unsigned char)(tmpchr))) return i; /* Alphanumeric string */
 
     if (tmpchr == '/') { /* Embedded c-style comment - used to ignore
         comments inside of Metamath comment for LaTeX/HTML definitions */
@@ -943,7 +830,7 @@ long texDefWhiteSpaceLen(char *ptr)
         while (1) {
           ptr1 = strchr(ptr + i + 2, '*');
           if (!ptr1) {
-            return(i + (long)strlen(&ptr[i])); /* Unterminated comment - goto EOF */
+            return i + (long)strlen(&ptr[i]); /* Unterminated comment - goto EOF */
           }
           if (ptr1[1] == '/') break;
           i = ptr1 - ptr;
@@ -951,14 +838,14 @@ long texDefWhiteSpaceLen(char *ptr)
         i = ptr1 - ptr + 2;
         continue;
       } else {
-        return(i);
+        return i;
       }
     }
-    if (isgraph((unsigned char)tmpchr)) return (i);
+    if (isgraph((unsigned char)tmpchr)) return i;
     i++;
   }
   bug(2307);
-  return(0); /* Dummy return - never executed */
+  return 0; /* Dummy return - never executed */
 } /* texDefWhiteSpaceLen */
 
 
@@ -978,9 +865,9 @@ long texDefTokenLen(char *ptr)
     while (1) {
       ptr1 = strchr(ptr + i + 1, '\"');
       if (!ptr1) {
-        return(i + (long)strlen(&ptr[i])); /* Unterminated quote - goto EOF */
+        return i + (long)strlen(&ptr[i]); /* Unterminated quote - goto EOF */
       }
-      if (ptr1[1] != '\"') return(ptr1 - ptr + 1); /* Double quote is literal */
+      if (ptr1[1] != '\"') return ptr1 - ptr + 1; /* Double quote is literal */
       i = ptr1 - ptr + 1;
     }
   }
@@ -988,20 +875,20 @@ long texDefTokenLen(char *ptr)
     while (1) {
       ptr1 = strchr(ptr + i + 1, '\'');
       if (!ptr1) {
-        return(i + (long)strlen(&ptr[i])); /* Unterminated quote - goto EOF */
+        return i + (long)strlen(&ptr[i]); /* Unterminated quote - goto EOF */
       }
-      if (ptr1[1] != '\'') return(ptr1 - ptr + 1); /* Double quote is literal */
+      if (ptr1[1] != '\'') return ptr1 - ptr + 1; /* Double quote is literal */
       i = ptr1 - ptr + 1;
     }
   }
-  if (ispunct((unsigned char)tmpchr)) return (1); /* Single-char token */
+  if (ispunct((unsigned char)tmpchr)) return 1; /* Single-char token */
   while (1) {
     tmpchr = ptr[i];
-    if (!isalnum((unsigned char)tmpchr)) return (i); /* End of alphnum. token */
+    if (!isalnum((unsigned char)tmpchr)) return i; /* End of alphnum. token */
     i++;
   }
   bug(2308);
-  return(0); /* Dummy return - never executed */
+  return 0; /* Dummy return - never executed */
 } /* texDefTokenLen */
 
 /* Token comparison for qsort */
@@ -1010,8 +897,8 @@ int texSortCmp(const void *key1, const void *key2)
   /* Returns -1 if key1 < key2, 0 if equal, 1 if key1 > key2 */
   /* Note:  ptr->fld == (*ptr).fld
             str.fld == (&str)->fld   */
-  return (strcmp( ((struct texDef_struct *)key1)->tokenName,
-      ((struct texDef_struct *)key2)->tokenName));
+  return strcmp(((struct texDef_struct *)key1)->tokenName,
+      ((struct texDef_struct *)key2)->tokenName);
 } /* texSortCmp */
 
 
@@ -1019,8 +906,8 @@ int texSortCmp(const void *key1, const void *key2)
 int texSrchCmp(const void *key, const void *data)
 {
   /* Returns -1 if key < data, 0 if equal, 1 if key > data */
-  return (strcmp(key,
-      ((struct texDef_struct *)data)->tokenName));
+  return strcmp(key,
+      ((struct texDef_struct *)data)->tokenName);
 } /* texSrchCmp */
 
 /* Convert ascii to a string of \tt tex; must not have control chars */
@@ -1072,31 +959,12 @@ vstring asciiToTt(vstring s)
     } else {
       switch (ttstr[i]) {
         /* For all unspecified cases, HTML will accept the character 'as is' */
-        /* 1-Oct-04 Don't convert to &amp; anymore but leave as is.  This
+        /* Don't convert to &amp; but leave as is.  This
            will allow the user to insert HTML entities for Unicode etc.
            directly in the database source. */
-        /*
-        case '&':
-          let(&ttstr,cat(left(ttstr,i),"&amp;",right(ttstr,i+2),NULL));
-          k = 5;
-          break;
-        */
+        /* case '&': ... */
         case '<':
-          /* 11/15/02 Leave in some special HTML tags (case must match) */
-          /* This was done specially for the set.mm inf3 comment */
-          /*
-          if (!strcmp(mid(ttstr, i + 1, 5), "<PRE>")) {
-            let(&ttstr, ttstr); /@ Purge stack to prevent overflow by 'mid' @/
-            i = i + 5;
-            break;
-          }
-          if (!strcmp(mid(ttstr, i + 1, 6), "</PRE>")) {
-            let(&ttstr, ttstr); /@ Purge stack to prevent overflow by 'mid' @/
-            i = i + 6;
-            break;
-          }
-          */
-          /* 26-Dec-2011 nm - changed <PRE> to more general <HTML> */
+          /* Leave in HTML tags (case must match) */
           if (!strcmp(mid(ttstr, i + 1, 6), "<HTML>")) {
             let(&ttstr, ttstr); /* Purge stack to prevent overflow by 'mid' */
             i = i + 6;
@@ -1128,7 +996,7 @@ vstring asciiToTt(vstring s)
   } /* Next i */
 
   let(&tmp, "");  /* Deallocate */
-  return(ttstr);
+  return ttstr;
 } /* asciiToTt */
 
 
@@ -1152,11 +1020,10 @@ vstring tokenToTex(vstring mtoken, long statemNum /*for error msgs*/)
   if (texDefsPtr) { /* Found it */
     let(&tex, ((struct texDef_struct *)texDefsPtr)->texEquiv);
   } else {
-    /* 9/5/99 If it wasn't found, give user a warning... */
+    /* If it wasn't found, give user a warning... */
     saveOutputToString = g_outputToString;
     g_outputToString = 0;
-    /* if (statemNum <= 0 || statemNum > g_statements) bug(2331); */ /* OLD */
-    /* 19-Sep-2012 nm It is possible for statemNum to be 0 when
+    /* It is possible for statemNum to be 0 when
        tokenToTex() is called (via getTexLongMath()) from
        printTexLongMath(), when its hypStmt argument is 0 (= not associated
        with a statement).  (Reported by Wolf Lammen.) */
@@ -1209,7 +1076,7 @@ vstring tokenToTex(vstring mtoken, long statemNum /*for error msgs*/)
 
   } /* End if */
 
-  return (tex);
+  return tex;
 } /* tokenToTex */
 
 
@@ -1223,7 +1090,6 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
   vstring lastTex = "";
   vstring token = "";
   flag alphnew, alphold, unknownnew, unknownold;
-  /* flag firstToken; */  /* Not used */
   long i;
   vstring srcptr;
 
@@ -1231,7 +1097,6 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
 
   let(&texLine, "");
   let(&lastTex, "");
-  /* firstToken = 1; */
   while(1) {
     i = whiteSpaceLen(srcptr);
     srcptr = srcptr + i;
@@ -1247,10 +1112,10 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
       /* If this token and previous token begin with letter, add a thin
            space between them */
       /* Also, anything not in table will have space added */
-      alphnew = !!isalpha((unsigned char)(tex[0])); /* 31-Aug-2012 nm Added
-            "!!" here and below because isalpha returns an integer, whose
-            unspecified non-zero value could be truncated to 0 when
-            converted to char.  Thanks to Wolf Lammen for pointing this out. */
+      /* Use "!!" here and below because isalpha returns an integer, whose
+        unspecified non-zero value could be truncated to 0 when
+        converted to char.  Thanks to Wolf Lammen for pointing this out. */
+      alphnew = !!isalpha((unsigned char)(tex[0]));
       unknownnew = 0;
       if (!strcmp(left(tex, 10), "\\mbox{\\rm ")) { /* Token not in table */
         unknownnew = 1;
@@ -1260,8 +1125,7 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
       if (!strcmp(left(lastTex, 10), "\\mbox{\\rm ")) { /* Token not in table*/
         unknownold = 1;
       }
-   /*if ((alphold && alphnew) || unknownold || (unknownnew && !firstToken)) {*/
-      /* Put thin space only between letters and/or unknowns  11/3/94 */
+      /* Put thin space only between letters and/or unknowns */
       if ((alphold || unknownold) && (alphnew || unknownnew)) {
         /* Put additional thin space between two letters */
         let(&texLine, cat(texLine, "\\,", tex, " ", NULL));
@@ -1273,15 +1137,12 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
     }
     let(&lastTex, ""); /* Deallocate */
     lastTex = tex; /* Pass deallocation responsibility for tex to lastTex */
-
-    /* firstToken = 0; */
-
   } /* End while (1) */
+
   let(&lastTex, ""); /* Deallocate */
   let(&token, ""); /* Deallocate */
 
-  return (texLine);
-
+  return texLine;
 } /* asciiMathToTex */
 
 
@@ -1294,12 +1155,12 @@ vstring getCommentModeSection(vstring *srcptr, char *mode)
   vstring modeSection = "";
   vstring ptr; /* Not allocated */
   flag addMode = 0;
-  if (!g_outputToString) bug(2319);  /* 10/10/02 */
+  if (!g_outputToString) bug(2319);
 
   if ((*srcptr)[0] != DOLLAR_SUBST /*'$'*/) {
     if ((*srcptr)[0] == 0) { /* End of string */
       *mode = 0; /* End of comment */
-      return ("");
+      return "";
     } else {
       *mode = 'n'; /* Normal text */
       addMode = 1;
@@ -1315,7 +1176,7 @@ vstring getCommentModeSection(vstring *srcptr, char *mode)
         bug(2317);
         /* Leave old code in case user continues through the bug */
         *mode = 0; /* End of comment */
-        return ("");
+        return "";
         break;
       default:
         *mode = 'n';
@@ -1339,7 +1200,7 @@ vstring getCommentModeSection(vstring *srcptr, char *mode)
                 NULL));
           }
           *srcptr = ptr;
-          return (modeSection);
+          return modeSection;
           break;
       }
     } else {
@@ -1351,12 +1212,12 @@ vstring getCommentModeSection(vstring *srcptr, char *mode)
                 NULL));
           }
           *srcptr = ptr;
-          return (modeSection);
+          return modeSection;
       }
     }
     ptr++;
   } /* End while */
-  return(NULL); /* Dummy return - never executes */
+  return NULL; /* Dummy return - never executes */
 } /* getCommentModeSection */
 
 
@@ -1371,18 +1232,17 @@ void printTexHeader(flag texHeaderFlag)
   long i, j, k;
   vstring tmpStr = "";
 
-  /* 2-Aug-2009 nm - "Mathbox for <username>" mod */
+  /* "Mathbox for <username>" mod */
   vstring localSandboxTitle = "";
-  vstring hugeHdr = ""; /* 21-Jun-2014 nm */
+  vstring hugeHdr = "";
   vstring bigHdr = "";
   vstring smallHdr = "";
-  vstring tinyHdr = "";  /* 21-Aug-2017 nm */
-  vstring hugeHdrComment = ""; /* 8-May-2015 nm */
-  vstring bigHdrComment = ""; /* 8-May-2015 nm */
-  vstring smallHdrComment = ""; /* 8-May-2015 nm */
-  vstring tinyHdrComment = ""; /* 21-Aug-2017 nm */
+  vstring tinyHdr = "";
+  vstring hugeHdrComment = "";
+  vstring bigHdrComment = "";
+  vstring smallHdrComment = "";
+  vstring tinyHdrComment = "";
 
-  /*if (!g_texDefsRead) {*/ /* 17-Nov-2015 nm Now done in readTexDefs() */
   if (2/*error*/ == readTexDefs(0/*errorsOnly=0*/, 0 /*noGifCheck=0*/)) {
     print2(
        "?There was an error in the $t comment's LaTeX/HTML definitions.\n");
@@ -1391,15 +1251,13 @@ void printTexHeader(flag texHeaderFlag)
   /*}*/
 
   g_outputToString = 1;  /* Redirect print2 and printLongLine to g_printString */
-  /*let(&g_printString, "");*/ /* May have stuff to be printed 7/4/98 */
   if (!g_htmlFlag) {
     print2("%s This LaTeX file was created by Metamath on %s %s.\n",
        "%", date(), time_());
 
-    /* 14-Sep-2010 nm Added OLD_TEX (g_oldTexFlag) */
     if (texHeaderFlag && !g_oldTexFlag) {
       print2("\\documentclass{article}\n");
-      print2("\\usepackage{graphicx} %% For rotated iota\n"); /* 29-Nov-2013 nm */
+      print2("\\usepackage{graphicx} %% For rotated iota\n");
       print2("\\usepackage{amssymb}\n");
       print2("\\usepackage{amsmath} %% For \\begin{align}...\n");
       print2("\\usepackage{amsthm}\n");
@@ -1411,100 +1269,56 @@ void printTexHeader(flag texHeaderFlag)
       print2("\\allowdisplaybreaks[1] %% Allow page breaks in {align}\n");
       print2("\\usepackage[plainpages=false,pdfpagelabels]{hyperref}\n");
       print2("\\hypersetup{colorlinks} %% Get rid of boxes around links\n");
-                                                        /* 2-May-2017 */
       print2("\\begin{document}\n");
       print2("\n");
     }
 
     if (texHeaderFlag && g_oldTexFlag) {
-      /******* LaTeX 2.09
-      print2(
-"\\documentstyle[leqno]{article}\n");
-      *******/
       /* LaTeX 2e */
-      print2(
-    "\\documentclass[leqno]{article}\n");
+      print2("\\documentclass[leqno]{article}\n");
       /* LaTeX 2e */
-      print2("\\usepackage{graphicx}\n"); /* 29-Nov-2013 nm For rotated iota */
-      print2(
-    "\\usepackage{amssymb}\n");
-      print2(
-"\\raggedbottom\n");
-      print2(
-"\\raggedright\n");
-      print2(
-"%%\\title{Your title here}\n");
-      print2(
-"%%\\author{Your name here}\n");
-      print2(
-"\\begin{document}\n");
-      /******* LaTeX 2.09
-      print2(
-"\\input amssym.def  %% Load in AMS fonts\n");
-      print2(
-"\\input amssym.tex  %% Load in AMS fonts\n");
-      *******/
-      print2(
-"%%\\maketitle\n");
-      print2(
-"\\newbox\\mlinebox\n");
-      print2(
-"\\newbox\\mtrialbox\n");
-      print2(
-"\\newbox\\startprefix  %% Prefix for first line of a formula\n");
-      print2(
-"\\newbox\\contprefix  %% Prefix for continuation line of a formula\n");
-      print2(
-"\\def\\startm{  %% Initialize formula line\n");
-      print2(
-"  \\setbox\\mlinebox=\\hbox{\\unhcopy\\startprefix}\n");
-      print2(
-"}\n");
-      print2(
-"\\def\\m#1{  %% Add a symbol to the formula\n");
-      print2(
-"  \\setbox\\mtrialbox=\\hbox{\\unhcopy\\mlinebox $\\,#1$}\n");
-      print2(
-"  \\ifdim\\wd\\mtrialbox>\\hsize\n");
-      print2(
-"    \\box\\mlinebox\n");
-      print2(
-"    \\setbox\\mlinebox=\\hbox{\\unhcopy\\contprefix $\\,#1$}\n");
-      print2(
-"  \\else\n");
-      print2(
-"    \\setbox\\mlinebox=\\hbox{\\unhbox\\mtrialbox}\n");
-      print2(
-"  \\fi\n");
-      print2(
-"}\n");
-      print2(
-"\\def\\endm{  %% Output the last line of a formula\n");
-      print2(
-"  \\box\\mlinebox\n");
-      print2(
-"}\n");
+      print2("\\usepackage{graphicx}\n"); /* For rotated iota */
+      print2("\\usepackage{amssymb}\n");
+      print2("\\raggedbottom\n");
+      print2("\\raggedright\n");
+      print2("%%\\title{Your title here}\n");
+      print2("%%\\author{Your name here}\n");
+      print2("\\begin{document}\n");
+      print2("%%\\maketitle\n");
+      print2("\\newbox\\mlinebox\n");
+      print2("\\newbox\\mtrialbox\n");
+      print2("\\newbox\\startprefix  %% Prefix for first line of a formula\n");
+      print2("\\newbox\\contprefix  %% Prefix for continuation line of a formula\n");
+      print2("\\def\\startm{  %% Initialize formula line\n");
+      print2("  \\setbox\\mlinebox=\\hbox{\\unhcopy\\startprefix}\n");
+      print2("}\n");
+      print2("\\def\\m#1{  %% Add a symbol to the formula\n");
+      print2("  \\setbox\\mtrialbox=\\hbox{\\unhcopy\\mlinebox $\\,#1$}\n");
+      print2("  \\ifdim\\wd\\mtrialbox>\\hsize\n");
+      print2("    \\box\\mlinebox\n");
+      print2("    \\setbox\\mlinebox=\\hbox{\\unhcopy\\contprefix $\\,#1$}\n");
+      print2("  \\else\n");
+      print2("    \\setbox\\mlinebox=\\hbox{\\unhbox\\mtrialbox}\n");
+      print2("  \\fi\n");
+      print2("}\n");
+      print2("\\def\\endm{  %% Output the last line of a formula\n");
+      print2("  \\box\\mlinebox\n");
+      print2("}\n");
     }
   } else { /* g_htmlFlag */
 
-    print2(
-        "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n");
+    print2("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n");
     print2(     "    \"http://www.w3.org/TR/html4/loose.dtd\">\n");
     print2("<HTML LANG=\"EN-US\">\n");
     print2("<HEAD>\n");
     print2("%s%s\n", "<META HTTP-EQUIV=\"Content-Type\" ",
         "CONTENT=\"text/html; charset=iso-8859-1\">");
-    /* 13-Aug-2016 nm */
     /* Improve mobile device display per David A. Wheeler */
-    print2(
-"<META NAME=\"viewport\" CONTENT=\"width=device-width, initial-scale=1.0\">\n"
-        );
+    print2("<META NAME=\"viewport\" CONTENT=\"width=device-width, initial-scale=1.0\">\n");
 
     print2("<STYLE TYPE=\"text/css\">\n");
     print2("<!--\n");
-    /* 15-Apr-2015 nm - align math symbol images to text */
-    /* 18-Oct-2015 nm Image alignment fix */
-    /* 10-Jan-2016 nm Optional information but takes unnecessary file space */
+    /* Optional information but takes unnecessary file space */
     /* (change @ to * if uncommenting)
     print2(
         "/@ Math symbol images will be shifted down 4 pixels to align with\n");
@@ -1525,7 +1339,7 @@ void printTexHeader(flag texHeaderFlag)
     /* There is no color */
     print2("   }\n");
 
-    /* nm 3-Feb-04 Experiment to indent web proof displays */
+    /* Indent web proof displays */
     /* Print style sheet for HTML proof indentation number */
     /* ??? Future - combine with above style sheet */
     print2(".i { font-family: \"Arial Narrow\";\n");
@@ -1536,78 +1350,35 @@ void printTexHeader(flag texHeaderFlag)
     print2("</STYLE>\n");
     printLongLine(g_htmlCSS, "", " ");
 
-    /*
-    /@ 12-Jan-2016 nm Per Mario Carneiro's suggestion @/
-    print2(".set { color: red; font-style: italic }\n");
-    print2(".class { color: #C3C; font-style: italic }\n");
-    print2(".wff { color: blue; font-style: italic }\n");
-    /@ .symvar = use symbol as class variable @/
-    print2(".symvar { text-decoration: underline dotted; color: #C3C}\n");
-    print2(".typecode { color: gray }\n");
-    print2(".hidden { color: gray }\n");
-    /@ 10-Jan-2016 nm Experiment to always include a style sheet @/
-    /@   Todo: decide on name and directory for .css's @/
-    print2("<LINK href=\"mmstyle.css\" title=\"mmstyle\"\n");
-    print2("      rel=\"stylesheet\" type=\"text/css\">\n");
-    print2("<LINK href=\"mmstylealt.css\" title=\"mmstylealt\"\n");
-    print2("      rel=\"alternate stylesheet\" type=\"text/css\">\n");
-    */
-
-    /*
-    print2("<META NAME=\"ROBOTS\" CONTENT=\"NONE\">\n");
-    print2("<META NAME=\"GENERATOR\" CONTENT=\"Metamath\">\n");
-    */
-    /*
-    if (g_showStatement < g_extHtmlStmt) {
-      print2("%s\n", cat("<TITLE>", htmlTitle, " - ",
-          / * Strip off ".html" * /
-          left(g_texFileName, (long)strlen(g_texFileName) - 5),
-          / *left(g_texFileName, instr(1, g_texFileName, ".htm") - 1),* /
-          "</TITLE>", NULL));
-    } else {
-      print2("%s\n", cat("<TITLE>", g_extHtmlTitle, " - ",
-          / * Strip off ".html" * /
-          left(g_texFileName, (long)strlen(g_texFileName) - 5),
-          / *left(g_texFileName, instr(1, g_texFileName, ".htm") - 1),* /
-          "</TITLE>", NULL));
-    }
-    */
-    /* 4-Jun-06 nm - Put theorem name before "Metamath Proof Explorer" etc. */
+    /* Put theorem name before "Metamath Proof Explorer" etc. */
     if (g_showStatement < g_extHtmlStmt) {
       print2("%s\n", cat("<TITLE>",
           /* Strip off ".html" */
           left(g_texFileName, (long)strlen(g_texFileName) - 5),
-          /*left(g_texFileName, instr(1, g_texFileName, ".htm") - 1),*/
           " - ", htmlTitle,
           "</TITLE>", NULL));
-    /*} else {*/
-    } else if (g_showStatement < g_mathboxStmt) { /* 29-Jul-2008 nm Sandbox stuff */
+    } else if (g_showStatement < g_mathboxStmt) { /* Sandbox stuff */
       print2("%s\n", cat("<TITLE>",
           /* Strip off ".html" */
           left(g_texFileName, (long)strlen(g_texFileName) - 5),
-          /*left(g_texFileName, instr(1, g_texFileName, ".htm") - 1),*/
           " - ", g_extHtmlTitle,
           "</TITLE>", NULL));
 
-    /* 29-Jul-2008 nm Sandbox stuff */
     } else {
-
-      /* 2-Aug-2009 nm - "Mathbox for <username>" mod */
+      /* "Mathbox for <username>" */
       /* Scan from this statement backwards until a big header is found */
       for (i = g_showStatement; i > g_mathboxStmt; i--) {
         if (g_Statement[i].type == a_ || g_Statement[i].type == p_) {
-                                                            /* 18-Dec-2016 nm */
           /* Note: only bigHdr is used; the other 5 returned strings are
              ignored */
           getSectionHeadings(i, &hugeHdr, &bigHdr, &smallHdr,
               &tinyHdr,
-              /* 5-May-2015 nm */
               &hugeHdrComment, &bigHdrComment, &smallHdrComment,
               &tinyHdrComment,
               0, /* fineResolution */
               0  /* fullComment */);
           if (bigHdr[0] != 0) break;
-        } /* 18-Dec-2016 nm */
+        }
       } /* next i */
       if (bigHdr[0]) {
         /* A big header was found; use it for the page title */
@@ -1625,14 +1396,10 @@ void printTexHeader(flag texHeaderFlag)
       let(&bigHdrComment, "");   /* Deallocate memory */
       let(&smallHdrComment, ""); /* Deallocate memory */
       let(&tinyHdrComment, ""); /* Deallocate memory */
-      /* 2-Aug-2009 nm - end of "Mathbox for <username>" mod */
 
       printLongLine(cat("<TITLE>",
           /* Strip off ".html" */
           left(g_texFileName, (long)strlen(g_texFileName) - 5),
-          /*left(g_texFileName, instr(1, g_texFileName, ".htm") - 1),*/
-          /*" - ", sandboxTitle,*/
-          /* 2-Aug-2009 nm - "Mathbox for <username>" mod */
           " - ", localSandboxTitle,
           "</TITLE>", NULL), "", "\"");
 
@@ -1640,17 +1407,10 @@ void printTexHeader(flag texHeaderFlag)
     /* Icon for bookmark */
     print2("%s%s\n", "<LINK REL=\"shortcut icon\" HREF=\"favicon.ico\" ",
         "TYPE=\"image/x-icon\">");
-    /*
-    print2("<META HTML-EQUIV=\"Keywords\"\n");
-    print2("CONTENT=\"%s\">\n", htmlTitle);
-    */
 
     print2("</HEAD>\n");
-    /*print2("<BODY BGCOLOR=\"#D2FFFF\">\n");*/
-    /*print2("<BODY BGCOLOR=%s>\n", MINT_BACKGROUND_COLOR);*/
     print2("<BODY BGCOLOR=\"#FFFFFF\">\n");
 
-    /* 16-Aug-2016 nm Major revision of header */
     print2("<TABLE BORDER=0 CELLSPACING=0 CELLPADDING=0 WIDTH=\"100%s\">\n",
          "%");
     print2("  <TR>\n");
@@ -1677,7 +1437,6 @@ void printTexHeader(flag texHeaderFlag)
     print2("    </TD>\n");
     print2(
 "    <TD ALIGN=CENTER COLSPAN=2 VALIGN=TOP><FONT SIZE=\"+3\" COLOR=%s><B>\n",
-                              /* Change COLSPAN=1 -> 2 */ /* 27-Dec-2020 nm */
       GREEN_TITLE_COLOR);
     /* Allow plenty of room for long titles (although over 79 chars. will
        trigger bug 1505). */
@@ -1686,57 +1445,6 @@ void printTexHeader(flag texHeaderFlag)
              (g_showStatement < g_mathboxStmt ? g_extHtmlTitle :
              localSandboxTitle)));
     print2("      </B></FONT></TD>\n");
-    /* print2("    </TD>\n"); */ /* 26-Dec-2016 nm Delete extra </TD> */
-
-
-    /*
-    print2("<TABLE BORDER=0 WIDTH=\"100%s\"><TR>\n", "%");
-    print2("<TD ALIGN=LEFT VALIGN=TOP WIDTH=\"25%s\"\n", "%");
-    */
-
-    /*
-    print2("<A HREF=\"mmexplorer.html\">\n");
-    print2("<IMG SRC=\"cowboy.gif\"\n");
-    print2("ALT=\"[Image of cowboy]Home Page\"\n");
-    print2("WIDTH=27 HEIGHT=32 ALIGN=LEFT><FONT SIZE=-1 FACE=sans-serif>Home\n");
-    print2("</FONT></A>");
-    */
-    /*
-    if (g_showStatement < g_extHtmlStmt) {
-      printLongLine(cat("ROWSPAN=2>", g_htmlHome, "</TD>", NULL), "", "\"");
-    /@} else {@/
-    } else if (g_showStatement < g_mathboxStmt) { /@ 29-Jul-2008 nm Sandbox stuff @/
-      printLongLine(cat("ROWSPAN=2>", extHtmlHome, "</TD>", NULL), "", "\"");
-
-    /@ 29-Jul-2008 nm Sandbox stuff @/
-    } else {
-      printLongLine(cat("ROWSPAN=2>", sandboxHome, "</TD>", NULL), "", "\"");
-
-    }
-
-    if (g_showStatement < g_extHtmlStmt) {
-      printLongLine(cat(
-          "<TD ALIGN=CENTER VALIGN=TOP ROWSPAN=2><FONT SIZE=\"+3\" COLOR=",
-          GREEN_TITLE_COLOR, "><B>", htmlTitle, "</B></FONT>", NULL), "", "\"");
-    /@} else {@/
-    } else if (g_showStatement < g_mathboxStmt) { /@ 29-Jul-2008 nm Sandbox stuff @/
-      printLongLine(cat(
-          "<TD ALIGN=CENTER VALIGN=TOP ROWSPAN=2><FONT SIZE=\"+3\" COLOR=",
-          GREEN_TITLE_COLOR, "><B>", g_extHtmlTitle, "</B></FONT>", NULL), "", "\"");
-
-    /@ 29-Jul-2008 nm Sandbox stuff @/
-    } else {
-      printLongLine(cat(
-          "<TD ALIGN=CENTER VALIGN=TOP ROWSPAN=2><FONT SIZE=\"+3\" COLOR=",
-          GREEN_TITLE_COLOR, "><B>",
-          /@sandboxTitle,@/
-          /@ 2-Aug-2009 nm - "Mathbox for <username>" mod @/
-          localSandboxTitle,
-           "</B></FONT>", NULL), "", "\"");
-
-    }
-    */
-
 
     if (texHeaderFlag) {  /* For HTML, 1 means to put prev/next links */
       /* Put Previous/Next links into web page */
@@ -1746,17 +1454,8 @@ void printTexHeader(flag texHeaderFlag)
       j = 0;
       k = 0;
       for (i = g_showStatement - 1; i >= 1; i--) {
-        if ((g_Statement[i].type == (char)p_ ||
-            g_Statement[i].type == (char)a_ )
-            /* Skip dummy "xxx..." statements.  We rely on lazy
-               evaluation to prevent array bound overflow. */
-            /* 16-Aug-2016 nm Took out this obsolete feature */
-            /*
-            && (g_Statement[i].labelName[0] != 'x'
-              || g_Statement[i].labelName[1] != 'x'
-              || g_Statement[i].labelName[2] != 'x')
-            */
-            ) {
+        if (g_Statement[i].type == (char)p_ ||
+            g_Statement[i].type == (char)a_) {
           j = i;
           break;
         }
@@ -1765,17 +1464,8 @@ void printTexHeader(flag texHeaderFlag)
         k = 1; /* First statement flag */
         /* For the first statement, wrap to last one */
         for (i = g_statements; i >= 1; i--) {
-          if ((g_Statement[i].type == (char)p_ ||
-              g_Statement[i].type == (char)a_ )
-              /* Skip dummy "xxx..." statements.  We rely on lazy
-                 evaluation to prevent array bound overflow. */
-              /* 16-Aug-2016 nm Took out this obsolete feature */
-              /*
-              && (g_Statement[i].labelName[0] != 'x'
-                || g_Statement[i].labelName[1] != 'x'
-                || g_Statement[i].labelName[2] != 'x')
-              */
-              ) {
+          if (g_Statement[i].type == (char)p_ ||
+              g_Statement[i].type == (char)a_ ) {
             j = i;
             break;
           }
@@ -1793,17 +1483,8 @@ void printTexHeader(flag texHeaderFlag)
       j = 0;
       k = 0;
       for (i = g_showStatement + 1; i <= g_statements; i++) {
-        if ((g_Statement[i].type == (char)p_ ||
-            g_Statement[i].type == (char)a_ )
-            /* Skip dummy "xxx..." statements.  We rely on lazy
-               evaluation to prevent array bound overflow. */
-            /* 16-Aug-2016 nm Took out this obsolete feature */
-            /*
-            && (g_Statement[i].labelName[0] != 'x'
-              || g_Statement[i].labelName[1] != 'x'
-              || g_Statement[i].labelName[2] != 'x')
-            */
-            ) {
+        if (g_Statement[i].type == (char)p_ ||
+            g_Statement[i].type == (char)a_) {
           j = i;
           break;
         }
@@ -1812,24 +1493,14 @@ void printTexHeader(flag texHeaderFlag)
         k = 1; /* Last statement flag */
         /* For the last statement, wrap to first one */
         for (i = 1; i <= g_statements; i++) {
-          if ((g_Statement[i].type == (char)p_ ||
-              g_Statement[i].type == (char)a_ )
-              /* Skip dummy "xxx..." statements.  We rely on lazy
-                 evaluation to prevent array bound overflow. */
-              /* 16-Aug-2016 nm Took out this obsolete feature */
-              /*
-              && (g_Statement[i].labelName[0] != 'x'
-                || g_Statement[i].labelName[1] != 'x'
-                || g_Statement[i].labelName[2] != 'x')
-              */
-              ) {
+          if (g_Statement[i].type == (char)p_ ||
+              g_Statement[i].type == (char)a_) {
             j = i;
             break;
           }
         }
       }
       if (j == 0) bug(2315);
-      /*print2("<A HREF=\"%s.html\">Next</A></FONT>\n",*/
       if (!k) {
         print2("      <A HREF=\"%s.html\">Next &gt;</A>\n",
             g_Statement[j].labelName);
@@ -1848,32 +1519,14 @@ void printTexHeader(flag texHeaderFlag)
          the same as the THEOREMS_PER_PAGE in WRITE THEOREMS (have a SET
          global variable in place of THEOREMS_PER_PAGE?) */
       i = ((g_Statement[g_showStatement].pinkNumber - 1) / 100) + 1; /* Page # */
-      /* let(&tmpStr, cat("mmtheorems", (i == 1) ? "" : str(i), ".html#", */
       /* 18-Jul-2015 nm - all thm pages now have page num after mmtheorems
          since mmtheorems.html is now just the table of contents */
       let(&tmpStr, cat("mmtheorems", str((double)i), ".html#",
           g_Statement[g_showStatement].labelName, NULL)); /* Link to page/stmt */
-      /*print2("      <BR><A HREF=\"%s\">Nearby theorems</A>\n",
-            tmpStr);*/
-      /* 3-May-2017 nm Break up lines w/ long labels to prevent bug 1505 */
+      /* Break up lines w/ long labels to prevent bug 1505 */
       printLongLine(cat("      <BR><A HREF=\"", tmpStr,
             "\">Nearby theorems</A>", NULL), " ", " ");
 
-      /* Print the GIF/Unicode Font choice, if directories are specified */
-      /*
-      if (htmlDir[0]) {
-
-        if (g_altHtmlFlag) {
-          print2("      <BR><A HREF=\"%s%s\">GIF version</A>\n",
-                htmlDir, g_texFileName);
-
-        } else {
-          print2("      <BR><A HREF=\"%s%s\">Unicode version</A>\n",
-                altHtmlDir, g_texFileName);
-
-        }
-      }
-      */
       print2("      </FONT>\n");
       print2("    </TD>\n");
       print2("  </TR>\n");
@@ -1903,18 +1556,7 @@ void printTexHeader(flag texHeaderFlag)
                               /* Change COLSPAN=1 -> 2 */ /* 27-Dec-2020 nm */
       print2("      <FONT SIZE=-2 FACE=sans-serif>\n");
 
-
-      /**** Deleted 26-Dec-2020 nm
-      /@ 3-Jun-2018 nm Add link to Thierry Arnoux's site @/
-      /@ This was added to version 0.162 to become 0.162-thierry @/
-      /@@@@@@ THIS IS TEMPORARY AND MAY BE CHANGED OR DELETED @@@@@@@@@/
-      printLongLine(cat("      <A HREF=\"",
-          "http://metamath.tirix.org/", g_texFileName,
-          "\">Structured version</A>&nbsp;&nbsp;", NULL), "", " ");
-      /@@@@@@ END OF LINKING TO THIERRY ARNOUX'S SITE @@@@@@@@@@@@/
-      ***** End of 26-Dec-2020 deletion *****/
-
-      /* 26-Dec-2020 nm Add link(s) specified by htmlexturl in $t statement */
+      /* Add link(s) specified by htmlexturl in $t statement */
       /* The position of the theorem name is indicated with "*" in the
          htmlexturl $t variable.  If a literal "*" is part of the URL,
          use the alternate URL encoding "%2A" */
@@ -1935,7 +1577,6 @@ void printTexHeader(flag texHeaderFlag)
             right(tmpStr, i + 1), NULL));
       }
       printLongLine(tmpStr, "", " ");
-      /* End of 26-Dec-2020 mod */
 
       /* Print the GIF/Unicode Font choice, if directories are specified */
       if (htmlDir[0]) {
@@ -1952,8 +1593,7 @@ void printTexHeader(flag texHeaderFlag)
       }
 
     } else { /* texHeaderFlag=0 for HTML means not to put prev/next links */
-      /*print2("      </TD><TD ALIGN=RIGHT VALIGN=TOP\n");*/
-      /* 14-Oct-2019 there is no table open (mmascii, mmdefinitions), so don't
+      /* there is no table open (mmascii, mmdefinitions), so don't
          add </TD> which caused HTML validation failure */
       print2("      <TD ALIGN=RIGHT VALIGN=TOP\n");
       print2("       ><FONT FACE=sans-serif SIZE=-2>\n", "%");
@@ -2005,11 +1645,9 @@ void printTexHeader(flag texHeaderFlag)
 /* Note: the global long "g_showStatement" is referenced to determine whether
    to read bibliography from mmset.html or mmhilbert.html (or other
    g_htmlBibliography or extHtmlBibliography file pair). */
-/* Returns 1 if an error or warning message was printed */ /* 17-Nov-2015 */
+/* Returns 1 if an error or warning message was printed */
 flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
-    /* 17-Nov-2015 nm */
     long actionBits, /* see below */
-        /* 13-Dec-2018 */
         /* Indicators for actionBits:
             #define ERRORS_ONLY 1 - just report errors, don't print output
             #define PROCESS_SYMBOLS 2
@@ -2042,34 +1680,28 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   vstring outputLine = "";
   vstring tmp = "";
   flag textMode, mode, lastLineFlag, displayMode;
-  vstring tmpComment = ""; /* Added 10/10/02 */
-  /* 11/15/02 A comment section with <PRE>...</PRE> is formatted into a
-              monospaced text table */
-  /* 26-Dec-2011 nm - changed <PRE> to more general <HTML> */
-  /*flag preformattedMode = 0; /@ HTML <PRE> preformatted mode @/ */
+  vstring tmpComment = "";
   flag preformattedMode = 0; /* HTML <HTML> preformatted mode */
 
-  /* 10/10/02 For bibliography hyperlinks */
+  /* For bibliography hyperlinks */
   vstring bibTag = "";
   vstring bibFileName = "";
   vstring bibFileContents = "";
   vstring bibFileContentsUpper = ""; /* Uppercase version */
   vstring bibTags = "";
   long pos1, pos2, htmlpos1, htmlpos2, saveScreenWidth;
-  flag tmpMathMode; /* 15-Feb-2014 nm */
+  flag tmpMathMode;
 
   /* Variables for converting ` ` and ~ to old $m,$n and $l,$n formats in
      order to re-use the old code */
   /* Note that DOLLAR_SUBST will replace the old $. */
   vstring cmt = "";
-  vstring cmtMasked = ""; /* cmt with math syms blanked */ /* 20-Aug-2014 nm */
-          /* 20-Oct-2018 - also mask ~ label */
-  vstring tmpMasked = ""; /* tmp with math syms blanked */ /* 20-Aug-2014 nm */
-  vstring tmpStrMasked = ""; /* tmpStr w/ math syms blanked */ /* 20-Aug-2014 */
+  vstring cmtMasked = ""; /* cmt with math syms blanked */ /* also mask ~ label */
+  vstring tmpMasked = ""; /* tmp with math syms blanked */
+  vstring tmpStrMasked = ""; /* tmpStr w/ math syms blanked */
   long i, clen;
-  flag returnVal = 0; /* 1 means error/warning */ /* 17-Nov-2015 nm */
+  flag returnVal = 0; /* 1 means error/warning */
 
-  /* 13-Dec-2018 nm */
   /* Internal flags derived from actionBits argument, for MARKUP command use */
   flag errorsOnly;
   flag processSymbols;
@@ -2093,7 +1725,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   /* We must let this procedure handle switching output to string mode */
   if (g_outputToString) bug(2309);
   /* The LaTeX (or HTML) file must be open */
-  if (errorsOnly == 0) {   /* 17-Nov-2015 nm */
+  if (errorsOnly == 0) {
     if (!g_texFilePtr) bug(2321);
   }
 
@@ -2117,16 +1749,16 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
 
   /* All actions on cmt should be mirrored on cmdMasked, except that
      math symbols are replaced with blanks in cmdMasked */
-  let(&cmtMasked, cmt); /* 20-Aug-2014 nm */
+  let(&cmtMasked, cmt);
 
 
   /* This section is independent and can be removed without side effects */
   if (g_htmlFlag) {
     /* Convert special characters <, &, etc. to HTML entities */
     /* But skip converting math symbols inside ` ` */
-    /* 26-Dec-2011 nm Detect preformatted HTML (this is crude, since it
+    /* Detect preformatted HTML (this is crude, since it
        will apply to whole comment - perhaps fine-tune this later) */
-    if (convertToHtml != 0) { /* 13-Dec-2018 nm */
+    if (convertToHtml != 0) {
       if (instr(1, cmt, "<HTML>") != 0) preformattedMode = 1;
     } else {
       preformattedMode = 1; /* For MARKUP command - don't convert HTML */
@@ -2177,7 +1809,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   }
 
 
-  /* 10/10/02 Add leading and trailing HTML markup to comment here
+  /* Add leading and trailing HTML markup to comment here
      (instead of in caller).  Also convert special characters. */
   if (g_htmlFlag) {
     /* This used to be done in mmcmds.c */
@@ -2191,14 +1823,10 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   }
 
 
-  /* Added Oct-20-2018 nm */
   /* Mask out _ (underscore) in labels so they won't become subscripts
      (reported by Benoit Jubin) */
   /* This section is independent and can be removed without side effects */
-  if (g_htmlFlag != 0
-      /* && processSymbols != 0*/ /* Mode 3 processes symbols only */
-         /* (Actually we should do this all the time; this is the mask) */
-      ) {
+  if (g_htmlFlag != 0) {
     pos1 = 0;
     while (1) {   /* Look for label start */
       pos1 = instr(pos1 + 1, cmtMasked, "~");
@@ -2235,26 +1863,15 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   } /* if g_htmlFlag */
 
 
-  /* 5-Dec-03 Handle dollar signs in comments converted to LaTeX */
+  /* Handle dollar signs in comments converted to LaTeX */
   /* This section is independent and can be removed without side effects */
   /* This must be done before the underscores below so subscript $'s */
   /* won't be converted to \$'s */
   if (!g_htmlFlag) {  /* LaTeX */
-
-    /* MARKUP command doesn't handle LaTeX */
-    /* 25-Jan-2019 nm - this gets set by PROCESS_EVERYTHING in many calls;
-       it's not specific to MARKUP and not a bug. */
-    /* if (metamathComment != 0) bug(2343); */
-
     pos1 = 0;
     while (1) {
       pos1 = instr(pos1 + 1, cmt, "$");
       if (!pos1) break;
-      /*
-      /@ Don't modify anything inside of <PRE>...</PRE> tags @/
-      if (pos1 > instr(1, cmt, "<PRE>") && pos1 < instr(1, cmt, "</PRE>"))
-        continue;
-      */
       /* Don't modify anything inside of <HTML>...</HTML> tags */
       if (pos1 > instr(1, cmt, "<HTML>") && pos1 < instr(1, cmt, "</HTML>"))
         continue;
@@ -2266,8 +1883,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     } /* while (1) */
   }
 
-  /* 15-Feb-2014 nm */
-  /* 1-May-2017 nm - moved this section up to BEFORE the underscore handling
+  /* This section comes BEFORE the underscore handling
      below, so that "{\em...}" won't be converted to "\}\em...\}" */
   /* Convert any remaining special characters for LaTeX */
   /* This section is independent and can be removed without side effects */
@@ -2317,37 +1933,21 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     } /* Next pos1 */
   } /* if (!g_htmlFlag) */
 
-  /* 10-Oct-02 Handle underscores in comments converted to HTML:  Convert _abc_
+  /* Handle underscores in comments converted to HTML:  Convert _abc_
      to <I>abc</I> for book titles, etc.; convert a_n to a<SUB>n</SUB> for
      subscripts */
-  /* 5-Dec-03 Added LaTeX handling */
   /* This section is independent and can be removed without side effects */
-  if (g_htmlFlag != 0     /* 5-Dec-03 */
-      && processUnderscores != 0) {  /* 13-Dec-2018 nm */
+  if (g_htmlFlag != 0 && processUnderscores != 0) {
     pos1 = 0;
     while (1) {
-      /* pos1 = instr(pos1 + 1, cmt, "_"); */
-      /* 20-Aug-2014 nm Only look at non-math part of comment */
+      /* Only look at non-math part of comment */
       pos1 = instr(pos1 + 1, cmtMasked, "_");
       if (!pos1) break;
-      /*
-      /@ Don't modify anything inside of <PRE>...</PRE> tags @/
-      if (pos1 > instr(1, cmt, "<PRE>") && pos1 < instr(1, cmt, "</PRE>"))
-        continue;
-      */
       /* Don't modify anything inside of <HTML>...</HTML> tags */
       if (pos1 > instr(1, cmt, "<HTML>") && pos1 < instr(1, cmt, "</HTML>"))
         continue;
-      /* 23-Jul-2006 nm Don't modify anything inside of math symbol strings
-         (imperfect - only works if `...` is not split across lines) */
-      /* 20-Aug-2014 nm No longer necessary since we now use cmtMasked */
-      /*
-      if (pos1 > instr(1, cmt, "`") && pos1 < instr(instr(1, cmt, "`") + 1,
-          cmt, "`"))
-        continue;
-      */
 
-      /* 5-Apr-2007 nm Don't modify external hyperlinks containing "_" */
+      /* Don't modify external hyperlinks containing "_" */
       pos2 = pos1 - 1;
       while (1) { /* Get to previous whitespace */
         if (pos2 == 0 || isspace((unsigned char)(cmt[pos2]))) break;
@@ -2356,11 +1956,9 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       if (!strcmp(mid(cmt, pos2 + 2, 7), "http://")) {
         continue;
       }
-      /* 20-Aug-2014 nm Add https */
       if (!strcmp(mid(cmt, pos2 + 2, 8), "https://")) {
         continue;
       }
-      /* 20-Oct-2018 nm Add mm */
       if (!strcmp(mid(cmt, pos2 + 2, 2), "mm")) {
         continue;
       }
@@ -2374,7 +1972,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           if (!isspace((unsigned char)(cmt[pos1]))
             && strchr(CLOSING_PUNCTUATION, cmt[pos1]) == NULL) {
 
-            /* 28-Sep-03 - Added subscript handling */
             /* Found <nonwhitespace>_<nonwhitespace> - assume subscript */
             /* Locate the whitepace (or end of string) that closes subscript */
             /* Note:  This algorithm is not perfect in that the subscript
@@ -2413,7 +2010,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
               pos1 = pos2 + 4; /* Adjust for 5-1 extra chars in "let" above */
             }
             continue;
-            /* 23-Sep-03 - End of subscript handling */
 
           } else {
             /* Found <nonwhitespace>_<whitespace> - not an opening "_" */
@@ -2423,8 +2019,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         }
       }
       if (!isalnum((unsigned char)(cmt[pos1]))) continue;
-      /* pos2 = instr(pos1 + 1, cmt, "_"); */
-      /* 20-Aug-2014 nm Only look at non-math part of comment */
+      /* Only look at non-math part of comment */
       pos2 = instr(pos1 + 1, cmtMasked, "_");
       if (!pos2) break;
       /* Closing "_" must be <alphanum>_<nonalphanum> */
@@ -2450,7 +2045,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     }
   }
 
-  /* 1-May-2017 nm */
   /* Convert opening double quote to `` for LaTeX */
   /* This section is independent and can be removed without side effects */
   if (!g_htmlFlag) { /* If LaTeX mode */
@@ -2473,27 +2067,23 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     }
   }
 
-  /* 10/10/02 Put bibliography hyperlinks in comments converted to HTML:
+  /* Put bibliography hyperlinks in comments converted to HTML:
         [Monk2] becomes <A HREF="mmset.html#monk2>[Monk2]</A> etc. */
   /* This section is independent and can be removed without side effects */
-  if (g_htmlFlag
-      && processBibrefs != 0 /* 13-Dec-2018 nm */
-      ) {
+  if (g_htmlFlag && processBibrefs != 0) {
     /* Assign local tag list and local HTML file name */
     if (g_showStatement < g_extHtmlStmt) {
       let(&bibTags, g_htmlBibliographyTags);
       let(&bibFileName, g_htmlBibliography);
-    /*} else {*/
-    } else if (g_showStatement < g_mathboxStmt) { /* 29-Jul-2008 nm Sandbox stuff */
+    } else if (g_showStatement < g_mathboxStmt) { /* Sandbox stuff */
       let(&bibTags, extHtmlBibliographyTags);
       let(&bibFileName, extHtmlBibliography);
-
-    /* 29-Jul-2008 nm Sandbox stuff */
     } else {
+      /* Sandbox stuff */
       let(&bibTags, g_htmlBibliographyTags);  /* Go back to Mm Prf Explorer */
       let(&bibFileName, g_htmlBibliography);
-
     }
+
     if (bibFileName[0]) {
       /* The user specified a bibliography file in the xxx.mm $t comment
          (otherwise we don't do anything) */
@@ -2501,8 +2091,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       while (1) {
         /* Look for any bibliography tags to convert to hyperlinks */
         /* The biblio tag should be in brackets e.g. "[Monk2]" */
-        /* pos1 = instr(pos1 + 1, cmt, "["); */
-        /* 20-Aug-2014 nm Only look at non-math part of comment */
+        /* Only look at non-math part of comment */
         pos1 = instr(pos1 + 1, cmtMasked, "[");
         if (!pos1) break; /* 3-Feb-2019 nm Moved this to before block below */
 
@@ -2518,27 +2107,11 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           continue;
         }
 
-        /* pos2 = instr(pos1 + 1, cmt, "]"); */
-        /* 20-Aug-2014 nm Only look at non-math part of comment */
+        /* Only look at non-math part of comment */
         pos2 = instr(pos1 + 1, cmtMasked, "]");
         if (!pos2) break;
 
-        /* 30-Jun-2011 nm */
-        /* See if we are in math mode */
-        /* clen = (long)strlen(cmt); */ /* 18-Sep-2013 never used */
-        /* 20-Aug-2014 nm Deleted since cmtMasked takes care of it */
-        /*
-        mode = 0; /@ 0 = normal, 1 = math @/
-        for (i = 0; i < pos1; i++) {
-          if (cmt[i] == '`' && cmt[i + 1] != '`') {
-            mode = (char)(1 - mode);
-          }
-        }
-        if (mode) continue; /@ Don't process [...] brackets in math mode @/
-        */
-
-        /* let(&bibTag, seg(cmt, pos1, pos2)); */
-        /* 20-Aug-2014 nm Get bibTag from cmtMasked as extra precaution */
+        /* Get bibTag from cmtMasked as extra precaution */
         let(&bibTag, seg(cmtMasked, pos1, pos2));
         /* There should be no white space in the tag */
         if ((signed)(strcspn(bibTag, " \n\r\t\f")) < pos2 - pos1 + 1) continue;
@@ -2546,16 +2119,16 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
            read in yet, let's do so here for error-checking. */
 
         /* Start of error-checking */
-        if (noFileCheck == 0) {  /* 17-Nov-2015 nm */
+        if (noFileCheck == 0) {
           if (!bibTags[0]) {
             /* The bibliography file has not be read in yet. */
             let(&bibFileContents, "");
-            if (errorsOnly == 0) { /* 17-Nov-2015 nm */
+            if (errorsOnly == 0) {
               print2("Reading HTML bibliographic tags from file \"%s\"...\n",
                   bibFileName);
             }
             bibFileContents = readFileToString(bibFileName, 0,
-                &i /* charCount; not used here */); /* 31-Dec-2017 nm */
+                &i /* charCount; not used here */);
             if (!bibFileContents) {
               /* The file was not found or had some problem (use verbose mode = 1
                  in 2nd argument of readFileToString for debugging). */
@@ -2566,7 +2139,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                   "\" in the comment for statement \"",
                   g_Statement[g_showStatement].labelName, "\".",
                   NULL), "", " ");
-              returnVal = 1; /* Error/warning printed */ /* 17-Nov-2015 nm */
+              returnVal = 1; /* Error/warning printed */
               bibFileContents = ""; /* Restore to normal string */
               let(&bibTags, "?"); /* Assign to a nonsense tag that won't match
                   but tells us an attempt was already made to read the file */
@@ -2602,7 +2175,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                       " bibliographic reference \"",
                       seg(bibFileContents, htmlpos1, htmlpos2),
                       "\" in the file \"", bibFileName, "\".", NULL), "", " ");
-                  returnVal = 1; /* Error/warning printed */ /* 17-Nov-2015 nm */
+                  returnVal = 1; /* Error/warning printed */
                 }
                 /* Add tag to tag list */
                 let(&bibTags, cat(bibTags, tmp, NULL));
@@ -2618,10 +2191,8 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
             let(&g_htmlBibliographyTags, bibTags);
           /*} else {*/
           } else if (g_showStatement < g_mathboxStmt) {
-                                             /* 29-Jul-2008 nm Sandbox stuff */
             let(&extHtmlBibliographyTags, bibTags);
 
-          /* 29-Jul-2008 nm Sandbox stuff */
           } else {
             let(&g_htmlBibliographyTags, bibTags);
 
@@ -2638,7 +2209,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                 seg(bibTag, 2, pos2 - pos1),
                 "\"></A> anchor in the file \"", bibFileName, "\".", NULL),
                 "", " ");
-            returnVal = 1; /* Error/warning printed */ /* 17-Nov-2015 nm */
+            returnVal = 1; /* Error/warning printed */
           }
         }
         /* End of error-checking */
@@ -2655,7 +2226,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       } /* end while(1) */
     } /* end if (bibFileName[0]) */
   } /* end of if (g_htmlFlag) */
-  /* 10/10/02 End of bibliography hyperlinks */
 
   /* All actions on cmt should be mirrored on cmdMasked, except that
      math symbols are replaced with blanks in cmdMasked */
@@ -2669,13 +2239,13 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   for (i = 0; i < clen; i++) {
     if (cmt[i] == '`') {
       if (cmt[i + 1] == '`') {
-        if (processSymbols != 0) { /* 13-Dec-2018 nm */
+        if (processSymbols != 0) {
           /* Escaped ` = actual ` */
           let(&cmt, cat(left(cmt, i + 1), right(cmt, i + 3), NULL));
           clen--;
         }
       } else {
-        /* 13-Dec-2018 nm We will still enter and exit math mode when
+        /* We will still enter and exit math mode when
            processSymbols=0 so as to skip ~ in math symbols.  However,
            we don't insert the "DOLLAR_SUBST mode" so that later on
            it will look like normal text */
@@ -2686,19 +2256,16 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           mode = 'n';
         }
 
-        if (processSymbols != 0) {  /* 13-Dec-2018 nm */
+        if (processSymbols != 0) {
           let(&cmt, cat(left(cmt, i), chr(DOLLAR_SUBST) /*$*/, chr(mode),
               right(cmt, i+2), NULL));
           clen++;
           i++;
         }
 
-        /* 10/10/02 */
         /* If symbol is preceded by opening punctuation and a space, take out
            the space so it looks better. */
-        if (mode == 'm'
-            && processSymbols != 0 /* 13-Dec-2018 nm */
-            ) {
+        if (mode == 'm' && processSymbols != 0) {
           let(&tmp, mid(cmt, i - 2, 2));
           if (!strcmp("( ", tmp)) {
             let(&cmt, cat(left(cmt, i - 2), right(cmt, i), NULL));
@@ -2715,9 +2282,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         }
         /* If symbol is followed by a space and closing punctuation, take out
            the space so it looks better. */
-        if (mode == 'n'
-            && processSymbols != 0 /* 13-Dec-2018 nm */
-            ) {
+        if (mode == 'n' && processSymbols != 0) {
           /* (Why must it be i + 2 here but i + 1 in label version below?
              Didn't investigate but seems strange.) */
           let(&tmp, mid(cmt, i + 2, 2));
@@ -2740,10 +2305,8 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       }
     }
     if (cmt[i] == '~' && mode != 'm') {
-      if (cmt[i + 1] == '~' /* Escaped ~ */
-          || processLabels == 0 /* 13-Dec-2018 nm */
-          ) {
-        if (processLabels != 0) {  /* 13-Dec-2018 nm */
+      if (cmt[i + 1] == '~' /* Escaped ~ */ || processLabels == 0) {
+        if (processLabels != 0) {
           /* Escaped ~ = actual ~ */
           let(&cmt, cat(left(cmt, i + 1), right(cmt, i + 3), NULL));
           clen--;
@@ -2752,7 +2315,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         /* Enter or exit label mode */
         if (mode != 'l') {
           mode = 'l';
-          /* 9/5/99 - If there is whitespace after the ~, then remove
+          /* If there is whitespace after the ~, then remove
              all whitespace immediately after the ~ to join the ~ to
              the label.  This enhances the Metamath syntax so that
              whitespace is now allowed between the ~ and the label, which
@@ -2763,23 +2326,18 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
             clen--;
           }
         } else {
-          /* This really should never happen */
-          /* 1-Oct-04 If you see this bug, the most likely cause is a tilde
+          /* If you see this bug, the most likely cause is a tilde
              character in a comment that does not prefix a label or hyperlink.
              The most common problem is the "~" inside a hyperlink that
              specifies a user's directory.  To fix it, use a double tilde
-             "~~" to escape it, which will become a single tilde on output.
-             (At some future point this bug should be converted to a
-             meaningful error message that doesn't abort the program.) */
-          /* bug(2310); */
-          /* 2-Oct-2015 nm Changed to error message */
+             "~~" to escape it, which will become a single tilde on output. */
           g_outputToString = 0;
           printLongLine(cat("?Warning: There is a \"~\" inside of a label",
               " in the comment of statement \"",
               g_Statement[g_showStatement].labelName,
               "\".  Use \"~~\" to escape \"~\" in an http reference.",
               NULL), "", " ");
-          returnVal = 1; /* Error/warning printed */ /* 17-Nov-2015 nm */
+          returnVal = 1; /* Error/warning printed */
           g_outputToString = 1;
           mode = 'n';
         }
@@ -2788,7 +2346,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         clen++;
         i++;
 
-        /* 10/10/02 */
         /* If label is preceded by opening punctuation and space, take out
            the space so it looks better. */
         let(&tmp, mid(cmt, i - 2, 2));
@@ -2804,11 +2361,11 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
 
     if (processLabels == 0 && mode == 'l') {
       /* We should have prevented it from ever getting into label mode */
-      bug(2344); /* 13-Dec-2018 nm */
+      bug(2344);
     }
 
     if ((isspace((unsigned char)(cmt[i]))
-            || cmt[i] == '<') /* 17-Nov-2012 nm If the label ends the comment,
+            || cmt[i] == '<') /* If the label ends the comment,
                "</TD>" with no space will be appended before this section. */
         && mode == 'l') {
       /* Whitespace exits label mode */
@@ -2818,7 +2375,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       clen = clen + 2;
       i = i + 2;
 
-      /* 10/10/02 */
       /* If label is followed by space and end punctuation, take out the space
          so it looks better. */
       let(&tmp, mid(cmt, i + 1, 2));
@@ -2837,7 +2393,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   /* End convert line to the old $m..$n and $l..$n */
 
 
-  /* 29-May-2017 nm */
   /* Put <HTML> and </HTML> at beginning of line so preformattedMode won't
      be switched on or off in the middle of processing a line */
   /* This also fixes the problem where multiple <HTML>...</HTML> on one
@@ -2849,7 +2404,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     pos1 = instr(pos1 + 2/*skip new \n*/, cmt, "<HTML>");
     if (pos1 == 0
       || convertToHtml == 0 /* Don't touch <HTML> in MARKUP command */
-                                 /* 13-Dec-2018 nm */
       ) break;
 
     /* If <HTML> begins a line (after stripping spaces), don't put a \n so
@@ -2866,7 +2420,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     pos1 = instr(pos1 + 2/*skip new \n*/, cmt, "</HTML>");
     if (pos1 == 0
       || convertToHtml == 0 /* Don't touch </HTML> in MARKUP command */
-                                 /* 13-Dec-2018 nm */
       ) break;
 
     /* If </HTML> begins a line (after stripping spaces), don't put a \n so
@@ -2883,7 +2436,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   cmtptr = cmt; /* cmtptr is for scanning cmt */
 
   g_outputToString = 1; /* Redirect print2 and printLongLine to g_printString */
-  /*let(&g_printString, "");*/ /* May have stuff to be printed 7/4/98 */
 
   while (1) {
     /* Get a "line" of text, up to the next new-line.  New-lines embedded
@@ -2899,7 +2451,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       }
       if (cmtptr[0] == '\n' && textMode) break;
       /* if (cmtptr[0] == '$') { */
-      if (cmtptr[0] == DOLLAR_SUBST) {  /* 14-Feb-2014 nm */
+      if (cmtptr[0] == DOLLAR_SUBST) {
         if (cmtptr[1] == ')') {
           bug(2312); /* Obsolete (should never happen) */
           lastLineFlag = 1;
@@ -2929,9 +2481,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     if (mode == 'm') {
       modeSection = getCommentModeSection(&srcptr, &mode);
       let(&modeSection, ""); /* Deallocate */
-      /* 9/9/99  displayMode is obsolete.  Because it depends on a manual
-         user edit, by default it will create a LaTeX error. Turn it off. */
-      /*if (mode == 0) displayMode = 1;*/ /* No text after math mode text */
     }
     let(&tmpStr, ""); /* Deallocate */
 
@@ -2949,7 +2498,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           break;
         case 'l': /* Label mode */
 
-          if (processLabels == 0) { /* 13-Dec-2018 nm */
+          if (processLabels == 0) {
             /* Labels should be treated as normal text */
             bug(2345);
           }
@@ -2958,10 +2507,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                       leading and trailing blanks; reduce spaces to one space */
           let(&tmpStr, "");
           tmpStr = asciiToTt(modeSection);
-          if (!tmpStr[0]) { /* Can't be blank */
-            /* bug(2313); */ /* 2-Oct-2015 nm Commented out */
-
-            /* 2-Oct-2015 nm */
+          if (!tmpStr[0]) {
             /* This can happen if ~ is followed by ` (start of math string) */
             g_outputToString = 0;
             printLongLine(cat("?Error: There is a \"~\" with no label",
@@ -2975,32 +2521,13 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
 
           }
 
-          /* 10/10/02 - obsolete */
-          /* 9/5/99 - Make sure the label in a comment corresponds to a real
-             statement so we won't have broken HTML links (or misleading
-             LaTeX information) - since label references in comments are
-             rare, we just do a linear scan instead of binary search */
-          /******* 10/10/02
-          for (i = 1; i <= g_statements; i++) {
-            if (!strcmp(g_Statement[i].labelName, tmpStr)) break;
-          }
-          if (i > g_statements) {
-            g_outputToString = 0;
-            printLongLine(cat("?Error: Statement \"", tmpStr,
-               "\" (referenced in comment) does not exist.", NULL), "", " ");
-            g_outputToString = 1;
-            returnVal = 1;
-          }
-          *******/
-
           if (!strcmp("http://", left(tmpStr, 7))
-              || !strcmp("https://", left(tmpStr, 8)) /* 20-Aug-2014 nm */
-              || !strcmp("mm", left(tmpStr, 2)) /* 20-Oct-2018 nm */
-              ) {
-            /* 4/13/04 nm - If the "label" begins with 'http://', then
+              || !strcmp("https://", left(tmpStr, 8))
+              || !strcmp("mm", left(tmpStr, 2))) {
+            /* If the "label" begins with 'http://', then
                assume it is an external hyperlink and not a real label.
                This is kind of a syntax kludge but it is easy to do.
-               20-Oct-2018 nm - Added starting with 'mm', which is illegal
+               Added starting with 'mm', which is illegal
                for set.mm labels - e.g. mmtheorems.html#abc */
 
             if (g_htmlFlag) {
@@ -3008,7 +2535,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                   "\">", tmpStr, "</A>", tmp, NULL));
             } else {
 
-              /* 1-May-2017 nm */
               /* Generate LaTeX version of the URL */
               i = instr(1, tmpStr, "\\char`\\~");
               /* The url{} function automatically converts ~ to LaTeX */
@@ -3021,7 +2547,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
 
             }
           } else {
-            /* 10/10/02 Do binary search through just $a's and $p's (there
+            /* Do binary search through just $a's and $p's (there
                are no html pages for local labels) */
             i = lookupLabel(tmpStr);
             if (i < 0) {
@@ -3031,7 +2557,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                   g_Statement[g_showStatement].labelName,
                   "\") is not a $a or $p statement label.", NULL), "", " ");
               g_outputToString = 1;
-              returnVal = 1; /* Error/warning printed */ /* 17-Nov-2015 nm */
+              returnVal = 1; /* Error/warning printed */
             }
 
             if (!g_htmlFlag) {
@@ -3039,7 +2565,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                  "}", NULL));
             } else {
               let(&tmp, "");
-              if (addColoredLabelNumber != 0) { /* 13-Dec-2018 nm */
+              if (addColoredLabelNumber != 0) {
                 /* When the error above occurs, i < 0 will cause pinkHTML()
                    to issue "(future)" for pleasant readability */
                 tmp = pinkHTML(i);
@@ -3059,7 +2585,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           break;
         case 'm': /* Math mode */
 
-          if (processSymbols == 0) { /* 13-Dec-2018 nm */
+          if (processSymbols == 0) {
             /* Math symbols should be treated as normal text */
             bug(2346);
           }
@@ -3084,9 +2610,8 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
             /* Enclose math symbols in a span to be used for font selection */
             let(&tmpStr, cat(
                 (g_altHtmlFlag ? cat("<SPAN ", g_htmlFont, ">", NULL) : ""),
-                                               /* 14-Jan-2016 nm */
                 tmpStr,
-                (g_altHtmlFlag ? "</SPAN>" : ""),    /* 14-Jan-2016 nm */
+                (g_altHtmlFlag ? "</SPAN>" : ""),
                 NULL));
             let(&outputLine, cat(outputLine, tmpStr, NULL)); /* html */
           }
@@ -3101,7 +2626,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       /* Change blank lines into paragraph breaks except in <HTML> mode */
       if (!outputLine[0]) { /* Blank line */
         if (preformattedMode == 0
-            && convertToHtml == 1 /* Not MARKUP command */ /* 13-Dec-2018 nm */
+            && convertToHtml == 1 /* Not MARKUP command */
             ) {  /* Make it a paragraph break */
           let(&outputLine,
               /* "<P>"); */
@@ -3109,41 +2634,22 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
               "<P STYLE=\"margin-bottom:0em\">");
         }
       }
-      /* 11/15/02 If a statement comment has a section embedded in
-         <PRE>...</PRE>, we make it a table with monospaced text and a
-         background color */
-      /* pos1 = instr(1, outputLine, "<PRE>"); */
-      /* 26-Dec-2011 nm - changed <PRE> to more general <HTML> */
+      /* If a statement comment has a section embedded in
+         <HTML>...</HTML>, we keep the contents verbatim */
       pos1 = instr(1, outputLine, "<HTML>");
-      if (pos1 != 0
-          && convertToHtml == 1 /* 13-Dec-2018 nm */
-          ) {
-        /* 26-Dec-2011 nm - The line below is probably redundant since we
+      if (pos1 != 0 && convertToHtml == 1) {
+        /* The line below is probably redundant since we
            set preformattedMode ealier.  Maybe add a bug check to make sure
            it is 1 here. */
         preformattedMode = 1; /* So we don't put <P> for blank lines */
-        /* 26-Dec-2011 nm - Took out fancy table for simplicity
-        let(&outputLine, cat(left(outputLine, pos1 - 1),
-            "<P><CENTER><TABLE BORDER=0 CELLSPACING=0 CELLPADDING=10 BGCOLOR=",
-            /@ MINT_BACKGROUND_COLOR, @/
-            "\"#F0F0F0\"", /@ Very light gray @/
-            "><TR><TD ALIGN=LEFT>", right(outputLine, pos1), NULL));
-        */
-        /* 26-Dec-2011 nm - Strip out the "<HTML>" string */
+        /* Strip out the "<HTML>" string */
         let(&outputLine, cat(left(outputLine, pos1 - 1),
             right(outputLine, pos1 + 6), NULL));
       }
-      /* pos1 = instr(1, outputLine, "</PRE>"); */
       pos1 = instr(1, outputLine, "</HTML>");
-      if (pos1 != 0
-          && convertToHtml == 1 /* 13-Dec-2018 nm */
-          ) {
+      if (pos1 != 0 && convertToHtml == 1) {
         preformattedMode = 0;
-        /* 26-Dec-2011 nm - Took out fancy table for simplicity
-        let(&outputLine, cat(left(outputLine, pos1 + 5),
-            "</TD></TR></TABLE></CENTER>", right(outputLine, pos1 + 6), NULL));
-        */
-        /* 26-Dec-2011 nm - Strip out the "</HTML>" string */
+        /* Strip out the "</HTML>" string */
         let(&outputLine, cat(left(outputLine, pos1 - 1),
             right(outputLine, pos1 + 7), NULL));
       }
@@ -3151,7 +2657,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
 
     if (!g_htmlFlag) { /* LaTeX */
       /* Convert <PRE>...</PRE> HTML tags to LaTeX */
-      /* 26-Dec-2011 nm - leave this in for now */
+      /* leave this in for now */
       while (1) {
         pos1 = instr(1, outputLine, "<PRE>");
         if (pos1) {
@@ -3170,7 +2676,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           break;
         }
       }
-      /* 26-Dec-2011 nm - strip out <HTML>, </HTML> */
+      /* strip out <HTML>, </HTML> */
       /* The HTML part may screw up LaTeX; maybe we should just take out
          any HTML code completely in the future? */
       while (1) {
@@ -3194,10 +2700,8 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     }
 
     saveScreenWidth = g_screenWidth;
-    /* 26-Dec-2011 nm - in <PRE> mode, we don't want to wrap the HTML
-       output with spurious newlines */
-    /*if (preformattedMode) g_screenWidth = PRINTBUFFERSIZE - 2;*/
-    /* 19-Jun-2010 nm PRINTBUFFERSIZE was removed.  Any large value will
+    /* in <PRE> mode, we don't want to wrap the HTML
+       output with spurious newlines. Any large value will
        do; we just need to accomodate the worst case line length that will
        result from converting ~ label, [author], ` math ` to HTML */
     if (preformattedMode) g_screenWidth = 50000;
@@ -3212,17 +2716,15 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   } /* end while(1) */
 
   if (g_htmlFlag) {
-    if (convertToHtml != 0) { /* Not MARKUP command */ /* 13-Dec-2018 nm */
+    if (convertToHtml != 0) { /* Not MARKUP command */
       print2("\n"); /* Don't change what the previous code did */
     } else {
-      /* 13-Dec-2018 nm */
       /* Add newline if string is not empty and has no newline at end */
       if (g_printString[0] != 0) {
         i = (long)strlen(g_printString);
         if (g_printString[i - 1] != '\n')  {
           print2("\n");
         } else {
-          /* 13-Dec-2018 nm */
           /* There is an extra \n added by something previous.  Until
              we figure out what, take it off so that MARKUP output will
              equal input when no processing qualifiers are used. */
@@ -3236,7 +2738,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     }
   } else { /* LaTeX mode */
     if (!g_oldTexFlag) {
-      /* 14-Sep-2010 nm Suppress blank line for LaTeX */
+      /* Suppress blank line for LaTeX */
       /* print2("\n"); */
     } else {
       print2("\n");
@@ -3244,7 +2746,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   }
 
   g_outputToString = 0; /* Restore normal output */
-  if (errorsOnly == 0) { /* 17-Nov-2015 nm */
+  if (errorsOnly == 0) {
     fprintf(g_texFilePtr, "%s", g_printString);
   }
 

--- a/mmwtex.h
+++ b/mmwtex.h
@@ -15,13 +15,9 @@
 #define MINT_BACKGROUND_COLOR "\"#EEFFFA\""
 #define PINK_NUMBER_COLOR "\"#FA8072\""      /* =salmon; was FF6666 */
 #define PURPLISH_BIBLIO_COLOR "\"#FAEEFF\""
-
-
-/* 29-Jul-2008 nm Sandbox stuff */
 #define SANDBOX_COLOR "\"#FFFFD9\""
 
 /* TeX flags */
-/* 14-Sep-2010 nm Removed simpleTexFlag; added g_oldTexFlag */
 extern flag g_oldTexFlag; /* Use macros in output; obsolete; take out someday */
 
 /* HTML flags */
@@ -38,14 +34,11 @@ extern long g_extHtmlStmt; /* At this statement and above, use the exthtmlxxx
 extern vstring g_extHtmlTitle; /* Title of extended section if any; set by
     by exthtmltitle command in special $t comment of database source */
 extern vstring g_htmlVarColor; /* Set by htmlvarcolor commands */
-/* Added 26-Aug-2017 nm for use by mmcmds.c */
 extern vstring g_htmlHome; /* Set by htmlhome command */
-/* Added 10/13/02 for use in metamath.c bibliography cross-reference */
 extern vstring g_htmlBibliography; /* Optional; set by htmlbibliography command */
 extern vstring g_extHtmlBibliography; /* Optional; set by exthtmlbibliography
                                        command */
-extern vstring g_htmlCSS; /* Set by htmlcss commands */  /* 14-Jan-2016 nm */
-/* Added 14-Jan-2016 */
+extern vstring g_htmlCSS; /* Set by htmlcss commands */
 extern vstring g_htmlFont; /* Optional; set by g_htmlFont command */
 
 void eraseTexDefs(void); /* Undo readTexDefs() */
@@ -58,11 +51,11 @@ flag readTexDefs(
   flag noGifCheck   /* 1 = don't check for missing GIFs */);
 
 extern flag g_texDefsRead;
-struct texDef_struct {  /* 27-Oct-2012 nm Made global for "erase" */
+struct texDef_struct {  /* for "erase" */
   vstring tokenName; /* ASCII token */
   vstring texEquiv; /* Converted to TeX */
 };
-extern struct texDef_struct *g_TexDefs; /* 27-Oct-2012 nm Now glob for "erase" */
+extern struct texDef_struct *g_TexDefs; /* for "erase" */
 
 
 long texDefWhiteSpaceLen(char *ptr);
@@ -91,7 +84,7 @@ void printTexHeader(flag texHeaderFlag);
    allocation.  htmlCenterFlag, if 1, means to center the HTML and add a
    "Description:" prefix.*/
 /* void printTexComment(vstring commentPtr, char htmlCenterFlag); */
-/* 17-Nov-2015 nm Added 3rd & 4th arguments; returns 1 if error/warning */
+/* returns 1 if error/warning */
 flag printTexComment(vstring commentPtr,    /* Sends result to g_texFilePtr */
     flag htmlCenterFlag, /* 1 = htmlCenterFlag */
     long actionBits, /* see indicators below */
@@ -116,8 +109,7 @@ void printTexLongMath(nmbrString *proofStep, vstring startPrefix,
     vstring contPrefix, long hypStmt, long indentationLevel);
 void printTexTrailer(flag texHeaderFlag);
 
-/* Added 4-Dec-03
-   Function implementing WRITE THEOREM_LIST / THEOREMS_PER_PAGE nn */
+/* Function implementing WRITE THEOREM_LIST / THEOREMS_PER_PAGE nn */
 void writeTheoremList(long theoremsPerPage, flag showLemmas,
     flag noVersioning);
 
@@ -126,48 +118,27 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas,
 #define SMALL_DECORATION "=-=-"
 #define TINY_DECORATION "-.-."
 
-/* 2-Aug-2009 nm - broke this function out from writeTheoremList() */
-/* 20-Jun-2014 nm - added hugeHdrAddr */
-/* 21-Aug-2017 nm - added tinyHdrAddr */
-/* 6-Aug-2019 nm - changed return type from void to flag (=char) */
-/* 24-Aug-2020 nm - added fineResolution */
-/* 12-Sep-2020 nm - added fullComment */
 flag getSectionHeadings(long stmt, vstring *hugeHdrTitle,
     vstring *bigHdrTitle,
     vstring *smallHdrTitle,
     vstring *tinyHdrTitle,
-    /* Added 8-May-2015 nm */
     vstring *hugeHdrComment,
     vstring *bigHdrComment,
     vstring *smallHdrComment,
     vstring *tinyHdrComment,
-    /* Added 24-Aug-2020 nm */
     flag fineResolution, /* 0 = consider just successive $a/$p, 1 = all stmts */
     flag fullComment /* 1 = put $( + header + comment + $) into xxxHdrTitle */
     );
-
-/****** 15-Aug-2020 nm Obsolete
-/@ TeX symbol dictionary @/
-extern FILE @g_tex_dict_fp;     /@ File pointers @/
-extern vstring g_tex_dict_fn;   /@ File names @/
-******/
 
 /* TeX normal output */
 extern flag g_texFileOpenFlag;
 extern FILE *g_texFilePtr;
 
-/* Pink statement number for HTML pages */
-/* 10/10/02 (This is no longer used?) */
-/*
-long pinkNumber(long statemNum);
-*/
-
-/* Pink statement number HTML code for HTML pages - added 10/10/02 */
+/* Pink statement number HTML code for HTML pages */
 /* Warning: caller must deallocate returned string */
 vstring pinkHTML(long statemNum);
 
-/* Pink statement number range HTML code for HTML pages, separated by a
-   "-" - added 24-Aug-04 */
+/* Pink statement number range HTML code for HTML pages, separated by a "-" */
 /* Warning: caller must deallocate returned string */
 vstring pinkRangeHTML(long statemNum1, long statemNum2);
 
@@ -177,26 +148,20 @@ vstring pinkRangeHTML(long statemNum1, long statemNum2);
 /* This function converts a "spectrum" color (1 to maxColor) to an
    RBG value in hex notation for HTML.  The caller must deallocate the
    returned vstring.  color = 1 (red) to maxColor (violet). */
-/* ndm 10-Jan-04 */
 vstring spectrumToRGB(long color, long maxColor);
 
-/* Added 20-Sep-03 (broken out of printTexLongMath() for better
-   modularization) */
 /* Returns the HTML code for GIFs (!g_altHtmlFlag) or Unicode (g_altHtmlFlag),
    or LaTeX when !g_htmlFlag, for the math string (hypothesis or conclusion) that
    is passed in. */
 /* Warning: The caller must deallocate the returned vstring. */
 vstring getTexLongMath(nmbrString *mathString, long statemNum);
 
-/* Added 18-Sep-03 (transferred from metamath.c) */
 /* Returns the TeX, or HTML code for GIFs (!g_altHtmlFlag) or Unicode
    (g_altHtmlFlag), for a statement's hypotheses and assertion in the form
    hyp & ... & hyp => assertion */
 /* Warning: The caller must deallocate the returned vstring. */
-/* 14-Sep-2010 nm Changed name from getHTMLHypAndAssertion() */
 vstring getTexOrHtmlHypAndAssertion(long statemNum);
 
-/* Added 17-Nov-2015 (broken out of metamath.c for better modularization) */
 /* For WRITE BIBLIOGRAPHY command and error checking by VERIFY MARKUP */
 /* Returns 0 if OK, 1 if error or warning found */
 flag writeBibliography(vstring bibFile,
@@ -204,7 +169,6 @@ flag writeBibliography(vstring bibFile,
     flag errorsOnly,  /* 1 = no output, just warning msgs if any */
     flag noFileCheck); /* 1 = ignore missing external files (gifs, bib, etc.) */
 
-/* 5-Aug-2020 nm */
 /* Globals to hold mathbox information.  They should be re-initialized
    by the ERASE command (eraseSource()).  g_mathboxStmt = 0 indicates
    it and the other variables haven't been initialized. */
@@ -216,7 +180,6 @@ extern nmbrString *g_mathboxStart; /* Start stmt vs. mathbox # */
 extern nmbrString *g_mathboxEnd; /* End stmt vs. mathbox # */
 extern pntrString *g_mathboxUser; /* User name vs. mathbox # */
 
-/* 5-Aug-2020 nm */
 /* Returns 1 if statements are in different mathboxes */
 flag inDiffMathboxes(long stmt1, long stmt2);
 /* Returns the user of the mathbox that a statement is in, or ""


### PR DESCRIPTION
This is a big commit, it touches essentially every file. There should be no behavioral changes in this commit, it is all comment removal / editing except for a few instances of e.g. removing empty `else { }` branches.

I tried to keep as many comments as possible, but remove anything that represents inline evolution of the code (i.e. a comment that says "section added 2-May-04" or explains why a commented out bit of code is commented out). Large commented out blocks of code are also completely removed in most cases.

Ideally, I would like the code to explain itself without reference to history, just saying what the current design is. For the most part, any comment with a date in it has had the date removed, as well as the author (in the vast majority of cases `nm`, of course). I don't think it is necessary to have author attribution for comments explaining the code, unless the author is not sure about something or is inviting the reader to uncomment something, etc.