### PR TITLE
add types for temp_(v/nmbr/pntr)String, use const

### DIFF
--- a/src/mmdata.h
+++ b/src/mmdata.h
@@ -23,11 +23,13 @@ typedef long nmbrString; /* String of numbers */
 typedef void* pntrString; /* String of pointers */
 
 /* A nmbrString allocated in temporary storage. These strings will be deallocated
-after the next call to `nmbrLet`. */
+   after the next call to `nmbrLet`.
+   See also `temp_vstring` for information on how temporaries are handled. */
 typedef nmbrString temp_nmbrString;
 
 /* A pntrString allocated in temporary storage. These strings will be deallocated
-after the next call to `pntrLet`. */
+   after the next call to `pntrLet`.
+   See also `temp_vstring` for information on how temporaries are handled. */
 typedef pntrString temp_pntrString;
 
 enum mTokenType { var_, con_ };

--- a/src/mmdata.h
+++ b/src/mmdata.h
@@ -22,7 +22,13 @@ extern flag g_toolsMode; /* In metamath mode:  0 = metamath, 1 = tools */
 typedef long nmbrString; /* String of numbers */
 typedef void* pntrString; /* String of pointers */
 
+/* A nmbrString allocated in temporary storage. These strings will be deallocated
+after the next call to `nmbrLet`. */
+typedef nmbrString temp_nmbrString;
 
+/* A pntrString allocated in temporary storage. These strings will be deallocated
+after the next call to `pntrLet`. */
+typedef pntrString temp_pntrString;
 
 enum mTokenType { var_, con_ };
 #define lb_ '{' /* ${ */
@@ -186,7 +192,7 @@ void initBigArrays(void);
 long getFreeSpace(long max);
 
 /* Fatal memory allocation error */
-void outOfMemory(vstring msg);
+void outOfMemory(const char *msg);
 
 /* Bug check error */
 void bug(int bugNum);
@@ -213,13 +219,13 @@ extern struct nullPntrStruct g_PntrNull;
 
 /* This function returns a 1 if any entry in a comma-separated list
    matches using the matches() function. */
-flag matchesList(vstring testString, vstring pattern, char wildCard,
+flag matchesList(const char *testString, const char *pattern, char wildCard,
     char oneCharWildCard);
 
 /* This function returns a 1 if the first argument matches the pattern of
    the second argument.  The second argument may have 0-or-more and
    exactly-1 character match wildcards, typically '*' and '?'.*/
-flag matches(vstring testString, vstring pattern, char wildCard,
+flag matches(const char *testString, const char *pattern, char wildCard,
     char oneCharWildCard);
 
 
@@ -247,117 +253,114 @@ void nmbrMakeTempAlloc(nmbrString *s);
 
 
 /* String assignment - MUST be used to assign vstrings */
-void nmbrLet(nmbrString **target,nmbrString *source);
+void nmbrLet(nmbrString **target, const nmbrString *source);
 
 /* String concatenation - last argument MUST be NULL */
-nmbrString *nmbrCat(nmbrString *string1,...);
+temp_nmbrString *nmbrCat(const nmbrString *string1,...);
 
 /* Emulation of nmbrString functions similar to BASIC string functions */
-nmbrString *nmbrSeg(nmbrString *sin, long p1, long p2);
-nmbrString *nmbrMid(nmbrString *sin, long p, long l);
-nmbrString *nmbrLeft(nmbrString *sin, long n);
-nmbrString *nmbrRight(nmbrString *sin, long n);
+temp_nmbrString *nmbrSeg(const nmbrString *sin, long p1, long p2);
+temp_nmbrString *nmbrMid(const nmbrString *sin, long p, long l);
+temp_nmbrString *nmbrLeft(const nmbrString *sin, long n);
+temp_nmbrString *nmbrRight(const nmbrString *sin, long n);
 
 /* Allocate and return an "empty" string n "characters" long */
-nmbrString *nmbrSpace(long n);
+temp_nmbrString *nmbrSpace(long n);
 
-long nmbrLen(nmbrString *s);
-long nmbrAllocLen(nmbrString *s);
+long nmbrLen(const nmbrString *s);
+long nmbrAllocLen(const nmbrString *s);
 void nmbrZapLen(nmbrString *s, long length);
 
 /* Search for string2 in string 1 starting at start_position */
-long nmbrInstr(long start, nmbrString *sin, nmbrString *s);
+long nmbrInstr(long start, const nmbrString *sin, const nmbrString *s);
 
 /* Search for string2 in string 1 in reverse starting at start_position */
 /* (Reverse nmbrInstr) */
-long nmbrRevInstr(long start_position,nmbrString *string1,
-    nmbrString *string2);
+long nmbrRevInstr(long start_position, const nmbrString *string1,
+   const nmbrString *string2);
 
 /* 1 if strings are equal, 0 otherwise */
-int nmbrEq(nmbrString *sout,nmbrString *sin);
+flag nmbrEq(const nmbrString *s, const nmbrString *t);
 
 /* Converts mString to a vstring with one space between tokens */
-vstring nmbrCvtMToVString(nmbrString *s);
+temp_vstring nmbrCvtMToVString(const nmbrString *s);
 
 /* Converts rString to a vstring with one space between tokens */
-vstring nmbrCvtRToVString(nmbrString *s,
+temp_vstring nmbrCvtRToVString(const nmbrString *s,
     flag explicitTargets,
     long statemNum);
 
 /* Get step numbers in an rString - needed by cvtRToVString & elsewhere */
-nmbrString *nmbrGetProofStepNumbs(nmbrString *reason);
+nmbrString *nmbrGetProofStepNumbs(const nmbrString *reason);
 
 /* Converts any nmbrString to an ASCII string of numbers corresponding
    to the .tokenNum field -- used for debugging only. */
-vstring nmbrCvtAnyToVString(nmbrString *s);
+temp_vstring nmbrCvtAnyToVString(const nmbrString *s);
 
 /* Extract variables from a math token string */
-nmbrString *nmbrExtractVars(nmbrString *m);
+temp_nmbrString *nmbrExtractVars(const nmbrString *m);
 
 /* Determine if an element is in a nmbrString; return position if it is */
-long nmbrElementIn(long start, nmbrString *g, long element);
+long nmbrElementIn(long start, const nmbrString *g, long element);
 
 /* Add a single number to end of a nmbrString - faster than nmbrCat */
-nmbrString *nmbrAddElement(nmbrString *g, long element);
+temp_nmbrString *nmbrAddElement(const nmbrString *g, long element);
 
 /* Get the set union of two math token strings (presumably
    variable lists) */
-nmbrString *nmbrUnion(nmbrString *m1,nmbrString *m2);
+temp_nmbrString *nmbrUnion(const nmbrString *m1, const nmbrString *m2);
 
 /* Get the set intersection of two math token strings (presumably
    variable lists) */
-nmbrString *nmbrIntersection(nmbrString *m1,nmbrString *m2);
+temp_nmbrString *nmbrIntersection(const nmbrString *m1, const nmbrString *m2);
 
 /* Get the set difference m1-m2 of two math token strings (presumably
    variable lists) */
-nmbrString *nmbrSetMinus(nmbrString *m1,nmbrString *m2);
+temp_nmbrString *nmbrSetMinus(const nmbrString *m1,const nmbrString *m2);
 
 
 
 /* This is a utility function that returns the length of a subproof that
    ends at step */
-long nmbrGetSubproofLen(nmbrString *proof, long step);
+long nmbrGetSubproofLen(const nmbrString *proof, long step);
 
 /* This function returns a "squished" proof, putting in {} references
    to previous subproofs. */
-nmbrString *nmbrSquishProof(nmbrString *proof);
+temp_nmbrString *nmbrSquishProof(const nmbrString *proof);
 
 /* This function unsquishes a "squished" proof, replacing {} references
-   to previous subproofs by the subproofs themselvs.  The returned nmbrString
-   must be deallocated by the caller. */
-nmbrString *nmbrUnsquishProof(nmbrString *proof);
+   to previous subproofs by the subproofs themselves. */
+temp_nmbrString *nmbrUnsquishProof(const nmbrString *proof);
 
 /* This function returns the indentation level vs. step number of a proof
    string.  This information is used for formatting proof displays.  The
    function calls itself recursively, but the first call should be with
-   startingLevel = 0.  The caller is responsible for deallocating the
-   result. */
-nmbrString *nmbrGetIndentation(nmbrString *proof,
+   startingLevel = 0. */
+temp_nmbrString *nmbrGetIndentation(const nmbrString *proof,
   long startingLevel);
 
 /* This function returns essential (1) or floating (0) vs. step number of a
    proof string.  This information is used for formatting proof displays.  The
    function calls itself recursively, but the first call should be with
-   startingLevel = 0.  The caller is responsible for deallocating the
-   result. */
-nmbrString *nmbrGetEssential(nmbrString *proof);
+   startingLevel = 0. */
+temp_nmbrString *nmbrGetEssential(const nmbrString *proof);
 
 /* This function returns the target hypothesis vs. step number of a proof
    string.  This information is used for formatting proof displays.  The
-   function calls itself recursively.  The caller is responsible for
-   deallocating the result.  statemNum is the statement being proved. */
-nmbrString *nmbrGetTargetHyp(nmbrString *proof, long statemNum);
+   function calls itself recursively.
+   statemNum is the statement being proved. */
+temp_nmbrString *nmbrGetTargetHyp(const nmbrString *proof, long statemNum);
 
 /* Converts a proof string to a compressed-proof-format ASCII string.
    Normally, the proof string would be compacted with squishProof first,
    although it's not a requirement. */
 /* The statement number is needed because required hypotheses are
    implicit in the compressed proof. */
-vstring compressProof(nmbrString *proof, long statemNum,
+temp_vstring compressProof(const nmbrString *proof, long statemNum,
     flag oldCompressionAlgorithm);
 
 /* Gets length of the ASCII form of a compressed proof */
-long compressedProofSize(nmbrString *proof, long statemNum);
+long compressedProofSize(const nmbrString *proof, long statemNum);
 
 
 /*******************************************************************/
@@ -383,48 +386,48 @@ void pntrMakeTempAlloc(pntrString *s);
 
 
 /* String assignment - MUST be used to assign vstrings */
-void pntrLet(pntrString **target,pntrString *source);
+void pntrLet(pntrString **target, const pntrString *source);
 
 /* String concatenation - last argument MUST be NULL */
-pntrString *pntrCat(pntrString *string1,...);
+temp_pntrString *pntrCat(const pntrString *string1,...);
 
 /* Emulation of pntrString functions similar to BASIC string functions */
-pntrString *pntrSeg(pntrString *sin, long p1, long p2);
-pntrString *pntrMid(pntrString *sin, long p, long length);
-pntrString *pntrLeft(pntrString *sin, long n);
-pntrString *pntrRight(pntrString *sin, long n);
+temp_pntrString *pntrSeg(const pntrString *sin, long p1, long p2);
+temp_pntrString *pntrMid(const pntrString *sin, long p, long length);
+temp_pntrString *pntrLeft(const pntrString *sin, long n);
+temp_pntrString *pntrRight(const pntrString *sin, long n);
 
 /* Allocate and return an "empty" string n "characters" long */
-pntrString *pntrSpace(long n);
+temp_pntrString *pntrSpace(long n);
 
 /* Allocate and return an "empty" string n "characters" long
    initialized to nmbrStrings instead of vStrings */
-pntrString *pntrNSpace(long n);
+temp_pntrString *pntrNSpace(long n);
 
 /* Allocate and return an "empty" string n "characters" long
    initialized to pntrStrings instead of vStrings */
-pntrString *pntrPSpace(long n);
+temp_pntrString *pntrPSpace(long n);
 
-long pntrLen(pntrString *s);
-long pntrAllocLen(pntrString *s);
+long pntrLen(const pntrString *s);
+long pntrAllocLen(const pntrString *s);
 void pntrZapLen(pntrString *s, long length);
 
 /* Search for string2 in string 1 starting at start_position */
-long pntrInstr(long start, pntrString *sin, pntrString *s);
+long pntrInstr(long start, const pntrString *sin, const pntrString *s);
 
 /* Search for string2 in string 1 in reverse starting at start_position */
 /* (Reverse pntrInstr) */
-long pntrRevInstr(long start_position,pntrString *string1,
-    pntrString *string2);
+long pntrRevInstr(long start_position, const pntrString *string1,
+    const pntrString *string2);
 
 /* 1 if strings are equal, 0 otherwise */
-int pntrEq(pntrString *sout,pntrString *sin);
+flag pntrEq(const pntrString *sout, const pntrString *sin);
 
 /* Add a single null string element to a pntrString - faster than pntrCat */
-pntrString *pntrAddElement(pntrString *g);
+temp_pntrString *pntrAddElement(const pntrString *g);
 
 /* Add a single null pntrString element to a pntrString - faster than pntrCat */
-pntrString *pntrAddGElement(pntrString *g);
+temp_pntrString *pntrAddGElement(const pntrString *g);
 
 /* Utility functions */
 

--- a/src/mminou.c
+++ b/src/mminou.c
@@ -66,7 +66,7 @@ flag backFromCmdInput = 0; /* User typed "B" at main prompt */
 /* Returns 0 if user typed "q" during scroll prompt; this lets a procedure
    interrupt it's output for speedup (rest of output will be suppressed anyway
    until next command line prompt) */
-flag print2(char* fmt, ...) {
+flag print2(const char* fmt, ...) {
   /* This performs the same operations as printf, except that if a log file is
     open, the characters will also be printed to the log file. */
   /* Also, scrolling is paused at each page if in scroll-prompted mode. */
@@ -356,8 +356,7 @@ flag print2(char* fmt, ...) {
 /* Special:  if breakMatch is " (quote), treat as if space but don't break
              quotes, and also let lines grow long - use this call for all HTML
              code */
-void printLongLine(vstring line, vstring startNextLine, vstring breakMatch)
-{
+void printLongLine(const char *line, const char *startNextLine, const char *breakMatch) {
   vstring longLine = "";
   vstring multiLine = "";
   vstring prefix = "";
@@ -606,7 +605,7 @@ void printLongLine(vstring line, vstring startNextLine, vstring breakMatch)
 } /* printLongLine */
 
 
-vstring cmdInput(FILE *stream, vstring ask) {
+vstring cmdInput(FILE *stream, const char *ask) {
   /* This function prints a prompt (if 'ask' is not NULL) and gets a line from
     the input stream.  NULL is returned when end-of-file is encountered.
     New memory is allocated each time linput is called.  This space must
@@ -733,8 +732,7 @@ vstring cmdInput(FILE *stream, vstring ask) {
   return g;
 } /* cmdInput */
 
-vstring cmdInput1(vstring ask)
-{
+vstring cmdInput1(const char *ask) {
   /* This function gets a line from either the terminal or the command file
     stream depending on g_commandFileNestingLevel > 0.  It calls cmdInput(). */
   /* Warning: the calling program must deallocate the returned string. */
@@ -956,7 +954,7 @@ void errorMessage(vstring line, long lineNum, long column, long tokenLength,
 
 /* Opens files with error message; opens output files with
    backup of previous version.   Mode must be "r" or "w" or "d" (delete). */
-FILE *fSafeOpen(vstring fileName, vstring mode, flag noVersioningFlag) {
+FILE *fSafeOpen(const char *fileName, const char *mode, flag noVersioningFlag) {
   FILE *fp;
   vstring prefix = "";
   vstring postfix = "";
@@ -1103,8 +1101,7 @@ FILE *fSafeOpen(vstring fileName, vstring mode, flag noVersioningFlag) {
 
 /* Renames a file with backup of previous version.  If non-zero
    is returned, there was an error. */
-int fSafeRename(vstring oldFileName, vstring newFileName)
-{
+int fSafeRename(const char *oldFileName, const char *newFileName) {
   int error = 0;
   int i;
   FILE *fp;
@@ -1154,8 +1151,7 @@ int fSafeRename(vstring oldFileName, vstring newFileName)
         str1 = fTmpName("zz~list");  ]
    The file whose name is the returned string is not left open;
    the caller must separately open the file. */
-vstring fGetTmpName(vstring filePrefix)
-{
+vstring fGetTmpName(const char *filePrefix) {
   FILE *fp;
   vstring fname = "";
   static long counter = 0;
@@ -1182,7 +1178,7 @@ vstring fGetTmpName(vstring filePrefix)
    must deallocate the returned string.  If a NULL is returned, the file
    could not be opened or had a non-ASCII Unicode character or some other
    problem.   If verbose is 0, error and warning messages are suppressed. */
-vstring readFileToString(vstring fileName, char verbose, long *charCount) {
+vstring readFileToString(const char *fileName, char verbose, long *charCount) {
   FILE *inputFp;
   long fileBufSize;
   char *fileBuf;

--- a/src/mminou.h
+++ b/src/mminou.h
@@ -34,7 +34,7 @@ extern vstring g_input_fn, g_output_fn;  /* File names */
 
 /* Warning:  never call print2 with string longer than PRINTBUFFERSIZE - 1 */
 /* print2 returns 0 if the user has quit the printout. */
-flag print2(char* fmt,...);
+flag print2(const char* fmt,...);
 extern long g_screenHeight; /* Height of screen */
 extern long g_screenWidth; /* Width of screen */
 #define MAX_LEN 79 /* Default width of screen */
@@ -43,9 +43,10 @@ extern flag g_scrollMode; /* Flag for continuous or prompted scroll */
 extern flag g_quitPrint; /* Flag that user typed 'q' to last scrolling prompt */
 
 /* printLongLine automatically puts a newline \n in the output line. */
-void printLongLine(vstring line, vstring startNextLine, vstring breakMatch);
-vstring cmdInput(FILE *stream,vstring ask);
-vstring cmdInput1(vstring ask);
+void printLongLine(const char *line, const char *startNextLine, const char *breakMatch);
+vstring cmdInput(FILE *stream, const char *ask);
+vstring cmdInput1(const char *ask);
+flag cmdInputIsY(const char *ask);
 
 enum severity {notice_,warning_,error_,fatal_};
 void errorMessage(vstring line, long lineNum, long column, long tokenLength,
@@ -53,16 +54,16 @@ void errorMessage(vstring line, long lineNum, long column, long tokenLength,
 
 /* Opens files with error message; opens output files with
    backup of previous version.   Mode must be "r" or "w". */
-FILE *fSafeOpen(vstring fileName, vstring mode, flag noVersioningFlag);
+FILE *fSafeOpen(const char *fileName, const char *mode, flag noVersioningFlag);
 
 /* Renames a file with backup of previous version.  If non-zero
    is returned, there was an error. */
-int fSafeRename(vstring oldFileName, vstring newFileName);
+int fSafeRename(const char *oldFileName, const char *newFileName);
 
 /* Finds the name of the first file of the form filePrefix +
    nnn + ".tmp" that does not exist.  THE CALLER MUST DEALLOCATE
    THE RETURNED STRING. */
-vstring fGetTmpName(vstring filePrefix);
+vstring fGetTmpName(const char *filePrefix);
 
 /* This function returns a character string containing the entire contents of
    an ASCII file, or Unicode file with only ASCII characters.   On some
@@ -70,7 +71,7 @@ vstring fGetTmpName(vstring filePrefix);
    MUST DEALLOCATE THE RETURNED STRING.  If a NULL is returned, the file
    could not be opened or had a non-ASCII Unicode character or some other
    problem.   If verbose is 0, error and warning messages are suppressed. */
-vstring readFileToString(vstring fileName, char verbose, long *charCount);
+vstring readFileToString(const char *fileName, char verbose, long *charCount);
 
 /* Returns total elapsed time in seconds since starting session (for the
    lcc compiler) or the CPU time used (for the gcc compiler).  The

--- a/src/mmpars.c
+++ b/src/mmpars.c
@@ -3660,7 +3660,7 @@ vstring shortDumpRPNStack(void) {
 /* ???Todo:  use this elsewhere in mmpars.c to modularize this lookup */
 /* Lookup $a or $p label and return statement number.
    Return -1 if not found. */
-long lookupLabel(vstring label)
+long lookupLabel(const char *label)
 {
   void *voidPtr; /* bsearch returned value */
   long statemNum;
@@ -3893,7 +3893,7 @@ long proofTokenLen(char *ptr)
    If length = -1, then use end-of-string 0 to stop.
    If length >= 0, then scan at most length chars, but stop
        if end-of-string 0 is found. */
-long countLines(vstring start, long length) {
+long countLines(const char *start, long length) {
   long lines, i;
   lines = 0;
   if (length == -1) {
@@ -4379,8 +4379,7 @@ vstring outputStatement(long stmt, flag reformatFlag) {
    conventions.  This may be overly aggressive, and user should do a
    diff to see if result is as desired.  Called by WRITE SOURCE / REWRAP.
    Caller must deallocate returned vstring. */
-vstring rewrapComment(vstring comment1)
-{
+vstring rewrapComment(const char *comment1) {
   /* Punctuation from mmwtex.c */
 #define OPENING_PUNCTUATION "(['\""
 /* #define CLOSING_PUNCTUATION ".,;)?!:]'\"_-" */
@@ -5274,7 +5273,7 @@ vstring writeSourceToBuffer(void)
    caller decide whether to say re-use fileBuf to create an unsplit version
    of the .mm file in case the split version generation encounters an error. */
 /*                                     TODO ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ */
-/*flag(TODO)*/ void writeSplitSource(vstring *fileBuf, vstring fileName,
+/*flag(TODO)*/ void writeSplitSource(vstring *fileBuf, const char *fileName,
     flag noVersioningFlag, flag noDeleteFlag) {
   FILE *fp;
   vstring tmpStr1 = "";
@@ -5485,8 +5484,8 @@ vstring writeSourceToBuffer(void)
 /* Get file name and line number given a pointer into the read buffer */
 /* The user must deallocate the returned string (file name) */
 /* The globals g_IncludeCall structure and g_includeCalls are used */
-vstring getFileAndLineNum(vstring buffPtr /* start of read buffer */,
-    vstring currentPtr /* place at which to get file name and line no */,
+vstring getFileAndLineNum(const char *buffPtr /* start of read buffer */,
+    const char *currentPtr /* place at which to get file name and line no */,
     long *lineNum /* return argument */) {
   long i, smallestOffset, smallestNdx;
   vstring fileName = "";
@@ -5547,8 +5546,8 @@ void assignStmtFileAndLineNum(long stmtNum) {
 /* If NULL is returned, it means a serious error occured (like missing file)
    and reading should be aborted. */
 /* Globals used:  g_IncludeCall[], g_includeCalls */
-char *readInclude(vstring fileBuf, long fileBufOffset,
-    vstring sourceFileName, long *size, long parentLineNum, flag *errorFlag)
+vstring readInclude(const char *fileBuf, long fileBufOffset,
+    const char *sourceFileName, long *size, long parentLineNum, flag *errorFlag)
 {
   long i;
   long inclSize;
@@ -6035,8 +6034,7 @@ char *readInclude(vstring fileBuf, long fileBufOffset,
 /* TODO - ability to flag error to skip raw source function */
 /* If NULL is returned, it means a serious error occured (like missing file)
    and reading should be aborted. */
-char *readSourceAndIncludes(vstring inputFn /*input*/, long *size /*output*/)
-{
+vstring readSourceAndIncludes(const char *inputFn /*input*/, long *size /*output*/) {
   long i;
 /*D*//*long j;*/
 /*D*//*vstring s=""; */

--- a/src/mmpars.h
+++ b/src/mmpars.h
@@ -79,7 +79,7 @@ long proofTokenLen(char *ptr);
    If length = -1, then use end-of-string 0 to stop.
    If length >= 0, then scan at most length chars, but stop
        if end-of-string 0 is found. */
-long countLines(vstring start, long length);
+long countLines(const char *start, long length);
 
 /* Array with sort keys for all possible labels, including the ones for
    hypotheses (which may not always be active) */
@@ -141,11 +141,11 @@ nmbrString *parseMathTokens(vstring userText, long statemNum);
 
 vstring outputStatement(long stmt, /*flag cleanFlag,*/ flag reformatFlag);
 /* Caller must deallocate return string */
-vstring rewrapComment(vstring comment);
+vstring rewrapComment(const char *comment);
 
 /* Lookup $a or $p label and return statement number.
    Return -1 if not found. */
-long lookupLabel(vstring label);
+long lookupLabel(const char *label);
 
 /* For file splitting */
 
@@ -170,7 +170,7 @@ vstring writeSourceToBuffer(void);
    a nonsplit source with $( Begin $[... etc. inclusions */
 /* Note that *fileBuf is assigned to the empty string upon return, to
    conserve memory */
-void writeSplitSource(vstring *fileBuf, vstring fileName,
+void writeSplitSource(vstring *fileBuf, const char *fileName,
     flag noVersioningFlag, flag noDeleteFlag);
 
 /* When "write source" does not have the "/split" qualifier, by default
@@ -181,8 +181,8 @@ void deleteSplits(vstring *fileBuf, flag noVersioningFlag);
 /* Get file name and line number given a pointer into the read buffer */
 /* The user must deallocate the returned string (file name) */
 /* The globals includeCall structure and includeCalls are used */
-vstring getFileAndLineNum(vstring buffPtr/*start of read buffer*/,
-    vstring currentPtr/*place at which to get file name and line no*/,
+vstring getFileAndLineNum(const char *buffPtr/*start of read buffer*/,
+    const char *currentPtr/*place at which to get file name and line no*/,
     long *lineNum/*return argument*/);
 
 /* statement[stmtNum].fileName and .lineNum are initialized to "" and 0.
@@ -194,11 +194,11 @@ vstring getFileAndLineNum(vstring buffPtr/*start of read buffer*/,
 void assignStmtFileAndLineNum(long stmtNum);
 
 /* Initial read of source file */
-vstring readSourceAndIncludes(vstring inputFn, long *size);
+vstring readSourceAndIncludes(const char *inputFn, long *size);
 
 /* Recursively expand the source of an included file */
-char *readInclude(vstring fileBuf, long fileBufOffset,
-    /*vstring inclFileName,*/ vstring sourceFileName,
+vstring readInclude(const char *fileBuf, long fileBufOffset,
+    /*vstring inclFileName,*/ const char *sourceFileName,
     long *size, long parentLineNum, flag *errorFlag);
 
 #endif /* METAMATH_MMPARS_H_ */

--- a/src/mmpfas.c
+++ b/src/mmpfas.c
@@ -1133,7 +1133,7 @@ vstring getKnownSubProofs(void)
 /* Add a subproof in place of an unknown step to g_ProofInProgress.  The
    .target, .source, and .user fields are initialized to empty (except
    .target and .user of the deleted unknown step are retained). */
-void addSubProof(nmbrString *subProof, long step) {
+void addSubProof(const nmbrString *subProof, long step) {
   long sbPfLen;
 
   if ((g_ProofInProgress.proof)[step] != -(long)'?') bug(1803);
@@ -1162,8 +1162,9 @@ void addSubProof(nmbrString *subProof, long step) {
    we make it an argument in case in the future we'd like to do this
    outside of the Proof Assistant. */
 /* The rawTargetProof may be uncompressed or compressed. */
+/* Note: The caller must deallocate the returned nmbrString. */
 nmbrString *expandProof(
-    nmbrString *rawTargetProof, /* May be compressed or uncompressed */
+    const nmbrString *rawTargetProof, /* May be compressed or uncompressed */
     long sourceStmtNum   /* The statement whose proof will be expanded */
     /* , long targetStmtNum */) { /* The statement begin proved */
   nmbrString *origTargetProof = NULL_NMBRSTRING;
@@ -1520,8 +1521,7 @@ char checkStmtMatch(long statemNum, long step)
 /* Check to see if a (user-specified) math string will match the
    g_ProofInProgress.target (or .user) of an step.  Returns 1 if match, 0 if
    not, 2 if unification timed out. */
-char checkMStringMatch(nmbrString *mString, long step)
-{
+char checkMStringMatch(const nmbrString *mString, long step) {
   pntrString *stateVector = NULL_PNTRSTRING;
   char targetFlag;
   char sourceFlag = 1; /* Default if no .source */
@@ -1548,7 +1548,7 @@ char checkMStringMatch(nmbrString *mString, long step)
 /* maxEDepth is the maximum depth at which statements with $e hypotheses are
    considered.  A value of 0 means none are considered. */
 /* The caller must deallocate the returned nmbrString. */
-nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
+nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDepth,
     long step, /* 0 means step 1; used for messages */
     flag noDistinct, /* 1 means don't try statements with $d's */
     flag overrideFlag, /* 1 means to override usage locks, 2 means to
@@ -1958,7 +1958,7 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
 /* This function does quick check for some common conditions that prevent
    a trial statement (scheme) from being unified with a given instance.
    Return value 0 means it can't be unified, 1 means it might be unifiable. */
-INLINE flag quickMatchFilter(long trialStmt, nmbrString *mString,
+INLINE flag quickMatchFilter(long trialStmt, const nmbrString *mString,
     long dummyVarFlag /* 0 if no dummy vars in mString */) {
   /* This function used to be part of proveFloating().
      It was separated out for reuse in other places */
@@ -2534,7 +2534,7 @@ void interactiveUnifyStep(long step, char messageFlag)
              1 = unification was selected; held in stateVector
              2 = unification timed out
              3 = no unification was selected */
-char interactiveUnify(nmbrString *schemeA, nmbrString *schemeB,
+char interactiveUnify(const nmbrString *schemeA, const nmbrString *schemeB,
     pntrString **stateVector)
 {
 
@@ -2881,7 +2881,7 @@ void makeSubstAll(pntrString *stateVector) {
 } /* makeSubstAll */
 
 /* Replace a dummy variable with a user-specified math string */
-void replaceDummyVar(long dummyVar, nmbrString *mString)
+void replaceDummyVar(long dummyVar, const nmbrString *mString)
 {
   long numSubs = 0;
   long numSteps = 0;
@@ -2948,8 +2948,7 @@ void replaceDummyVar(long dummyVar, nmbrString *mString)
 
 /* Get subproof length of a proof, starting at endStep and going backwards.
    Note that the first step is 0, the second is 1, etc. */
-long subproofLen(nmbrString *proof, long endStep)
-{
+long subproofLen(const nmbrString *proof, long endStep) {
   long stmt, p, lvl;
   lvl = 1;
   p = endStep + 1;
@@ -3196,7 +3195,7 @@ void copyProofStruct(struct pip_struct *outProofStruct,
    a starting proof.  Normally, proofStruct is the global g_ProofInProgress,
    although we've made it an argument to help modularize the function.  There
    are still globals such as g_pipDummyVars, updated by various functions. */
-void initProofStruct(struct pip_struct *proofStruct, nmbrString *proof,
+void initProofStruct(struct pip_struct *proofStruct, const nmbrString *proof,
     long proveStmt)
 {
   nmbrString *tmpProof = NULL_NMBRSTRING;

--- a/src/mmpfas.h
+++ b/src/mmpfas.h
@@ -82,7 +82,7 @@ vstring getKnownSubProofs(void);
 /* Add a subproof in place of an unknown step to g_ProofInProgress.  The
    .target, .source, and .user fields are initialized to empty (except
    .target of the deleted unknown step is retained). */
-void addSubProof(nmbrString *subProof, long step);
+void addSubProof(const nmbrString *subProof, long step);
 
 /* This function eliminates any occurrences of statement sourceStmtNum in the
    targetProof by substituting it with the proof of sourceStmtNum.  An empty
@@ -90,7 +90,8 @@ void addSubProof(nmbrString *subProof, long step);
 /* Normally, targetProof is the global g_ProofInProgress.proof.  However,
    we make it an argument in case in the future we'd like to do this
    outside of the proof assistant. */
-nmbrString *expandProof(nmbrString *targetProof, long sourceStmtNum);
+/* Note: The caller must deallocate the returned nmbrString. */
+nmbrString *expandProof(const nmbrString *targetProof, long sourceStmtNum);
 
 /* Delete a subproof starting (in reverse from) step.  The step is replaced
    with an unknown step, and its .target field is retained. */
@@ -104,12 +105,12 @@ char checkStmtMatch(long statemNum, long step);
 /* Check to see if a (user-specified) math string will match the
    g_ProofInProgress.target (or .user) of an step.  Returns 1 if match, 0 if
    not, 2 if unification timed out. */
-char checkMStringMatch(nmbrString *mString, long step);
+char checkMStringMatch(const nmbrString *mString, long step);
 
 /* Find proof of formula or simple theorem (no new vars in $e's) */
 /* maxEDepth is the maximum depth at which statements with $e hypotheses are
    considered.  A value of 0 means none are considered. */
-nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
+nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDepth,
     long step, flag noDistinct,
     flag overrideFlag, /* 0 means respect usage locks
                          1 means to override usage locks
@@ -120,12 +121,11 @@ nmbrString *proveFloating(nmbrString *mString, long statemNum, long maxEDepth,
 /* This function does quick check for some common conditions that prevent
    a trial statement (scheme) from being unified with a given instance.
    Return value 0 means it can't be unified, 1 means it might be unifiable. */
-char quickMatchFilter(long trialStmt, nmbrString *mString,
+char quickMatchFilter(long trialStmt, const nmbrString *mString,
     long dummyVarFlag /* 0 if no dummy vars in mString */);
 
 /* Shorten proof by using specified statement. */
-void minimizeProof(long repStatemNum, long prvStatemNum, flag
-    allowGrowthFlag);
+void minimizeProof(long repStatemNum, long prvStatemNum, flag allowGrowthFlag);
 
 /* Initialize g_ProofInProgress.source of the step, and .target of all
    hypotheses, to schemes using new dummy variables. */
@@ -151,7 +151,7 @@ void interactiveUnifyStep(long step, char messageFlag);
              1 = unification was selected; held in stateVector
              2 = unification timed out
              3 = no unification was selected */
-char interactiveUnify(nmbrString *schemeA, nmbrString *schemeB,
+char interactiveUnify(const nmbrString *schemeA, const nmbrString *schemeB,
     pntrString **stateVector);
 
 /* Automatically unify steps with unique unification */
@@ -162,10 +162,10 @@ void autoUnify(flag congrats);
 void makeSubstAll(pntrString *stateVector);
 
 /* Replace a dummy variable with a user-specified math string */
-void replaceDummyVar(long dummyVar, nmbrString *mString);
+void replaceDummyVar(long dummyVar, const nmbrString *mString);
 
 /* Get subproof length of a proof, starting at endStep and going backwards */
-long subproofLen(nmbrString *proof, long endStep);
+long subproofLen(const nmbrString *proof, long endStep);
 
 /* If testStep has no dummy variables, return 0;
    if testStep has isolated dummy variables (that don't affect rest of
@@ -186,7 +186,7 @@ void copyProofStruct(struct pip_struct *outProofStruct,
     struct pip_struct inProofStruct);
 
 /* Initiailizes the Proof Assistant proof state */
-void initProofStruct(struct pip_struct *proofStruct, nmbrString *proof,
+void initProofStruct(struct pip_struct *proofStruct, const nmbrString *proof,
     long proveStatement);
 
 /* Clears the Proof Assistant proof state */

--- a/src/mmunif.c
+++ b/src/mmunif.c
@@ -158,7 +158,7 @@ nmbrString *g_oneConst = NULL_NMBRSTRING;
    The caller must deallocate the returned nmbrString.
 */
 nmbrString *makeSubstUnif(flag *newVarFlag,
-    nmbrString *trialScheme, pntrString *stateVector)
+    const nmbrString *trialScheme, pntrString *stateVector)
 {
   long p,q,i,j,k,m,tokenNum;
   long schemeLen;
@@ -271,8 +271,8 @@ nmbrString *makeSubstUnif(flag *newVarFlag,
 
 
 char unify(
-    nmbrString *schemeA,
-    nmbrString *schemeB,
+    const nmbrString *schemeA,
+    const nmbrString *schemeB,
     /* nmbrString **unifiedScheme, */ /* stateVector[8] holds this */
     pntrString **stateVector,
     long reEntryFlag)
@@ -1203,8 +1203,8 @@ char unify(
    all unknown vars (including those without substitutions), not just
    the ones on the stack. */
 flag oneDirUnif(
-    nmbrString *schemeA,
-    nmbrString *schemeB,
+    const nmbrString *schemeA,
+    const nmbrString *schemeB,
     pntrString **stateVector,
     long reEntryFlag)
 {
@@ -1266,8 +1266,8 @@ nmbrString *oldStackUnkVarLen; /* Pointer only - not allocated */
      2: unification timed out
      3: more than one unification was possible */
 char uniqueUnif(
-    nmbrString *schemeA,
-    nmbrString *schemeB,
+    const nmbrString *schemeA,
+    const nmbrString *schemeB,
     pntrString **stateVector)
 {
   pntrString *saveStateVector = NULL_PNTRSTRING;
@@ -1438,8 +1438,7 @@ void purgeStateVector(pntrString **stateVector) {
 
 
 /* Prints the substitutions determined by unify for debugging purposes */
-void printSubst(pntrString *stateVector)
-{
+void printSubst(pntrString *stateVector) {
   long d;
   nmbrString *stackUnkVar; /* Pointer only - not allocated */
   nmbrString *unifiedScheme; /* Pointer only - not allocated */
@@ -1475,8 +1474,8 @@ void printSubst(pntrString *stateVector)
    returned by unify().  (The redundancy of equivalent unifications was
    a deficiency pointed out by Jeremy Henty.) */
 char unifyH(
-    nmbrString *schemeA,
-    nmbrString *schemeB,
+    const nmbrString *schemeA,
+    const nmbrString *schemeB,
     pntrString **stateVector,
     long reEntryFlag)
 {

--- a/src/mmunif.h
+++ b/src/mmunif.h
@@ -25,12 +25,12 @@ extern nmbrString *g_oneConst;
 
 
 nmbrString *makeSubstUnif(flag *newVarFlag,
-    nmbrString *trialScheme, pntrString *stateVector);
+    const nmbrString *trialScheme, pntrString *stateVector);
 
 
 char unify(
-    nmbrString *schemeA,
-    nmbrString *schemeB,
+    const nmbrString *schemeA,
+    const nmbrString *schemeB,
     /* nmbrString **unifiedScheme, */ /* stateVector[8] holds this */
     pntrString **stateVector,
     long reEntryFlag);
@@ -63,8 +63,8 @@ char unify(
    variables in schemeA have changed.  This is used to speed up the
    program. */
 flag oneDirUnif(
-    nmbrString *schemeA,
-    nmbrString *schemeB,
+    const nmbrString *schemeA,
+    const nmbrString *schemeB,
     pntrString **stateVector,
     long reEntryFlag);
 
@@ -76,8 +76,8 @@ flag oneDirUnif(
      2: unification timed out.
      3: more than one unification was possible. */
 char uniqueUnif(
-    nmbrString *schemeA,
-    nmbrString *schemeB,
+    const nmbrString *schemeA,
+    const nmbrString *schemeB,
     pntrString **stateVector);
 
 /* unifyH() is like unify(), except that when reEntryFlag is 1,
@@ -87,8 +87,8 @@ char uniqueUnif(
    those returned by unify().  (The elimination of equivalent
    unifications was suggested by Jeremy Henty.) */
 char unifyH(
-    nmbrString *schemeA,
-    nmbrString *schemeB,
+    const nmbrString *schemeA,
+    const nmbrString *schemeB,
     pntrString **stateVector,
     long reEntryFlag);
 

--- a/src/mmvstr.c
+++ b/src/mmvstr.c
@@ -88,9 +88,7 @@ static void* tempAlloc(long size)  /* String memory allocation/deallocation */
 } /* tempAlloc */
 
 
-/* Make string have temporary allocation to be released by next let() */
-/* Warning:  after makeTempAlloc() is called, the vstring may NOT be
-   assigned again with let() */
+/* Put string in temporary allocation arena */
 void makeTempAlloc(vstring s) {
   pushTempAlloc(s);
 /*E*/INCDB1((long)strlen(s) + 1);
@@ -100,11 +98,6 @@ void makeTempAlloc(vstring s) {
 
 
 /* String assignment */
-/* This function must ALWAYS be called to make assignment to */
-/* a vstring in order for the memory cleanup routines, etc. */
-/* to work properly.  If a vstring has never been assigned before, */
-/* it is the user's responsibility to initialize it to "" (the */
-/* null string). */
 void let(vstring *target, const char *source) {
 
   size_t sourceLength = strlen(source);  /* Save its length */
@@ -144,7 +137,8 @@ void let(vstring *target, const char *source) {
 
 } /* let */
 
-temp_vstring cat(const char *string1, ...) {       /* String concatenation */
+/* String concatenation */
+temp_vstring cat(const char *string1, ...) {
 #define MAX_CAT_ARGS 50
   va_list ap;   /* Declare list incrementer */
   const char *arg[MAX_CAT_ARGS];    /* Array to store arguments */

--- a/src/mmvstr.c
+++ b/src/mmvstr.c
@@ -225,7 +225,7 @@ int linput(FILE *stream, const char* ask, vstring *target) {
 
 
 /* Find out the length of a string */
-long len(vstring s) {
+long len(const char *s) {
   return (long)strlen(s);
 } /* len */
 

--- a/src/mmvstr.c
+++ b/src/mmvstr.c
@@ -646,7 +646,7 @@ temp_vstring xlate(const char *sin, const char *table)
 
 /* Returns the ascii value of a character */
 long ascii_(const char *c) {
-  return ((long)c[0]);
+  return (unsigned char)c[0];
 } /* ascii_ */
 
 

--- a/src/mmvstr.c
+++ b/src/mmvstr.c
@@ -91,8 +91,7 @@ static void* tempAlloc(long size)  /* String memory allocation/deallocation */
 /* Make string have temporary allocation to be released by next let() */
 /* Warning:  after makeTempAlloc() is called, the vstring may NOT be
    assigned again with let() */
-void makeTempAlloc(vstring s)
-{
+void makeTempAlloc(vstring s) {
   pushTempAlloc(s);
 /*E*/INCDB1((long)strlen(s) + 1);
 /*E*/db-=(long)strlen(s) + 1;
@@ -106,7 +105,7 @@ void makeTempAlloc(vstring s)
 /* to work properly.  If a vstring has never been assigned before, */
 /* it is the user's responsibility to initialize it to "" (the */
 /* null string). */
-void let(vstring *target, vstring source) {
+void let(vstring *target, const char *source) {
 
   size_t sourceLength = strlen(source);  /* Save its length */
   size_t targetLength = strlen(*target); /* Save its length */
@@ -138,25 +137,23 @@ void let(vstring *target, vstring source) {
     if (targetLength) {
       free(*target);
     }
-    *target= "";
+    *target = "";
   }
 
   freeTempAlloc(); /* Free up temporary strings used in expression computation */
 
 } /* let */
 
-vstring cat(vstring string1,...)        /* String concatenation */
+temp_vstring cat(const char *string1, ...) {       /* String concatenation */
 #define MAX_CAT_ARGS 50
-{
   va_list ap;   /* Declare list incrementer */
-  vstring arg[MAX_CAT_ARGS];    /* Array to store arguments */
+  const char *arg[MAX_CAT_ARGS];    /* Array to store arguments */
   size_t argPos[MAX_CAT_ARGS]; /* Array of argument positions in result */
-  vstring result;
   int i;
   int numArgs = 0;        /* Define "last argument" */
 
   size_t pos = 0;
-  char* curArg = string1;
+  const char* curArg = string1;
 
   va_start(ap, string1); /* Begin the session */
   do {
@@ -175,7 +172,7 @@ vstring cat(vstring string1,...)        /* String concatenation */
   va_end(ap);           /* End var args session */
 
   /* Allocate the memory for it */
-  result = tempAlloc((long)pos+1);
+  temp_vstring result = tempAlloc((long)pos+1);
   /* Move the strings into the newly allocated area */
   for (i = 0; i < numArgs; ++i)
     strcpy(result + argPos[i], arg[i]);
@@ -185,21 +182,21 @@ vstring cat(vstring string1,...)        /* String concatenation */
 
 /* Input a line from the user or from a file */
 /* Returns 1 if a (possibly empty) line was successfully read, 0 if EOF */
-int linput(FILE *stream, const char* ask, vstring *target)
-{                           /* Note: "vstring *target" means "char **target" */
-  /*
-    BASIC:  linput "what"; a$
-    c:      linput(NULL, "what?", &a);
+/*
+  BASIC:  linput "what"; a$
+  c:      linput(NULL, "what?", &a);
 
-    BASIC:  linput #1, a$                         (error trap on EOF)
-    c:      if (!linput(file1, NULL, &a)) break;  (break on EOF)
+  BASIC:  linput #1, a$                         (error trap on EOF)
+  c:      if (!linput(file1, NULL, &a)) break;  (break on EOF)
 
-  */
-  /* This function prints a prompt (if 'ask' is not NULL), gets a line from
-    the stream, and assigns it to target using the let(&...) function.
-    0 is returned when end-of-file is encountered.  The vstring
-    *target MUST be initialized to "" or previously assigned by let(&...)
-    before using it in linput. */
+*/
+/* This function prints a prompt (if 'ask' is not NULL), gets a line from
+  the stream, and assigns it to target using the let(&...) function.
+  0 is returned when end-of-file is encountered.  The vstring
+  *target MUST be initialized to "" or previously assigned by let(&...)
+  before using it in linput. */
+int linput(FILE *stream, const char* ask, vstring *target) {
+                            /* Note: "vstring *target" means "char **target" */
   char f[10001]; /* Read in chunks up to 10000 characters */
   int result = 0;
   int eol_found = 0;
@@ -234,50 +231,44 @@ int linput(FILE *stream, const char* ask, vstring *target)
 
 
 /* Find out the length of a string */
-long len(vstring s)
-{
-  return ((long)strlen(s));
+long len(vstring s) {
+  return (long)strlen(s);
 } /* len */
 
 
 /* Extract sin from character position start to stop into sout */
-vstring seg(vstring sin, long start, long stop)
-{
+temp_vstring seg(const char *sin, long start, long stop) {
   if (start < 1) start = 1;
   return mid(sin, start, stop - start + 1);
 } /* seg */
 
 
 /* Extract sin from character position start for length len */
-vstring mid(vstring sin, long start, long length)
-{
-  vstring sout;
+temp_vstring mid(const char *sin, long start, long length) {
   if (start < 1) start = 1;
   if (length < 0) length = 0;
-  sout=tempAlloc(length + 1);
-  strncpy(sout,sin + start - 1, (size_t)length);
+  temp_vstring sout = tempAlloc(length + 1);
+  strncpy(sout, sin + start - 1, (size_t)length);
 /*E*/ /*??? Should db be subtracted from if length > end of string? */
   sout[length] = 0;
-  return (sout);
+  return sout;
 } /* mid */
 
 
 /* Extract leftmost n characters */
-vstring left(vstring sin,long n)
-{
+temp_vstring left(const char *sin, long n) {
   return mid(sin, 1, n);
 } /* left */
 
 
 /* Extract after character n */
-vstring right(vstring sin, long n)
-{
+temp_vstring right(const char *sin, long n) {
   return seg(sin, n, (long)(strlen(sin)));
 } /* right */
 
 
 /* Emulate VMS BASIC edit$ command */
-vstring edit(vstring sin,long control) {
+temp_vstring edit(const char *sin, long control) {
 
 /* Added _ to fix '"isblank" redefined' compiler warning */
 #define isblank_(c) ((c == ' ') || (c == '\t'))
@@ -304,7 +295,6 @@ vstring edit(vstring sin,long control) {
        8192     Discard CR only (to assist DOS-to-Unix conversion)
        16384    Discard trailing spaces, tabs, and LFs
   */
-  vstring sout;
   long i, j, k, m;
   int last_char_is_blank;
   int clear_parity_flag, discardctrl_flag, bracket_flag, quote_flag, uppercase_flag;
@@ -337,11 +327,11 @@ vstring edit(vstring sin,long control) {
   /* Copy string */
   i = (long)strlen(sin) + 1;
   if (untab_flag) i = i * 7; /* Allow for max possible length */
-  sout=tempAlloc(i);
-  strcpy(sout,sin);
+  temp_vstring sout = tempAlloc(i);
+  strcpy(sout, sin);
 
   /* Discard leading space/tab */
-  i=0;
+  i = 0;
   if (leaddiscard_flag)
     while ((sout[i] != 0) && isblank_(sout[i]))
       sout[i++] = 0;
@@ -567,17 +557,15 @@ vstring edit(vstring sin,long control) {
     /* sout[k] = 0 is the last character at this point */
   }
 
-  return (sout);
+  return sout;
 } /* edit */
 
 
 /* Return a string of the same character */
-vstring string(long n, char c)
-{
-  vstring sout;
+temp_vstring string(long n, char c) {
   long j = 0;
   if (n < 0) n = 0;
-  sout=tempAlloc(n + 1);
+  temp_vstring sout = tempAlloc(n + 1);
   while (j < n) sout[j++] = c;
   sout[j] = 0;
   return (sout);
@@ -585,29 +573,25 @@ vstring string(long n, char c)
 
 
 /* Return a string of spaces */
-vstring space(long n)
-{
-  return (string(n, ' '));
+temp_vstring space(long n) {
+  return string(n, ' ');
 } /* space */
 
 
 /* Return a character given its ASCII value */
-vstring chr(long n)
-{
-  vstring sout;
-  sout = tempAlloc(2);
+temp_vstring chr(long n) {
+  temp_vstring sout = tempAlloc(2);
   sout[0] = (char)(n & 0xFF);
   sout[1] = 0;
-  return(sout);
+  return sout;
 } /* chr */
 
 
 /* Search for string2 in string1 starting at start_position */
 /* If there is no match, 0 is returned */
 /* If string2 is "", (length of the string) + 1 is returned */
-long instr(long start_position, vstring string1, vstring string2)
-{
-  char *sp1, *sp2;
+long instr(long start_position, const char *string1, const char *string2) {
+  const char *sp1, *sp2;
   long ls1, ls2;
   long found = 0;
   if (start_position < 1) start_position = 1;
@@ -622,7 +606,7 @@ long instr(long start_position, vstring string1, vstring string2)
     } else
       sp1 = sp2 + 1;
   }
-  return (found);
+  return found;
 } /* instr */
 
 
@@ -630,8 +614,7 @@ long instr(long start_position, vstring string1, vstring string2)
 /* 1 = 1st string character; 0 = not found */
 /* ??? Future - this could be made more efficient by searching directly,
    backwards from end of string1 */
-long rinstr(vstring string1, vstring string2)
-{
+long rinstr(const char *string1, const char *string2) {
   long pos = 0;
   long savePos = 0;
 
@@ -640,22 +623,21 @@ long rinstr(vstring string1, vstring string2)
     if (!pos) break;
     savePos = pos;
   }
-  return (savePos);
+  return savePos;
 } /* rinstr */
 
 
 /* Translate string in sin to sout based on table.
    Table must be 256 characters long!! <- not true anymore? */
-vstring xlate(vstring sin,vstring table)
+temp_vstring xlate(const char *sin, const char *table)
 {
-  vstring sout;
   long len_table, len_sin;
   long i, j;
   long table_entry;
   char m;
   len_sin = (long)strlen(sin);
   len_table = (long)strlen(table);
-  sout = tempAlloc(len_sin+1);
+  temp_vstring sout = tempAlloc(len_sin+1);
   for (i = j = 0; i < len_sin; i++)
   {
     table_entry = 0x000000FF & (long)sin[i];
@@ -669,15 +651,13 @@ vstring xlate(vstring sin,vstring table)
 
 
 /* Returns the ascii value of a character */
-long ascii_(vstring c)
-{
+long ascii_(const char *c) {
   return ((long)c[0]);
 } /* ascii_ */
 
 
 /* Returns the floating-point value of a numeric string */
-double val(vstring s)
-{
+double val(const char *s) {
   double v = 0;
   char signFound = 0;
   double power = 1.0;
@@ -707,9 +687,7 @@ double val(vstring s)
 
 
 /* Returns current date as an ASCII string */
-vstring date()
-{
-  vstring sout;
+temp_vstring date() {
   struct tm *time_structure;
   time_t time_val;
   char *month[12];
@@ -731,21 +709,19 @@ vstring date()
 
   time(&time_val); /* Retrieve time */
   time_structure = localtime(&time_val); /* Translate to time structure */
-  sout = tempAlloc(15); /* Use 15 instead of 12 to prevent gcc 8.3 warning */
+  temp_vstring sout = tempAlloc(15); /* Use 15 instead of 12 to prevent gcc 8.3 warning */
   /* "%02d" means leading zeros with min. field width of 2 */
   /* sprintf(sout,"%d-%s-%02d", */
   sprintf(sout,"%d-%s-%04d",
       time_structure->tm_mday,
       month[time_structure->tm_mon],
       (int)((time_structure->tm_year) + 1900));
-  return(sout);
+  return sout;
 } /* date */
 
 
 /* Return current time as an ASCII string */
-vstring time_()
-{
-  vstring sout;
+temp_vstring time_() {
   struct tm *time_structure;
   time_t time_val;
   int i;
@@ -768,7 +744,7 @@ vstring time_()
     time_structure->tm_hour -= 12;
   if (time_structure->tm_hour == 0)
     time_structure->tm_hour = 12;
-  sout = tempAlloc(12);
+  temp_vstring sout = tempAlloc(12);
   if (time_structure->tm_min >= 10)
     format = format1;
   else
@@ -777,20 +753,18 @@ vstring time_()
       time_structure->tm_hour,
       time_structure->tm_min,
       am_pm[i]);
-  return(sout);
+  return sout;
 } /* time */
 
 
 /* Return a number as an ASCII string */
-vstring str(double f)
-{
+temp_vstring str(double f) {
   /* This function converts a floating point number to a string in the */
   /* same way that %f in printf does, except that trailing zeroes after */
   /* the one after the decimal point are stripped; e.g., it returns 7 */
   /* instead of 7.000000000000000. */
-  vstring s;
   long i;
-  s = tempAlloc(50);
+  temp_vstring s = tempAlloc(50);
   sprintf(s,"%f", f);
   if (strchr(s, '.') != 0) { /* The string has a period in it */
     for (i = (long)strlen(s) - 1; i > 0; i--) {  /* Scan string backwards */
@@ -800,24 +774,22 @@ vstring str(double f)
     if (s[i] == '.') s[i] = 0; /* Delete trailing period */
 /*E*/INCDB1(-(49 - (long)strlen(s)));
   }
-  return (s);
+  return s;
 } /* str */
 
 
 /* Return a number as an ASCII string */
 /* (This may have differed slightly from str() in BASIC but I forgot how.
    It should be considered deprecated.) */
-vstring num1(double f)
-{
-  return (str(f));
+temp_vstring num1(double f) {
+  return str(f);
 } /* num1 */
 
 
 /* Return a number as an ASCII string surrounded by spaces */
 /* (This should be considered deprecated.) */
-vstring num(double f)
-{
-  return (cat(" ",str(f)," ",NULL));
+temp_vstring num(double f) {
+  return cat(" ", str(f), " ", NULL);
 } /* num */
 
 
@@ -835,9 +807,8 @@ vstring num(double f)
    list based on an integer position. */
 /* If element is less than 1 or greater than number of elements
    in the list, a null string is returned. */
-vstring entry(long element, vstring list)
+temp_vstring entry(long element, const char *list)
 {
-  vstring sout;
   long commaCount, lastComma, i, length;
   if (element < 1) return ("");
   lastComma = -1;
@@ -857,18 +828,17 @@ vstring entry(long element, vstring list)
   if (element > commaCount) return ("");
   length = i - lastComma - 1;
   if (length < 1) return ("");
-  sout = tempAlloc(length + 1);
+  temp_vstring sout = tempAlloc(length + 1);
   strncpy(sout, list + lastComma + 1, (size_t)length);
   sout[length] = 0;
-  return (sout);
+  return sout;
 }
 
 /* Emulate PROGRESS lookup function */
 /* Returns an integer giving the first position of an expression
    in a comma-separated list. Returns a 0 if the expression
    is not in the list. */
-long lookup(vstring expression, vstring list)
-{
+long lookup(const char *expression, const char *list) {
   long i, exprNum, exprPos;
   char match;
 
@@ -904,8 +874,7 @@ long lookup(vstring expression, vstring list)
 /* Emulate PROGRESS num-entries function */
 /* Returns the number of items in a comma-separated list.  If the
    list is the empty string, return 0. */
-long numEntries(vstring list)
-{
+long numEntries(const char *list) {
   long i, commaCount;
   if (list[0] == 0) {
     commaCount = -1; /* Return 0 if list empty */
@@ -927,8 +896,7 @@ long numEntries(vstring list)
 /* If element is less than 1 or greater than number of elements
    in the list, a 0 is returned.  If entry is null, a 0 is
    returned. */
-long entryPosition(long element, vstring list)
-{
+long entryPosition(long element, const char *list) {
   long commaCount, lastComma, i;
   if (element < 1) return 0;
   lastComma = -1;

--- a/src/mmvstr.h
+++ b/src/mmvstr.h
@@ -219,7 +219,7 @@ temp_vstring time_(void);
 temp_vstring num(double x);
 temp_vstring num1(double x);
 temp_vstring str(double x);
-long len(vstring s);
+long len(const char *s);
 long instr(long start, const char *string1, const char *string2);
 long rinstr(const char *string1, const char *string2);
 long ascii_(const char *c);

--- a/src/mmvstr.h
+++ b/src/mmvstr.h
@@ -126,18 +126,26 @@ with 'let(&' and thus has the same effect as 'let(&'.
 
 #include <stdio.h>
 
+/* A vstring is like a C string, but it contains a control block allowing
+for memory allocation. New vstrings should always be constructed from the
+`vstringdef` macro. */
 typedef char* vstring;
+
+/* A vstring allocated in temporary storage. These strings will be deallocated
+after the next call to `let`. */
+typedef vstring temp_vstring;
+
 #define vstringdef(x) vstring x = ""
 
 /* Emulation of BASIC string assignment */
 /* 'let' MUST be used to assign vstrings, e.g. 'let(&abc, "Hello"); */
 /* Empty string deallocates memory, e.g. 'let(&abc, ""); */
-void let(vstring *target, vstring source);
+void let(vstring *target, const char *source);
 
 /* Emulation of BASIC string concatenation - last argument MUST be NULL */
 /* vstring cat(vstring string1, ..., stringN, NULL); */
 /* e.g. 'let(&abc, cat("Hello", " ", left("worldx", 5), "!", NULL);' */
-vstring cat(vstring string1,...);
+temp_vstring cat(const char * string1, ...);
 
 /* Emulation of BASIC linput (line input) statement; returns NULL if EOF */
 /* Note that linput assigns target string with let(&target,...) */
@@ -150,35 +158,35 @@ vstring cat(vstring string1,...);
 
   */
 /* returns whether a (possibly empty) line was successfully read */
-int linput(FILE *stream,const char* ask,vstring *target);
+int linput(FILE *stream, const char *ask, vstring *target);
 
 /* Emulation of BASIC string functions */
 /* Indices are 1-based */
-vstring seg(vstring sin, long p1, long p2);
-vstring mid(vstring sin, long p, long l);
-vstring left(vstring sin, long n);
-vstring right(vstring sin, long n);
-vstring edit(vstring sin, long control);
-vstring space(long n);
-vstring string(long n, char c);
-vstring chr(long n);
-vstring xlate(vstring sin, vstring control);
-vstring date(void);
-vstring time_(void);
-vstring num(double x);
-vstring num1(double x);
-vstring str(double x);
+temp_vstring seg(const char *sin, long p1, long p2);
+temp_vstring mid(const char *sin, long p, long l);
+temp_vstring left(const char *sin, long n);
+temp_vstring right(const char *sin, long n);
+temp_vstring edit(const char *sin, long control);
+temp_vstring space(long n);
+temp_vstring string(long n, char c);
+temp_vstring chr(long n);
+temp_vstring xlate(const char *sin, const char *table);
+temp_vstring date(void);
+temp_vstring time_(void);
+temp_vstring num(double x);
+temp_vstring num1(double x);
+temp_vstring str(double x);
 long len(vstring s);
-long instr(long start, vstring sin, vstring s);
-long rinstr(vstring string1, vstring string2);
-long ascii_(vstring c);
-double val(vstring s);
+long instr(long start, const char *string1, const char *string2);
+long rinstr(const char *string1, const char *string2);
+long ascii_(const char *c);
+double val(const char *s);
 
 /* Emulation of Progress 4GL string functions */
-vstring entry(long element, vstring list);
-long lookup(vstring expression, vstring list);
-long numEntries(vstring list);
-long entryPosition(long element, vstring list);
+temp_vstring entry(long element, const char *list);
+long lookup(const char *expression, const char *list);
+long numEntries(const char *list);
+long entryPosition(long element, const char *list);
 
 /* Routines may/may not be written (lowest priority):
 vstring place$(vstring sout);

--- a/src/mmvstr.h
+++ b/src/mmvstr.h
@@ -131,7 +131,7 @@ for memory allocation. New vstrings should always be constructed from the
 `vstringdef` macro. */
 typedef char* vstring;
 
-/* A vstring allocated in temporary storage. These strings will be deallocated
+/* A vstring is allocated in temporary storage. These strings will be deallocated
   after the next call to `let`.
 
   A `temp_vstring` should never be used as the first argument of a `let`.


### PR DESCRIPTION
The memory management pays a lot of attention to whether a returned `vstring` is to be deallocated by the caller, or it is a temporary value which is automatically deallocated by the next call to `let`. This commit makes it clear which is which by using the return type of the function (where `temp_vstring` is a typedef for `vstring`.)

Similarly, a `vstring` is not actually the same as a C `char *`: a `vstring` can be viewed as a `char *`, but it also has a control block at negative addresses which can be used to reallocate the string. Most functions that take `const vstring` are in fact `const char *` methods, so the type signatures have been changed to reflect this. Similarly, many input arguments can be `const`, which is a C99 thing (which was already in the codebase), so use it more consistently.

(This is one part of a big commit that I'm breaking into pieces for ease of review.)