### PR TITLE
Email address for technical support

### DIFF
--- a/mmdata.c
+++ b/mmdata.c
@@ -507,8 +507,9 @@ void bug(int bugNum)
   if (mode == 0) { /* Print detailed info for first bug */
     print2("\n");
     print2(
-  "To get technical support, please send Norm Megill (%salum.mit.edu) the\n",
-        "nm@");
+  "To get technical support, please open an issue \n");
+    print2(
+  "(https://github.com/metamath/metamath-exe/issues) with the\n");
     print2(
   "detailed command sequence or a command file that reproduces this bug,\n");
     print2(

--- a/mmhlpb.c
+++ b/mmhlpb.c
@@ -49,8 +49,6 @@ H("For current program settings, type SHOW SETTINGS.");
 H("For a simple but general-purpose ASCII file manipulator, type TOOLS.");
 H("To exit Metamath, type EXIT (or its synonym QUIT).");
 H("");
-H(cat("If you need technical support, contact Norman Megill at nm",
-    "@", "alum.mit.edu.", NULL));
 H("Copyright (C) 2020 Norman Megill  License terms:  GPL 2.0 or later");
 H("");
 


### PR DESCRIPTION
This is mainly just to flag the two places in the code where Norman Megill's email address is given for technical support.  I'm pretty confident it's just these two.  What I've done about it in each case is just a guess on my part which could quite possibly be improved upon.

Naturally I have run Metamath to test both changes in output.