### PR TITLE
add macros for alloc/free of string types

### DIFF
--- a/src/metamath.c
+++ b/src/metamath.c
@@ -758,13 +758,17 @@ void command(int argc, char *argv[]) {
   long stmt, step;
   int subType = 0;
 #define SYNTAX 4
-  vstring str1 = "", str2 = "", str3 = "", str4 = "", str5= "";
+  vstring_def(str1);
+  vstring_def(str2);
+  vstring_def(str3);
+  vstring_def(str4);
+  vstring_def(str5);
   nmbrString *nmbrTmpPtr; /* Pointer only; not allocated directly */
-  nmbrString *nmbrTmp = NULL_NMBRSTRING;
-  nmbrString *nmbrSaveProof = NULL_NMBRSTRING;
+  nmbrString_def(nmbrTmp);
+  nmbrString_def(nmbrSaveProof);
   /*pntrString *pntrTmpPtr;*/ /* Pointer only; not allocated directly */
-  pntrString *pntrTmp = NULL_PNTRSTRING;
-  pntrString *expandedProof = NULL_PNTRSTRING;
+  pntrString_def(pntrTmp);
+  pntrString_def(expandedProof);
   flag tmpFlag;
 
   /* proofSavedFlag tells us there was at least one
@@ -794,21 +798,21 @@ void command(int argc, char *argv[]) {
   flag saveFlag; /* Flag to save in source */
   flag fastFlag; /* Flag for SAVE PROOF.../FAST */
   long indentation; /* Number of spaces to indent proof */
-  vstring labelMatch = ""; /* SHOW PROOF <label> argument */
+  vstring_def(labelMatch); /* SHOW PROOF <label> argument */
 
   flag axiomFlag; /* For SHOW TRACE_BACK */
   flag treeFlag; /* For SHOW TRACE_BACK */
   flag countStepsFlag; /* For SHOW TRACE_BACK */
   flag matchFlag; /* For SHOW TRACE_BACK */
-  vstring matchList = "";  /* For SHOW TRACE_BACK */
-  vstring traceToList = ""; /* For SHOW TRACE_BACK */
+  vstring_def(matchList);  /* For SHOW TRACE_BACK */
+  vstring_def(traceToList); /* For SHOW TRACE_BACK */
   flag recursiveFlag; /* For SHOW USAGE */
   long fromLine, toLine; /* For TYPE, SEARCH */
   flag joinFlag; /* For SEARCH */
   long searchWindow; /* For SEARCH */
   FILE *type_fp; /* For TYPE, SEARCH */
   long maxEssential; /* For MATCH */
-  nmbrString *essentialFlags = NULL_NMBRSTRING;
+  nmbrString_def(essentialFlags);
                                             /* For ASSIGN/IMPROVE FIRST/LAST */
   long improveDepth; /* For IMPROVE */
   flag searchAlg; /* For IMPROVE */
@@ -821,7 +825,7 @@ void command(int argc, char *argv[]) {
   flag commentOnlyFlag; /* For SHOW STATEMENT */
   flag briefFlag; /* For SHOW STATEMENT */
   flag linearFlag; /* For SHOW LABELS */
-  vstring bgcolor = ""; /* For SHOW STATEMENT definition list */
+  vstring_def(bgcolor); /* For SHOW STATEMENT definition list */
 
   flag verboseMode, mayGrowFlag /*, noDistinctFlag*/; /* For MINIMIZE_WITH */
   long prntStatus; /* For MINIMIZE_WITH */
@@ -831,13 +835,13 @@ void command(int argc, char *argv[]) {
   long thisMathboxStartStmt; /* For MINIMIZE_WITH */
   flag forwFlag; /* For MINIMIZE_WITH */
   long forbidMatchPos;  /* For MINIMIZE_WITH */
-  vstring forbidMatchList = "";  /* For MINIMIZE_WITH */
+  vstring_def(forbidMatchList);  /* For MINIMIZE_WITH */
   long noNewAxiomsMatchPos;  /* For NO_NEW_AXIOMS_FROM */
-  vstring noNewAxiomsMatchList = "";  /* For NO_NEW_AXIOMS_FROM */
+  vstring_def(noNewAxiomsMatchList);  /* For NO_NEW_AXIOMS_FROM */
   long allowNewAxiomsMatchPos;  /* For NO_NEW_AXIOMS_FROM */
-  vstring allowNewAxiomsMatchList = "";  /* For NO_NEW_AXIOMS_FROM */
-  vstring traceProofFlags = ""; /* For NO_NEW_AXIOMS_FROM */
-  vstring traceTrialFlags = ""; /* For NO_NEW_AXIOMS_FROM */
+  vstring_def(allowNewAxiomsMatchList);  /* For NO_NEW_AXIOMS_FROM */
+  vstring_def(traceProofFlags); /* For NO_NEW_AXIOMS_FROM */
+  vstring_def(traceTrialFlags); /* For NO_NEW_AXIOMS_FROM */
   flag overrideFlag; /* For discouraged statement /OVERRIDE */
 
   struct pip_struct saveProofForReverting = {
@@ -872,17 +876,19 @@ void command(int argc, char *argv[]) {
   FILE *list1_fp;
   FILE *list2_fp;
   FILE *list3_fp;
-  vstring list2_fname = "", list2_ftmpname = "";
-  vstring list3_ftmpname = "";
-  vstring oldstr = "", newstr = "";
+  vstring_def(list2_fname);
+  vstring_def(list2_ftmpname);
+  vstring_def(list3_ftmpname);
+  vstring_def(oldstr);
+  vstring_def(newstr);
   long lines, changedLines, oldChangedLines, twoMatches, p1, p2;
   long firstChangedLine;
   flag cmdMode, changedFlag, outMsgFlag;
   double sum;
-  vstring bufferedLine = "";
-  vstring tagStartMatch = "";  /* For TAG command */
+  vstring_def(bufferedLine);
+  vstring_def(tagStartMatch);  /* For TAG command */
   long tagStartCount = 0;      /* For TAG command */
-  vstring tagEndMatch = "";    /* For TAG command */
+  vstring_def(tagEndMatch);    /* For TAG command */
   long tagEndCount = 0;        /* For TAG command */
   long tagStartCounter = 0;    /* For TAG command */
   long tagEndCounter = 0;      /* For TAG command */
@@ -918,40 +924,40 @@ void command(int argc, char *argv[]) {
     g_errorCount = 0; /* Reset error count before each read or proof parse. */
 
     /* Deallocate stuff that may have been used in previous pass */
-    let(&str1,"");
-    let(&str2,"");
-    let(&str3,"");
-    let(&str4,"");
-    let(&str5,"");
-    nmbrLet(&nmbrTmp, NULL_NMBRSTRING);
-    pntrLet(&pntrTmp, NULL_PNTRSTRING);
-    nmbrLet(&nmbrSaveProof, NULL_NMBRSTRING);
-    nmbrLet(&essentialFlags, NULL_NMBRSTRING);
+    free_vstring(str1);
+    free_vstring(str2);
+    free_vstring(str3);
+    free_vstring(str4);
+    free_vstring(str5);
+    free_nmbrString(nmbrTmp);
+    free_pntrString(pntrTmp);
+    free_nmbrString(nmbrSaveProof);
+    free_nmbrString(essentialFlags);
     j = nmbrLen(g_rawArgNmbr);
     if (j != g_rawArgs) bug(1110);
     j = pntrLen(g_rawArgPntr);
     if (j != g_rawArgs) bug(1111);
     g_rawArgs = 0;
     for (i = 0; i < j; i++) let((vstring *)(&g_rawArgPntr[i]), "");
-    pntrLet(&g_rawArgPntr, NULL_PNTRSTRING);
-    nmbrLet(&g_rawArgNmbr, NULL_NMBRSTRING);
+    free_pntrString(g_rawArgPntr);
+    free_nmbrString(g_rawArgNmbr);
     j = pntrLen(g_fullArg);
     for (i = 0; i < j; i++) let((vstring *)(&g_fullArg[i]),"");
-    pntrLet(&g_fullArg,NULL_PNTRSTRING);
+    free_pntrString(g_fullArg);
     j = pntrLen(expandedProof);
     if (j) {
       for (i = 0; i < j; i++) {
         let((vstring *)(&expandedProof[i]),"");
       }
-     pntrLet(&expandedProof,NULL_PNTRSTRING);
+     free_pntrString(expandedProof);
     }
 
-    let(&list2_fname, "");
-    let(&list2_ftmpname, "");
-    let(&list3_ftmpname, "");
-    let(&oldstr, "");
-    let(&newstr, "");
-    let(&labelMatch, "");
+    free_vstring(list2_fname);
+    free_vstring(list2_ftmpname);
+    free_vstring(list3_ftmpname);
+    free_vstring(oldstr);
+    free_vstring(newstr);
+    free_vstring(labelMatch);
     /* (End of space deallocation) */
 
     g_midiFlag = 0; /* Initialize here in case SHOW PROOF exits early */
@@ -977,7 +983,7 @@ void command(int argc, char *argv[]) {
       }
     }
 
-    let(&g_commandLine,""); /* Deallocate previous contents */
+    free_vstring(g_commandLine); /* Deallocate previous contents */
 
     if (!commandProcessedFlag && argc > 1 && argsProcessed < argc - 1
         && g_commandFileNestingLevel == 0) {
@@ -1245,10 +1251,10 @@ void command(int argc, char *argv[]) {
         memFreePoolPurge(0);
         eraseSource();
         freeData(); /* Call AFTER eraseSource()(->initBigArrays->malloc) */
-        let(&g_commandPrompt,"");
-        let(&g_commandLine,"");
-        let(&g_input_fn,"");
-        let(&g_contributorName, "");
+        free_vstring(g_commandPrompt);
+        free_vstring(g_commandLine);
+        free_vstring(g_input_fn);
+        free_vstring(g_contributorName);
 
         return; /* Exit from program */
       }
@@ -1324,7 +1330,7 @@ void command(int argc, char *argv[]) {
           let(&list2_fname, left(list2_fname, (long)(strlen(list2_fname)) - 2));
           print2("The output file will be called %s.\n", list2_fname);
         }
-        let(&list2_ftmpname, "");
+        free_vstring(list2_ftmpname);
         list2_ftmpname = fGetTmpName("zz~tools");
         list2_fp = fSafeOpen(list2_ftmpname, "w", 0/*noVersioningFlag*/);
         if (!list2_fp) continue; /* Couldn't open it (error msg was provided) */
@@ -1391,13 +1397,13 @@ void command(int argc, char *argv[]) {
             outMsgFlag = 1;
             break;
           case BUILD_MODE:
-            let(&str4, "");
+            free_vstring(str4);
             outMsgFlag = 1;
             break;
           case MATCH_MODE:
             outMsgFlag = 1;
         } /* End switch */
-        let(&bufferedLine, "");
+        free_vstring(bufferedLine);
         /*
         while (linput(list1_fp, NULL, &str1)) {
         */
@@ -1405,7 +1411,7 @@ void command(int argc, char *argv[]) {
           if (bufferedLine[0]) {
             /* Get input from buffered line (from rejected \n replacement) */
             let(&str1, bufferedLine);
-            let(&bufferedLine, "");
+            free_vstring(bufferedLine);
           } else {
             if (!linput(list1_fp, NULL, &str1)) break;
           }
@@ -1470,7 +1476,7 @@ void command(int argc, char *argv[]) {
                   if (instr(1, cat(str1, "\\n", bufferedLine, NULL),
                       g_fullArg[2])) {
                     let(&str2, cat(str1, "\\n", bufferedLine, NULL));
-                    let(&bufferedLine, "");
+                    free_vstring(bufferedLine);
                   } else {
                     k = 0; /* No match - leave bufferedLine for next pass */
                   }
@@ -1653,8 +1659,8 @@ void command(int argc, char *argv[]) {
         fclose(list2_fp);
         fSafeRename(list2_ftmpname, list2_fname);
         /* Deallocate string memory */
-        let(&tagStartMatch, "");
-        let(&tagEndMatch, "");
+        free_vstring(tagStartMatch);
+        free_vstring(tagEndMatch);
         continue;
       } /* end if cmdMode for ADD, etc. */
 
@@ -1677,7 +1683,7 @@ void command(int argc, char *argv[]) {
           let(&list2_fname, left(list2_fname, (long)strlen(list2_fname) - 2));
           print2("The output file will be called %s.\n", list2_fname);
         }
-        let(&list2_ftmpname, "");
+        free_vstring(list2_ftmpname);
         list2_ftmpname = fGetTmpName("zz~tools");
         list2_fp = fSafeOpen(list2_ftmpname, "w", 0/*noVersioningFlag*/);
         if (!list2_fp) continue; /* Couldn't open it (error msg was provided) */
@@ -1784,7 +1790,7 @@ void command(int argc, char *argv[]) {
 
         /* Deallocate memory */
         for (i = 0; i < lines; i++) let((vstring *)(&pntrTmp[i]), "");
-        pntrLet(&pntrTmp,NULL_PNTRSTRING);
+        free_pntrString(pntrTmp);
 
         fclose(list1_fp);
         fclose(list2_fp);
@@ -1797,7 +1803,7 @@ void command(int argc, char *argv[]) {
         list2_fp = fSafeOpen(g_fullArg[2], "r", 0/*noVersioningFlag*/);
         if (!list1_fp) continue; /* Couldn't open it (error msg was provided) */
         if (!list2_fp) continue; /* Couldn't open it (error msg was provided) */
-        let(&list3_ftmpname, "");
+        free_vstring(list3_ftmpname);
         list3_ftmpname = fGetTmpName("zz~tools");
         list3_fp = fSafeOpen(list3_ftmpname, "w", 0/*noVersioningFlag*/);
         if (!list3_fp) continue; /* Couldn't open it (error msg was provided) */
@@ -1807,13 +1813,13 @@ void command(int argc, char *argv[]) {
         j = 0; /* 1st line flag */
         let(&str3, "");
         while (1) {
-          let(&str1, "");
+          free_vstring(str1);
           if (p1) {
             p1 = linput(list1_fp, NULL, &str1);
             if (p1) p++;
             else let(&str1, "");
           }
-          let(&str2, "");
+          free_vstring(str2);
           if (p2) {
             p2 = linput(list2_fp, NULL, &str2);
             if (p2) q++;
@@ -1954,7 +1960,7 @@ void command(int argc, char *argv[]) {
 "?The revision tag must be of the form /*nn*/ or /*#nn*/.  Please try again.\n");
           continue;
         }
-        let(&list3_ftmpname, "");
+        free_vstring(list3_ftmpname);
         list3_ftmpname = fGetTmpName("zz~tools");
         list3_fp = fSafeOpen(list3_ftmpname, "w", 0/*noVersioningFlag*/);
         if (!list3_fp) continue; /* Couldn't open it (error msg was provided) */
@@ -1967,7 +1973,7 @@ void command(int argc, char *argv[]) {
       }
 
       if (cmdMatches("COPY") || cmdMatches("C")) {
-        let(&list2_ftmpname, "");
+        free_vstring(list2_ftmpname);
         list2_ftmpname = fGetTmpName("zz~tools");
         list2_fp = fSafeOpen(list2_ftmpname, "w", 0/*noVersioningFlag*/);
         if (!list2_fp) continue; /* Couldn't open it (error msg was provided) */
@@ -2097,7 +2103,7 @@ void command(int argc, char *argv[]) {
           );
       g_sourceChanged = 0;
 
-      let(&str1, ""); /* Deallocate */
+      free_vstring(str1); /* Deallocate */
       continue;
     } /* End of WRITE SOURCE */
 
@@ -2248,20 +2254,20 @@ void command(int argc, char *argv[]) {
             continue;
           }
 
-          let(&str2, "");
+          free_vstring(str2);
           str2 = getContrib(stmt, MOST_RECENT_DATE);
 
           /* See if the date comment matches */
           if (!strcmp(str2, str1)) {
             /* We have a match, so increment the match count */
             n++;
-            let(&str3, "");
+            free_vstring(str3);
             str3 = getDescription(stmt);
-            let(&str4, "");
+            free_vstring(str4);
             str4 = pinkHTML(stmt); /* Get little pink number */
             /* Output the description comment */
             /* Break up long lines for text editors with printLongLine */
-            let(&g_printString, "");
+            free_vstring(g_printString);
             g_outputToString = 1;
             print2("\n"); /* Blank line for HTML human readability */
             printLongLine(cat(
@@ -2299,7 +2305,7 @@ void command(int argc, char *argv[]) {
             g_outputToString = 1; /* Restore after printTexComment */
 
             /* Get HTML hypotheses => assertion */
-            let(&str4, "");
+            free_vstring(str4);
             str4 = getTexOrHtmlHypAndAssertion(stmt);
             printLongLine(cat("</TD></TR><TR",
 
@@ -2324,7 +2330,7 @@ void command(int argc, char *argv[]) {
 
             g_outputToString = 0;
             fprintf(list2_fp, "%s", g_printString);
-            let(&g_printString, "");
+            free_vstring(g_printString);
 
             if (n >= i /*RECENT_COUNT*/) break; /* We're done */
 
@@ -2372,7 +2378,7 @@ void command(int argc, char *argv[]) {
 
             g_outputToString = 0;
             fprintf(list2_fp, "%s", g_printString);
-            let(&g_printString, "");
+            free_vstring(g_printString);
 
           }
         } /* Next stmt - statement number */
@@ -2494,9 +2500,9 @@ void command(int argc, char *argv[]) {
       } /* next i */
       if (str2[0]) {
         print2("%s\n", str2);
-        let(&str2, "");
+        free_vstring(str2);
       }
-      let(&str1, "");
+      free_vstring(str1);
       continue;
     }
 
@@ -2523,14 +2529,14 @@ void command(int argc, char *argv[]) {
       }
       g_showStatement = s; /* Update for future defaults */
 
-      let(&str1, "");
+      free_vstring(str1);
       str1 = outputStatement(g_showStatement, /* cleanFlag */
           0 /* reformatFlag */);
       let(&str1,edit(str1,128)); /* Trim trailing spaces */
       if (str1[strlen(str1)-1] == '\n') let(&str1, left(str1,
           (long)strlen(str1) - 1));
       printLongLine(str1, "", "");
-      let(&str1,""); /* Deallocate vstring */
+      free_vstring(str1); /* Deallocate vstring */
       continue;
     } /* if (cmdMatches("SHOW SOURCE")) */
 
@@ -2763,7 +2769,7 @@ void command(int argc, char *argv[]) {
                   /* Output each token only once in case of multiple decl. */
                   if (!instr(1, str3, cat(" ", str1, " ", NULL))) {
                     let(&str3, cat(str3, " ", str1, " ", NULL));
-                    let(&str2, "");
+                    free_vstring(str2);
                     str2 = tokenToTex(g_MathToken[(g_Statement[i].mathString)[j]
                         ].tokenName, i/*stmt# for error msgs*/);
                     /* Skip any tokens (such as |- in QL Explorer) that may be suppressed */
@@ -2800,13 +2806,13 @@ void command(int argc, char *argv[]) {
                 } /* next j */
                 /* Close out the string now to prevent memory overflow */
                 fprintf(g_texFilePtr, "%s", g_printString);
-                let(&g_printString, "");
+                free_vstring(g_printString);
                 break;
               case -1: /* Falls through to next case */
               case 0:
-                let(&str1, "");
+                free_vstring(str1);
                 if (s == 0 || g_briefHtmlFlag) {
-                  let(&str1, "");
+                  free_vstring(str1);
                   /* Get HTML hypotheses => assertion */
                   str1 = getTexOrHtmlHypAndAssertion(i);
                   let(&str1, cat(str1, "</TD></TR>", NULL));
@@ -2828,7 +2834,7 @@ void command(int argc, char *argv[]) {
                   let(&str1, cat(str2, " ", str1, NULL));
                 } else {
                   /* Get little pink (or rainbow-colored) number */
-                  let(&str4, "");
+                  free_vstring(str4);
                   str4 = pinkHTML(i);
                   let(&str2, cat("<TR BGCOLOR=", bgcolor,
                       " ALIGN=LEFT><TD><A HREF=\"",
@@ -2851,7 +2857,7 @@ void command(int argc, char *argv[]) {
                 } else {
                   /* Theorems are listed w/ description; otherwise file is too
                      big for convenience */
-                  let(&str1, "");
+                  free_vstring(str1);
                   str1 = getDescription(i);
                   if (strlen(str1) > 29)
                     let(&str1, cat(left(str1, 26), "...", NULL));
@@ -2860,12 +2866,12 @@ void command(int argc, char *argv[]) {
                 }
                 /* Close out the string now to prevent overflow */
                 fprintf(g_texFilePtr, "%s", g_printString);
-                let(&g_printString, "");
+                free_vstring(g_printString);
                 break;
             } /* end switch */
           } /* next i (statement number) */
           g_outputToString = 0;  /* closing will write out the string */
-          let(&bgcolor, ""); /* Deallocate (to improve fragmentation) */
+          free_vstring(bgcolor); /* Deallocate (to improve fragmentation) */
 
         } else { /* s > 0 */
 
@@ -2894,7 +2900,7 @@ void command(int argc, char *argv[]) {
         printTexTrailer(1 /*texHeaderFlag*/);
         fclose(g_texFilePtr);
         g_texFileOpenFlag = 0;
-        let(&g_texFileName,"");
+        free_vstring(g_texFileName);
 
       } /* next s */
 
@@ -2964,7 +2970,7 @@ void command(int argc, char *argv[]) {
           fprintf(g_texFilePtr, "%s", str1);
 
           /* Print hypothesis */
-          let(&str1, ""); /* Free any previous allocation to str1 */
+          free_vstring(str1); /* Free any previous allocation to str1 */
           /* getTexLongMath does not return a temporary allocation; must
              assign str1 directly, not with let().  It will be deallocated
              with the next let(&str1,...). */
@@ -2983,7 +2989,7 @@ void command(int argc, char *argv[]) {
         let(&str1, "<FONT SIZE=\"+3\">");
         fprintf(g_texFilePtr, "%s", str1);
 
-        let(&str1, ""); /* Free any previous allocation to str1 */
+        free_vstring(str1); /* Free any previous allocation to str1 */
         /* getTexLongMath does not return a temporary allocation */
         str1 = getTexLongMath(g_Statement[s].mathString, s);
         fprintf(g_texFilePtr, "%s", str1);
@@ -2994,9 +3000,9 @@ void command(int argc, char *argv[]) {
 
       fclose(g_texFilePtr);
       g_texFileOpenFlag = 0;
-      let(&g_texFileName,"");
-      let(&str1,"");
-      let(&str2,"");
+      free_vstring(g_texFileName);
+      free_vstring(str1);
+      free_vstring(str2);
 
       continue;
     } /* if (cmdMatches("SHOW STATEMENT") && switchPos("/ MNEMONICS")) */
@@ -3285,8 +3291,8 @@ void command(int argc, char *argv[]) {
             "See HELP SHOW TRACE_BACK for matching rules.", NULL), "", " ");
       }
 
-      let(&matchList, ""); /* Deallocate memory */
-      let(&traceToList, ""); /* Deallocate memory */
+      free_vstring(matchList); /* Deallocate memory */
+      free_vstring(traceToList); /* Deallocate memory */
       continue;
     } /* if (cmdMatches("SHOW TRACE_BACK")) */
 
@@ -3320,7 +3326,7 @@ void command(int argc, char *argv[]) {
         j = switchPos("/ DIRECT");
         if (j) recursiveFlag = 0; /* Direct references only */
 
-        let(&str1, "");
+        free_vstring(str1);
         str1 = traceUsage(g_showStatement,
             recursiveFlag,
             0 /* cutoffStmt */);
@@ -3383,7 +3389,7 @@ void command(int argc, char *argv[]) {
             }
           }
           if (strlen(str3) > 1) print2("%s\n", str3);
-          let(&str3, "");
+          free_vstring(str3);
         } else {
           print2("  (None)\n");
         } /* if (k != 0) */
@@ -3719,7 +3725,7 @@ void command(int argc, char *argv[]) {
             to avoid premature output */
           if (!nmbrElementIn(1, nmbrSaveProof, -(long)'?')) {
             /* Add a "(Contributed by...)" date if it isn't there */
-            let(&str2, "");
+            free_vstring(str2);
             str2 = getContrib(outStatement, CONTRIBUTOR);
             if (str2[0] == 0) { /* The is no contributor, so add one */
 
@@ -3766,9 +3772,9 @@ void command(int argc, char *argv[]) {
                 let(&str3, cat(left(str3, i - 1), str4, right(str3, i), NULL));
                 if (g_Statement[outStatement].labelSectionChanged == 1) {
                   /* Deallocate old comment if not original source */
-                  let(&str4, ""); /* Deallocate any previous str4 content */
+                  free_vstring(str4); /* Deallocate any previous str4 content */
                   str4 = g_Statement[outStatement].labelSectionPtr;
-                  let(&str4, ""); /* Deallocate the old content */
+                  free_vstring(str4); /* Deallocate the old content */
                 }
                 /* Set flag that this is not the original source */
                 g_Statement[outStatement].labelSectionChanged = 1;
@@ -3800,9 +3806,9 @@ void command(int argc, char *argv[]) {
             let(&g_printString, cat("\n", g_printString, NULL));
             if (g_Statement[outStatement].proofSectionChanged == 1) {
               /* Deallocate old proof if not original source */
-              let(&str1, ""); /* Deallocate any previous str1 content */
+              free_vstring(str1); /* Deallocate any previous str1 content */
               str1 = g_Statement[outStatement].proofSectionPtr;
-              let(&str1, ""); /* Deallocate the proof section */
+              free_vstring(str1); /* Deallocate the proof section */
             }
             /* Set flag that this is not the original source */
             g_Statement[outStatement].proofSectionChanged = 1;
@@ -3855,7 +3861,7 @@ void command(int argc, char *argv[]) {
                 /* "\" to clip out ends above this line.\n",NULL)); */
                 "\" (", str((double)l), " bytes) ends above this line.\n", NULL));
           } /* End if saveFlag */
-          nmbrLet(&nmbrSaveProof, NULL_NMBRSTRING);
+          free_nmbrString(nmbrSaveProof);
           if (pipFlag) break; /* Only one iteration for NEW_PROOF stuff */
           continue;  /* to next s iteration */
         } /* end if (switchPos("/ PACKED") || switchPos("/ NORMAL") ||
@@ -3892,7 +3898,7 @@ void command(int argc, char *argv[]) {
              mode before starting its output, so we must put out the
              g_printString ourselves here */
           fprintf(g_texFilePtr, "%s", g_printString);
-          let(&g_printString, ""); /* We'll clr it anyway */
+          free_vstring(g_printString); /* We'll clr it anyway */
         } else { /* !texFlag */
           /* Terminal output - display the statement if wildcard is used */
           if (!pipFlag) {
@@ -3945,7 +3951,7 @@ void command(int argc, char *argv[]) {
               print2("\n");
               g_outputToString = 0;
               fprintf(g_texFilePtr, "%s", g_printString);
-              let(&g_printString, "");
+              free_vstring(g_printString);
             } else {
             }
           } else { /* g_htmlFlag */
@@ -4020,7 +4026,7 @@ void command(int argc, char *argv[]) {
       print2("Result:  %s\n", nmbrCvtRToVString(nmbrTmpPtr,
                 0, /*explicitTargets*/
                 0 /*statemNum, used only if explicitTargets*/));
-      nmbrLet(&nmbrTmpPtr, NULL_NMBRSTRING);
+      free_nmbrString(nmbrTmpPtr);
 
       continue;
     }
@@ -4632,7 +4638,7 @@ void command(int argc, char *argv[]) {
          for user */
       autoUnify((char)p); /* 0 means no "congrats" message */
 
-      nmbrLet(&nmbrTmpPtr, NULL_NMBRSTRING); /* Deallocate memory */
+      free_nmbrString(nmbrTmpPtr); /* Deallocate memory */
 
       n = nmbrLen(g_ProofInProgress.proof); /* New proof length */
       if (nmbrElementIn(1, g_ProofInProgress.proof, -(long)'?')) {
@@ -4792,7 +4798,7 @@ void command(int argc, char *argv[]) {
         if (q > 1) deleteSubProof(s - 1);
         addSubProof(nmbrTmpPtr, s - q);
         assignKnownSteps(s - q, nmbrLen(nmbrTmpPtr));
-        nmbrLet(&nmbrTmpPtr, NULL_NMBRSTRING);
+        free_nmbrString(nmbrTmpPtr);
 
         n = nmbrLen(g_ProofInProgress.proof); /* New proof length */
         if (m == n) {
@@ -4887,7 +4893,7 @@ void command(int argc, char *argv[]) {
             /* Improve only subproofs with unknown steps */
             if (!nmbrElementIn(1, nmbrTmp, -(long)'?')) continue;
 
-            nmbrLet(&nmbrTmp, NULL_NMBRSTRING); /* No longer needed - dealloc */
+            free_nmbrString(nmbrTmp); /* No longer needed - dealloc */
 
             /* Check dummy variable status of step */
             dummyVarIsoFlag = checkDummyVarIsolation(s - 1);
@@ -4941,7 +4947,7 @@ void command(int argc, char *argv[]) {
                 nmbrLen(nmbrTmpPtr), s);
             if (nmbrLen(nmbrTmpPtr) || q != 1) n = s - q + 1;
                                                /* Save earliest step changed */
-            nmbrLet(&nmbrTmpPtr, NULL_NMBRSTRING);
+            free_nmbrString(nmbrTmpPtr);
             g_proofChangedFlag = 1;
             s = s - q + 1; /* Adjust step position to account for deleted subpr */
           } /* Next step s */
@@ -5263,7 +5269,7 @@ void command(int argc, char *argv[]) {
                     "", /*traceToList*/
                     &traceProofFlags, /* y/n list of flags */
                     &nmbrTmp /* unproved list - ignored */);
-                nmbrLet(&nmbrTmp, NULL_NMBRSTRING); /* Discard */
+                free_nmbrString(nmbrTmp); /* Discard */
 
                 /* Restore the SAVEd proof */
                 g_Statement[g_proveStatement].proofSectionPtr
@@ -5273,13 +5279,13 @@ void command(int argc, char *argv[]) {
                 g_Statement[g_proveStatement].proofSectionChanged
                     = saveZappedProofSectionChanged;
               }
-              let(&traceTrialFlags, "");
+              free_vstring(traceTrialFlags);
               traceProofWork(k, /* The trial statement */
                   1 /*essentialFlag*/,
                   "", /*traceToList*/
                   &traceTrialFlags, /* Y/N list of flags */
                   &nmbrTmp /* unproved list - ignored */);
-              nmbrLet(&nmbrTmp, NULL_NMBRSTRING); /* Discard */
+              free_nmbrString(nmbrTmp); /* Discard */
               j = 1; /* 1 = ok to use trial statement */
               for (i = 1; i < g_proveStatement; i++) {
                 if (g_Statement[i].type != (char)a_) continue; /* Not $a */
@@ -5391,7 +5397,7 @@ void command(int argc, char *argv[]) {
               j = instr(1, g_printString,
                   "There is a disjoint variable ($d) violation");
               g_outputToString = 0; /* Restore to normal output */
-              let(&g_printString, ""); /* Clear out the stored error messages */
+              free_vstring(g_printString); /* Clear out the stored error messages */
               cleanWrkProof(); /* Deallocate verifyProof storage */
               g_Statement[g_proveStatement].proofSectionPtr
                   = saveZappedProofSectionPtr;
@@ -5527,25 +5533,25 @@ void command(int argc, char *argv[]) {
             g_Statement[g_proveStatement].labelName);
       }
 
-      let(&str1, ""); /* Deallocate memory */
-      nmbrLet(&nmbrSaveProof, NULL_NMBRSTRING); /* Deallocate memory */
+      free_vstring(str1); /* Deallocate memory */
+      free_nmbrString(nmbrSaveProof); /* Deallocate memory */
 
       /* Clear these Y/N trace strings unconditionally since new axioms are no
         longer  allowed by default, so they may become set regardless of
         qualifiers */
-      let(&traceProofFlags, ""); /* Deallocate memory */
-      let(&traceTrialFlags, ""); /* Deallocate memory */
+      free_vstring(traceProofFlags); /* Deallocate memory */
+      free_vstring(traceTrialFlags); /* Deallocate memory */
 
       if (allowNewAxiomsMatchList[0]) { /* User provided /NO_NEW_AXIOMS_FROM list */
-        let(&allowNewAxiomsMatchList, ""); /* Deallocate memory */
+        free_vstring(allowNewAxiomsMatchList); /* Deallocate memory */
       }
 
       if (noNewAxiomsMatchList[0]) { /* User provided /ALLOW_NEW_AXIOMS list */
-        let(&noNewAxiomsMatchList, ""); /* Deallocate memory */
+        free_vstring(noNewAxiomsMatchList); /* Deallocate memory */
       }
 
       if (forbidMatchList[0]) { /* User provided a /FORBID list */
-        let(&forbidMatchList, ""); /* Deallocate memory */
+        free_vstring(forbidMatchList); /* Deallocate memory */
       }
 
       deallocProofStruct(&saveProofForReverting); /* Deallocate memory */
@@ -5602,8 +5608,8 @@ void command(int argc, char *argv[]) {
       } else {
         print2("No expansion occurred.  The proof was not changed.\n");
       }
-      nmbrLet(&nmbrSaveProof, NULL_NMBRSTRING);
-      nmbrLet(&nmbrTmp, NULL_NMBRSTRING);
+      free_nmbrString(nmbrSaveProof);
+      free_nmbrString(nmbrTmp);
       continue;
     } /* EXPAND */
 
@@ -5892,12 +5898,12 @@ void command(int argc, char *argv[]) {
         if (!matchesList(g_Statement[i].labelName, g_fullArg[1], '*', '?'))
           continue;
         if (n) { /* COMMENTS switch */
-          let(&str2, "");
+          free_vstring(str2);
           str2 = getDescription(i); /* str2 must be deallocated here */
           /* Strip linefeeds and reduce spaces; cvt to uppercase */
           j = instr(1, edit(str2, 4 + 8 + 16 + 128 + 32), str1);
           if (!j) { /* No match */
-            let(&str2, "");
+            free_vstring(str2);
             continue;
           }
           /* Strip linefeeds and reduce spaces */
@@ -5923,7 +5929,7 @@ void command(int argc, char *argv[]) {
           }
           print2("%s\n", cat(str((double)i), " ", g_Statement[i].labelName, " $",
               chr(g_Statement[i].type), " \"", str3, "\"", NULL));
-          let(&str2, "");
+          free_vstring(str2);
         } else { /* No COMMENTS switch */
           let(&str2,nmbrCvtMToVString(g_Statement[i].mathString));
 
@@ -6119,7 +6125,7 @@ void command(int argc, char *argv[]) {
         print2("Root directory was changed from \"%s\" to \"%s\"\n",
             str1, g_rootDirectory);
       }
-      let(&str1, "");
+      free_vstring(str1);
       continue;
     }
 
@@ -6175,7 +6181,7 @@ void command(int argc, char *argv[]) {
           fclose(g_logFilePtr);
           g_logFileOpenFlag = 0;
         }
-        let(&g_logFileName,"");
+        free_vstring(g_logFileName);
         continue;
     }
 
@@ -6225,7 +6231,7 @@ void command(int argc, char *argv[]) {
         fclose(g_texFilePtr);
         g_texFileOpenFlag = 0;
       }
-      let(&g_texFileName,"");
+      free_vstring(g_texFileName);
       continue;
     }
 
@@ -6310,7 +6316,7 @@ void command(int argc, char *argv[]) {
       for (i = 0; i < searchWindow; i++) {
         let((vstring *)(&pntrTmp[i]), "");
       }
-      pntrLet(&pntrTmp, NULL_PNTRSTRING);
+      free_pntrString(pntrTmp);
 
 
       continue;

--- a/src/mmcmdl.c
+++ b/src/mmcmdl.c
@@ -17,16 +17,16 @@
 #include "mmword.h"
 
 /* Global variables */
-pntrString *g_rawArgPntr = NULL_PNTRSTRING;
-nmbrString *g_rawArgNmbr = NULL_NMBRSTRING;
+pntrString_def(g_rawArgPntr);
+nmbrString_def(g_rawArgNmbr);
 long g_rawArgs = 0;
-pntrString *g_fullArg = NULL_PNTRSTRING;
-vstring g_fullArgString = ""; /* g_fullArg as one string */
-vstring g_commandPrompt = "";
-vstring g_commandLine = "";
+pntrString_def(g_fullArg);
+vstring_def(g_fullArgString); /* g_fullArg as one string */
+vstring_def(g_commandPrompt);
+vstring_def(g_commandLine);
 long g_showStatement = 0;
-vstring g_logFileName = "";
-vstring g_texFileName = "";
+vstring_def(g_logFileName);
+vstring_def(g_texFileName);
 flag g_PFASmode = 0; /* Proof assistant mode, invoked by PROVE command */
 flag g_queryMode = 0; /* If 1, explicit questions will be asked even if
     a field in the input command line is optional */
@@ -35,18 +35,17 @@ flag g_proofChanged = 0; /* Flag that user made some change to proof in progress
 flag g_commandEcho = 0; /* Echo full command */
 flag g_memoryStatus = 0; /* Always show memory */
 flag g_sourceHasBeenRead = 0; /* 1 if a source file has been read in */
-vstring g_rootDirectory = ""; /* Directory prefix to use for included files */
+vstring_def(g_rootDirectory); /* Directory prefix to use for included files */
 
 
 
-flag processCommandLine(void)
-{
-  vstring defaultArg = "";
-  vstring tmpStr = "";
+flag processCommandLine(void) {
+  vstring_def(defaultArg);
+  vstring_def(tmpStr);
   long i;
   g_queryMode = 0; /* If 1, explicit questions will be asked even if
     a field is optional */
-  pntrLet(&g_fullArg, NULL_PNTRSTRING);
+  free_pntrString(g_fullArg);
 
   if (!g_toolsMode) {
 
@@ -66,7 +65,7 @@ flag processCommandLine(void)
           "MARKUP|MORE|TOOLS|MIDI|<HELP>",
           NULL));
     }
-    if (!getFullArg(0,tmpStr)) {
+    if (!getFullArg(0, tmpStr)) {
       goto pclbad;
     }
 
@@ -163,8 +162,7 @@ flag processCommandLine(void)
             g_input_fn, ">? ", NULL)))
           goto pclbad;
         if (!strcmp(g_input_fn, g_fullArg[2])) {
-          print2(
-          "The input file will be renamed %s~1.\n", g_input_fn);
+          print2("The input file will be renamed %s~1.\n", g_input_fn);
         }
 
         /* Get any switches */
@@ -276,8 +274,8 @@ flag processCommandLine(void)
         if (g_logFileOpenFlag) {
           printLongLine(cat(
               "?Sorry, the log file \"", g_logFileName, "\" is currently open.  ",
-  "Type CLOSE LOG to close the current log if you want to open another one."
-              , NULL), "", " ");
+              "Type CLOSE LOG to close the current log if you want to open another one.",
+              NULL), "", " ");
           goto pclbad;
         }
         if (!getFullArg(2, "* What is the name of logging output file? "))
@@ -679,7 +677,6 @@ flag processCommandLine(void)
 
     } /* End of SEARCH */
 
-
     if (cmdMatches("SAVE")) {
       if (!g_PFASmode) {
         if (!getFullArg(1,
@@ -758,7 +755,6 @@ flag processCommandLine(void)
 
       goto pclgood;
     } /* End of SAVE */
-
 
     if (cmdMatches("PROVE")) {
       if (g_sourceHasBeenRead == 0) {
@@ -883,7 +879,6 @@ flag processCommandLine(void)
       } /* end while */
       goto pclgood;
     } /* end if IMPROVE */
-
 
     if (cmdMatches("MINIMIZE_WITH")) {
       if (!getFullArg(1, "* What statement label? ")) goto pclbad;
@@ -1349,7 +1344,7 @@ flag processCommandLine(void)
           "ADD|DELETE|SUBSTITUTE|S|SWAP|CLEAN|INSERT|BREAK|BUILD|MATCH|SORT|",
           "UNDUPLICATE|DUPLICATE|UNIQUE|REVERSE|RIGHT|PARALLEL|NUMBER|COUNT|",
           "COPY|C|TYPE|T|TAG|UPDATE|BEEP|B|EXIT|QUIT|<HELP>", NULL));
-    if (!getFullArg(0,tmpStr))
+    if (!getFullArg(0, tmpStr))
       goto pclbad;
 
     if (cmdMatches("HELP")) {
@@ -1488,7 +1483,6 @@ flag processCommandLine(void)
       goto pclgood;
     }
 
-
     if (cmdMatches("NUMBER")) {
       if (!getFullArg(1, "* Output file <n.tmp>? "))
         goto pclbad;
@@ -1508,32 +1502,25 @@ flag processCommandLine(void)
       goto pclgood;
     }
 
-
     if (cmdMatches("UPDATE")) {
-      print2(
-"Warning: Do not comment out code - delete it before running UPDATE!  If\n");
-      print2(
-"rerunning UPDATE, do not tamper with \"start/end of deleted section\" comments!\n");
-      print2(
-"Edit out tag on header comment line!  Review the output file!\n");
+      print2("Warning: Do not comment out code - delete it before running UPDATE!  If\n");
+      print2("rerunning UPDATE, do not tamper with \"start/end of deleted section\" comments!\n");
+      print2("Edit out tag on header comment line!  Review the output file!\n");
       if (!getFullArg(1, "& Original (reference) program input file? "))
         goto pclbad;
       if (!getFullArg(2, "& Edited program input file? "))
         goto pclbad;
-      if (!getFullArg(3, cat(
-"* Edited program output file with revisions tagged <",
+      if (!getFullArg(3, cat("* Edited program output file with revisions tagged <",
           g_fullArg[2], ">? ", NULL)))
         goto pclbad;
       if (!strcmp(g_fullArg[2], g_fullArg[3])) {
-        print2(
-"The input file will be renamed %s~1.\n", g_fullArg[2]);
+        print2("The input file will be renamed %s~1.\n", g_fullArg[2]);
       }
       if (!getFullArg(4,
           cat("* Revision tag for added lines </* #",
           str((double)(highestRevision(g_fullArg[1]) + 1)), " */>? ", NULL)))
         goto pclbad;
-      if (!getFullArg(5,
-"# Successive lines required for match (more = better sync) <3>? "))
+      if (!getFullArg(5, "# Successive lines required for match (more = better sync) <3>? "))
         goto pclbad;
       goto pclgood;
     }
@@ -1556,8 +1543,6 @@ flag processCommandLine(void)
     if (cmdMatches("EXIT") || cmdMatches("QUIT")) {
       goto pclgood;
     }
-
-
   } /* if !g_toolsMode ... else ... */
 
   if (cmdMatches("SUBMIT")) {
@@ -1603,13 +1588,11 @@ flag processCommandLine(void)
   /* Should never get here */
 
 
-
  pclgood:
-
   /* Strip off the last g_fullArg if a null argument was added by getFullArg
      in the case when "$" (nothing) is allowed */
   if (!strcmp(g_fullArg[pntrLen(g_fullArg) - 1], chr(3))) {
-    let((vstring *)(&g_fullArg[pntrLen(g_fullArg) - 1]), ""); /* Deallocate */
+    free_vstring(*(vstring *)(&g_fullArg[pntrLen(g_fullArg) - 1])); /* Deallocate */
     pntrLet(&g_fullArg, pntrLeft(g_fullArg, pntrLen(g_fullArg) - 1));
   }
 
@@ -1631,22 +1614,20 @@ flag processCommandLine(void)
 
 
   /* Deallocate memory */
-  let(&defaultArg, "");
-  let(&tmpStr, "");
-  return (1);
+  free_vstring(defaultArg);
+  free_vstring(tmpStr);
+  return 1;
 
  pclbad:
   /* Deallocate memory */
-  let(&defaultArg, "");
-  let(&tmpStr, "");
-  return (0);
-
+  free_vstring(defaultArg);
+  free_vstring(tmpStr);
+  return 0;
 } /* processCommandLine */
 
 
 
-flag getFullArg(long arg, vstring cmdList1)
-{
+flag getFullArg(long arg, vstring cmdList1) {
   /* This function converts the user's abbreviated keyword in
      g_rawArgPntr[arg] to a full, upper-case keyword,
      in g_fullArg[arg], matching
@@ -1659,15 +1640,15 @@ flag getFullArg(long arg, vstring cmdList1)
   /* "$" means a null argument is acceptable; put it in as
      special character chr(3) so it can be recognized */
 
-  pntrString *possCmd = NULL_PNTRSTRING;
+  pntrString_def(possCmd);
   long possCmds, i, j, k, m, p, q;
-  vstring defaultCmd = "";
-  vstring infoStr = "";
-  vstring tmpStr = "";
-  vstring tmpArg = "";
-  vstring errorLine = "";
-  vstring keyword = "";
-  vstring cmdList = "";
+  vstring_def(defaultCmd);
+  vstring_def(infoStr);
+  vstring_def(tmpStr);
+  vstring_def(tmpArg);
+  vstring_def(errorLine);
+  vstring_def(keyword);
+  vstring_def(cmdList);
   FILE *tmpFp;
 
   let(&cmdList,cmdList1); /* In case cmdList1 gets deallocated when it comes
@@ -1835,9 +1816,9 @@ flag getFullArg(long arg, vstring cmdList1)
   if (possCmds > 2) {
     let(&infoStr, "");
     for (i = 0; i < possCmds - 1; i++) {
-      let(&infoStr, cat(infoStr,possCmd[i], ", ", NULL));
+      let(&infoStr, cat(infoStr, possCmd[i], ", ", NULL));
     }
-    let(&infoStr, cat(infoStr, "or ",possCmd[possCmds - 1], NULL));
+    let(&infoStr, cat(infoStr, "or ", possCmd[possCmds - 1], NULL));
   }
 
   /* If the argument has not been entered, prompt the user for it */
@@ -1948,29 +1929,29 @@ flag getFullArg(long arg, vstring cmdList1)
 
   /* Deallocate memory */
   j = pntrLen(possCmd);
-  for (i = 0; i < j; i++) let((vstring *)(&possCmd[i]), "");
-  pntrLet(&possCmd, NULL_PNTRSTRING);
-  let(&defaultCmd, "");
-  let(&infoStr, "");
-  let(&tmpStr, "");
-  let(&tmpArg, "");
-  let(&errorLine, "");
-  let(&keyword, "");
-  let(&cmdList, "");
+  for (i = 0; i < j; i++) free_vstring(*(vstring *)(&possCmd[i]));
+  free_pntrString(possCmd);
+  free_vstring(defaultCmd);
+  free_vstring(infoStr);
+  free_vstring(tmpStr);
+  free_vstring(tmpArg);
+  free_vstring(errorLine);
+  free_vstring(keyword);
+  free_vstring(cmdList);
   return(1);
 
  return0:
   /* Deallocate memory */
   j = pntrLen(possCmd);
-  for (i = 0; i < j; i++) let((vstring *)(&possCmd[i]), "");
-  pntrLet(&possCmd, NULL_PNTRSTRING);
-  let(&defaultCmd, "");
-  let(&infoStr, "");
-  let(&tmpStr, "");
-  let(&tmpArg, "");
-  let(&errorLine, "");
-  let(&keyword, "");
-  let(&cmdList, "");
+  for (i = 0; i < j; i++) free_vstring(*(vstring *)(&possCmd[i]));
+  free_pntrString(possCmd);
+  free_vstring(defaultCmd);
+  free_vstring(infoStr);
+  free_vstring(tmpStr);
+  free_vstring(tmpArg);
+  free_vstring(errorLine);
+  free_vstring(keyword);
+  free_vstring(cmdList);
   return(0);
 
 } /* getFullArg */
@@ -1997,11 +1978,10 @@ void parseCommandLine(vstring line)
   vstring tokenComment = "!";
 
 
-  vstring tmpStr = ""; /* Dummy vstring to clean up temp alloc stack */
   flag mode;
   long tokenStart, i, p, lineLen;
 
-  vstring specialOneCharTokens = "";
+  vstring_def(specialOneCharTokens);
 
   /* Initialization to avoid compiler warning (should not be theoretically
      necessary) */
@@ -2021,7 +2001,7 @@ void parseCommandLine(vstring line)
      This is done because sometimes ! might be legal as part of a command */
   mode = 0;
   for (p = 0; p < lineLen; p++) {
-    let(&tmpStr, ""); /* Clean up temp alloc stack to prevent overflow */
+    freeTempAlloc(); /* Clean up temp alloc stack to prevent overflow */
     if (mode == 0) {
       /* If character is white space, ignore it */
       if (instr(1,tokenWhiteSpace,chr(line[p]))) {
@@ -2032,7 +2012,7 @@ void parseCommandLine(vstring line)
         break;
       }
       /* If character is a special token, get it but don't change mode */
-      if (instr(1,specialOneCharTokens,chr(line[p]))) {
+      if (instr(1, specialOneCharTokens, chr(line[p]))) {
         pntrLet(&g_rawArgPntr, pntrAddElement(g_rawArgPntr));
         nmbrLet(&g_rawArgNmbr, nmbrAddElement(g_rawArgNmbr, p+1));
                                                           /* Save token start */
@@ -2058,7 +2038,7 @@ void parseCommandLine(vstring line)
     }
     if (mode == 1) {
       /* If character is white space, end token and change mode */
-      if (instr(1,tokenWhiteSpace,chr(line[p]))) {
+      if (instr(1, tokenWhiteSpace, chr(line[p]))) {
         pntrLet(&g_rawArgPntr, pntrAddElement(g_rawArgPntr));
         nmbrLet(&g_rawArgNmbr, nmbrAddElement(g_rawArgNmbr, tokenStart));
                                                           /* Save token start */
@@ -2069,7 +2049,7 @@ void parseCommandLine(vstring line)
       }
 
       /* If character is a special token, get it and change mode */
-      if (instr(1,specialOneCharTokens,chr(line[p]))) {
+      if (instr(1, specialOneCharTokens, chr(line[p]))) {
         pntrLet(&g_rawArgPntr, pntrAddElement(g_rawArgPntr));
         nmbrLet(&g_rawArgNmbr, nmbrAddElement(g_rawArgNmbr, tokenStart));
                                                           /* Save token start */
@@ -2149,7 +2129,7 @@ void parseCommandLine(vstring line)
   }
 
   /* Deallocate */
-  let(&specialOneCharTokens, "");
+  free_vstring(specialOneCharTokens);
 } /* parseCommandLine */
 
 
@@ -2168,7 +2148,6 @@ flag cmdMatches(vstring cmdString)
   /* This function checks that fields 0 through n of g_fullArg match
      cmdString (separated by spaces). */
   long i, j, k;
-  vstring tmpStr = "";
   /* Count the number of spaces */
   k = len(cmdString);
   j = 0;
@@ -2176,20 +2155,21 @@ flag cmdMatches(vstring cmdString)
     if (cmdString[i] == ' ') j++;
   }
   k = pntrLen(g_fullArg);
+  vstring_def(tmpStr);
   for (i = 0; i <= j; i++) {
     if (j >= k) {
       /* Command to match is longer than the user's command; assume no match */
-      let(&tmpStr, "");
-      return (0);
+      free_vstring(tmpStr);
+      return 0;
     }
     let(&tmpStr, cat(tmpStr, " ", g_fullArg[i], NULL));
   }
   if (!strcmp(cat(" ", cmdString, NULL), tmpStr)) {
-    let(&tmpStr, "");
-    return (1);
+    free_vstring(tmpStr);
+    return 1;
   } else {
-    let(&tmpStr, "");
-    return (0);
+    free_vstring(tmpStr);
+    return 0;
   }
 } /* cmdMatches */
 
@@ -2206,41 +2186,41 @@ long switchPos(vstring swString)
      "DISPLAY PROOF / UNKNOWN / START_STEP = 10 / ESSENTIAL"
      and swString is "/ START_STEP", switchPos will return 5. */
   long i, j, k;
-  vstring tmpStr = "";
-  vstring swString1 = "";
+  vstring_def(tmpStr);
+  vstring_def(swString1);
 
   if (swString[0] != '/') bug(1108);
 
   /* Add a space after the "/" if there is none */
   if (swString[1] != ' ') {
-    let(&swString1, cat("/ ", right(swString,2), " ", NULL));
+    let(&swString1, cat("/ ", right(swString, 2), " ", NULL));
   } else {
-    let(&swString1,swString);
+    let(&swString1, swString);
   }
 
   /* Build the complete command */
   k = pntrLen(g_fullArg);
   for (i = 0; i < k; i++) {
-    let(&tmpStr, cat(tmpStr,g_fullArg[i], " ", NULL));
+    let(&tmpStr, cat(tmpStr, g_fullArg[i], " ", NULL));
   }
 
-  k = instr(1,tmpStr,swString1);
+  k = instr(1, tmpStr, swString1);
   if (!k) {
-    let(&swString1, "");
-    let(&tmpStr, "");
-    return (0);
+    free_vstring(swString1);
+    free_vstring(tmpStr);
+    return 0;
   }
 
-  let(&tmpStr,left(tmpStr,k));
+  let(&tmpStr, left(tmpStr, k));
   /* Count the number of spaces - it will be the g_fullArg position */
   k = len(tmpStr);
   j = 0;
   for (i = 0; i < k; i++) {
     if (tmpStr[i] == ' ') j++;
   }
-  let(&tmpStr, "");
-  let(&swString1, "");
-  return (j + 1);
+  free_vstring(tmpStr);
+  free_vstring(swString1);
+  return j + 1;
 } /* switchPos */
 
 
@@ -2248,8 +2228,8 @@ void printCommandError(vstring line1, long arg, vstring errorMsg)
 {
   /* Warning: errorMsg should not a temporarily allocated string such
      as the direct output of cat() */
-  vstring errorPointer = "";
-  vstring line = "";
+  vstring_def(errorPointer);
+  vstring_def(line);
   long column, tokenLength, j;
 
   let(&line,line1); /* Prevent deallocation in case line1 is
@@ -2257,7 +2237,7 @@ void printCommandError(vstring line1, long arg, vstring errorMsg)
   if (!line[0]) {
     /* Empty line - don't print an error pointer */
     print2("%s\n", errorMsg);
-    let(&line, "");
+    free_vstring(line);
     return;
   }
   column = g_rawArgNmbr[arg];
@@ -2280,18 +2260,18 @@ void printCommandError(vstring line1, long arg, vstring errorMsg)
     let(&errorPointer, cat(errorPointer, "^", NULL));
   print2("%s\n", errorPointer);
   printLongLine(errorMsg, "", " ");
-  let(&errorPointer, "");
-  let(&line, "");
+  free_vstring(errorPointer);
+  free_vstring(line);
 } /* printCommandError */
 
 void freeCommandLine() {
   long i, j;
   j = pntrLen(g_rawArgPntr);
-  for (i = 0; i < j; i++) let((vstring *)(&g_rawArgPntr[i]), "");
+  for (i = 0; i < j; i++) free_vstring(*(vstring *)(&g_rawArgPntr[i]));
   j = pntrLen(g_fullArg);
-  for (i = 0; i < j; i++) let((vstring *)(&g_fullArg[i]), "");
-  pntrLet(&g_fullArg, NULL_PNTRSTRING);
-  pntrLet(&g_rawArgPntr, NULL_PNTRSTRING);
-  nmbrLet(&g_rawArgNmbr, NULL_NMBRSTRING);
-  let(&g_fullArgString, "");
+  for (i = 0; i < j; i++) free_vstring(*(vstring *)(&g_fullArg[i]));
+  free_pntrString(g_fullArg);
+  free_pntrString(g_rawArgPntr);
+  free_nmbrString(g_rawArgNmbr);
+  free_vstring(g_fullArgString);
 }

--- a/src/mmcmds.c
+++ b/src/mmcmds.c
@@ -27,11 +27,11 @@ vstring bigSub(vstring bignum1, vstring bignum2);
 flag g_printHelp = 0;
 
 /* For HTML output */
-vstring g_printStringForReferencedBy = "";
+vstring_def(g_printStringForReferencedBy);
 
 /* For MIDI */
 flag g_midiFlag = 0;
-vstring g_midiParam = "";
+vstring_def(g_midiParam);
 
 /* Type (i.e. print) a statement */
 void typeStatement(long showStmt,
@@ -58,17 +58,19 @@ void typeStatement(long showStmt,
         only.
   */
   long i, j, k, m, n;
-  vstring str1 = "", str2 = "", str3 = "";
+  vstring_def(str1);
+  vstring_def(str2);
+  vstring_def(str3);
   nmbrString *nmbrTmpPtr1; /* Pointer only; not allocated directly */
   nmbrString *nmbrTmpPtr2; /* Pointer only; not allocated directly */
-  nmbrString *nmbrDDList = NULL_NMBRSTRING;
+  nmbrString_def(nmbrDDList);
   flag q1, q2;
   flag type;
   flag subType;
-  vstring htmlDistinctVars = "";
+  vstring_def(htmlDistinctVars);
   char htmlDistinctVarsCommaFlag = 0;
-  vstring str4 = "";
-  vstring str5 = "";
+  vstring_def(str4);
+  vstring_def(str5);
   long distVarGrps = 0;
 
   /* For syntax breakdown of definitions in HTML page */
@@ -152,7 +154,7 @@ void typeStatement(long showStmt,
         }
 
         /* Print a small pink statement number after the statement */
-        let(&str2, "");
+        free_vstring(str2);
         str2 = pinkHTML(showStmt);
         printLongLine(cat("<CENTER><B><FONT SIZE=\"+1\">", str1,
             " <FONT COLOR=", GREEN_TITLE_COLOR,
@@ -164,7 +166,7 @@ void typeStatement(long showStmt,
   }
 
   if (!briefFlag || commentOnlyFlag) {
-    let(&str1, "");
+    free_vstring(str1);
     str1 = getDescription(showStmt);
     if (!str1[0] /* No comment */) {
       print2("?Warning: Statement \"%s\" has no comment\n",
@@ -282,7 +284,7 @@ void typeStatement(long showStmt,
                 distVarGrps++;
               }
 
-              nmbrLet(&nmbrDDList, NULL_NMBRSTRING);
+              free_nmbrString(nmbrDDList);
               break; /* Out of n loop */
             }
           } /* If $d var in current list is not same as one we're adding */
@@ -298,7 +300,7 @@ void typeStatement(long showStmt,
               let(&htmlDistinctVars, cat(htmlDistinctVars, ",", NULL));
             }
             htmlDistinctVarsCommaFlag = 1;
-            let(&str2, "");
+            free_vstring(str2);
             str2 = tokenToTex(g_MathToken[nmbrTmpPtr1[k]].tokenName, showStmt);
                  /* tokenToTex allocates str2; we must deallocate it */
             let(&htmlDistinctVars, cat(htmlDistinctVars, str2, NULL));
@@ -316,7 +318,7 @@ void typeStatement(long showStmt,
               let(&htmlDistinctVars, cat(htmlDistinctVars, ",", NULL));
             }
             htmlDistinctVarsCommaFlag = 1;
-            let(&str2, "");
+            free_vstring(str2);
             str2 = tokenToTex(g_MathToken[nmbrTmpPtr2[k]].tokenName, showStmt);
                  /* tokenToTex allocates str2; we must deallocate it */
             let(&htmlDistinctVars, cat(htmlDistinctVars, str2, NULL));
@@ -435,7 +437,7 @@ void typeStatement(long showStmt,
       if (!g_oldTexFlag) {
         g_outputToString = 1;
         print2("\\begin{align}\n");
-        let(&str3, "");
+        free_vstring(str3);
         /* Get HTML hypotheses => assertion */
         str3 = getTexOrHtmlHypAndAssertion(showStmt); /* In mmwtex.c */
         printLongLine(cat(str3,
@@ -549,11 +551,11 @@ void typeStatement(long showStmt,
                 g_MathToken[nmbrTmpPtr2[k]].tokenName, ">", NULL));
           } else {
             if (htmlFlg && texFlag) {
-              let(&str2, "");
+              free_vstring(str2);
               str2 = tokenToTex(g_MathToken[nmbrTmpPtr1[k]].tokenName, showStmt);
                    /* tokenToTex allocates str2; we must deallocate it */
               let(&str1, cat(str1, " &nbsp; ", str2, NULL));
-              let(&str2, "");
+              free_vstring(str2);
               str2 = tokenToTex(g_MathToken[nmbrTmpPtr2[k]].tokenName, showStmt);
               let(&str1, cat(str1, ",", str2, NULL));
             }
@@ -592,7 +594,7 @@ void typeStatement(long showStmt,
         if (!texFlag) {
           printLongLine(cat(
               "Its optional disjoint variable pairs are:  ",
-              right(str1,3),NULL),"  "," ");
+              right(str1, 3), NULL), "  ", " ");
         }
       } /* if (i && type == p_) */
 
@@ -625,7 +627,7 @@ void typeStatement(long showStmt,
           g_outputToString = 0;
         }
 
-        let(&str2, "");
+        free_vstring(str2);
         str2 = htmlAllowedSubst(showStmt);
         if (str2[0] != 0) {
           g_outputToString = 1;
@@ -820,8 +822,8 @@ void typeStatement(long showStmt,
           g_Statement[showStmt].proofSectionLen = 0;
 
           /* Deallocate storage */
-          let(&str1, "");
-          nmbrLet(&nmbrTmpPtr2, NULL_NMBRSTRING);
+          free_vstring(str1);
+          free_nmbrString(nmbrTmpPtr2);
 
         } else { /* if (nmbrLen(nmbrTmpPtr2)) else */
           /* Proof was not found - probable syntax error */
@@ -838,7 +840,7 @@ void typeStatement(long showStmt,
         (g_Statement[showStmt].mathString)[0] = zapStatement1stToken;
 
         /* Deallocate storage */
-        nmbrLet(&nmbrTmpPtr1, NULL_NMBRSTRING);
+        free_nmbrString(nmbrTmpPtr1);
 
       } /* if (wffToken >= 0) */
 
@@ -860,7 +862,7 @@ void typeStatement(long showStmt,
     g_outputToString = 1;
     if (subType != SYNTAX) { /* Only do this for
         definitions, axioms, and theorems, not syntax statements */
-      let(&str1, "");
+      free_vstring(str1);
       g_outputToString = 0; /* Switch output to console in case
             traceUsage reports an error */
       str1 = traceUsage(showStmt,
@@ -890,7 +892,7 @@ void typeStatement(long showStmt,
           /* It should be a $p */
           if (g_Statement[m].type != p_) bug(241);
           /* Get the pink number */
-          let(&str4, "");
+          free_vstring(str4);
           str4 = pinkHTML(m);
           /* Assemble the href */
           let(&str2, cat(str2, " &nbsp;<A HREF=\"",
@@ -978,13 +980,13 @@ void typeStatement(long showStmt,
 
  returnPoint:
   /* Deallocate strings */
-  nmbrLet(&nmbrDDList, NULL_NMBRSTRING);
-  let(&str1, "");
-  let(&str2, "");
-  let(&str3, "");
-  let(&str4, "");
-  let(&str5, "");
-  let(&htmlDistinctVars, "");
+  free_nmbrString(nmbrDDList);
+  free_vstring(str1);
+  free_vstring(str2);
+  free_vstring(str3);
+  free_vstring(str4);
+  free_vstring(str5);
+  free_vstring(htmlDistinctVars);
 } /* typeStatement */
 
 
@@ -1002,13 +1004,13 @@ vstring htmlDummyVars(long showStmt)
   long numDVs;
   nmbrString *optHyp; /* Pointer only; not allocated directly */
   long numOptHyps;
-  vstring str1 = "";
+  vstring_def(str1);
   long k, l, n, hypStmt;
 
   /* Variables used while collecting a statement's dummy variables in $d's */
   long dummyVarCount; /* # of (different) dummy vars found in $d statements */
-  vstring dummyVarUsed = ""; /* 'Y'/'N' indicators that we found that var */
-  vstring htmlDummyVarList = ""; /* Output HTML string */
+  vstring_def(dummyVarUsed); /* 'Y'/'N' indicators that we found that var */
+  vstring_def(htmlDummyVarList); /* Output HTML string */
   long dummyVar; /* Current variable in a $d; test if it's a dummy variable */
 
   /* This function should be called only for web page generation */
@@ -1070,7 +1072,7 @@ vstring htmlDummyVars(long showStmt)
               dummyVarUsed[dummyVar] = 'Y';
               dummyVarCount++;
               /* tokenToTex allocates str1; must deallocate it first */
-              let(&str1, "");
+              free_vstring(str1);
               /* Convert token to htmldef/althtmldef string */
               str1 = tokenToTex(g_MathToken[dummyVar].tokenName,
                   showStmt);
@@ -1113,8 +1115,8 @@ vstring htmlDummyVars(long showStmt)
 
  RETURN_POINT:
   /* Deallocate strings */
-  let(&dummyVarUsed, "");
-  let(&str1, "");
+  free_vstring(dummyVarUsed);
+  free_vstring(str1);
 
   return htmlDummyVarList;
 } /* htmlDummyVars */
@@ -1134,15 +1136,15 @@ vstring htmlAllowedSubst(long showStmt)
   nmbrString *reqDVA; /* Pointer only; not allocated directly */
   nmbrString *reqDVB; /* Pointer only; not allocated directly */
   long numDVs;
-  nmbrString *setVar = NULL_NMBRSTRING; /* set (individual) variables */
+  nmbrString_def(setVar); /* set (individual) variables */
   char *strptr;
-  vstring str1 = "";
+  vstring_def(str1);
   long setVars;
   long wffOrClassVar;
-  vstring setVarDVFlag = "";
+  vstring_def(setVarDVFlag);
   flag found, first;
   long i, j, k;
-  vstring htmlAllowedList = "";
+  vstring_def(htmlAllowedList);
   long countInfo = 0;
 
   reqDVA = g_Statement[showStmt].reqDisjVarsA;
@@ -1242,7 +1244,7 @@ vstring htmlAllowedSubst(long showStmt)
     }
     if (found == 0) continue; /* All set vars have $d with this wff or class */
 
-    let(&str1, "");
+    free_vstring(str1);
     str1 = tokenToTex(g_MathToken[wffOrClassVar].tokenName, showStmt);
          /* tokenToTex allocates str1; we must deallocate it eventually */
     countInfo++;
@@ -1251,7 +1253,7 @@ vstring htmlAllowedSubst(long showStmt)
     first = 1;
     for (j = 0; j < setVars; j++) {
       if (setVarDVFlag[j] == 'N') {
-        let(&str1, "");
+        free_vstring(str1);
         str1 = tokenToTex(g_MathToken[setVar[j]].tokenName, showStmt);
         let(&htmlAllowedList, cat(htmlAllowedList,
             (first == 0) ? "," : "", str1, NULL));
@@ -1285,9 +1287,9 @@ vstring htmlAllowedSubst(long showStmt)
   }
 
   /* Deallocate strings */
-  nmbrLet(&setVar, NULL_NMBRSTRING);
-  let(&str1, "");
-  let(&setVarDVFlag, "");
+  free_nmbrString(setVar);
+  free_vstring(str1);
+  free_vstring(setVarDVFlag);
 
   return htmlAllowedList;
 } /* htmlAllowedSubst */
@@ -1367,36 +1369,36 @@ void typeProof(long statemNum,
         typeProof()
   */
   long i, j, plen, step, stmt, lens, lent, maxStepNum;
-  vstring tmpStr = "";
-  vstring tmpStr1 = "";
-  vstring locLabDecl = "";
-  vstring tgtLabel = "";
-  vstring srcLabel = "";
-  vstring startPrefix = "";
-  vstring tgtPrefix = "";
-  vstring srcPrefix = "";
-  vstring userPrefix = "";
-  vstring contPrefix = "";
-  vstring statementUsedFlags = "";
-  vstring startStringWithNum = "";
-  vstring startStringWithoutNum = "";
-  nmbrString *proof = NULL_NMBRSTRING;
-  nmbrString *localLabels = NULL_NMBRSTRING;
-  nmbrString *localLabelNames = NULL_NMBRSTRING;
-  nmbrString *indentationLevel = NULL_NMBRSTRING;
-  nmbrString *targetHyps = NULL_NMBRSTRING;
-  nmbrString *essentialFlags = NULL_NMBRSTRING;
-  nmbrString *stepRenumber = NULL_NMBRSTRING;
-  nmbrString *notUnifiedFlags = NULL_NMBRSTRING;
-  nmbrString *unprovedList = NULL_NMBRSTRING; /* For traceProofWork() */
-  nmbrString *relativeStepNums = NULL_NMBRSTRING; /* For unknownFlag */
+  vstring_def(tmpStr);
+  vstring_def(tmpStr1);
+  vstring_def(locLabDecl);
+  vstring_def(tgtLabel);
+  vstring_def(srcLabel);
+  vstring_def(startPrefix);
+  vstring_def(tgtPrefix);
+  vstring_def(srcPrefix);
+  vstring_def(userPrefix);
+  vstring_def(contPrefix);
+  vstring_def(statementUsedFlags);
+  vstring_def(startStringWithNum);
+  vstring_def(startStringWithoutNum);
+  nmbrString_def(proof);
+  nmbrString_def(localLabels);
+  nmbrString_def(localLabelNames);
+  nmbrString_def(indentationLevel);
+  nmbrString_def(targetHyps);
+  nmbrString_def(essentialFlags);
+  nmbrString_def(stepRenumber);
+  nmbrString_def(notUnifiedFlags);
+  nmbrString_def(unprovedList); /* For traceProofWork() */
+  nmbrString_def(relativeStepNums); /* For unknownFlag */
   long maxLabelLen = 0;
   long maxStepNumLen = 1;
   long maxStepNumOffsetLen = 0;
   char type;
   flag stepPrintFlag;
   long fromStep, toStep, byStep;
-  vstring hypStr = "";
+  vstring_def(hypStr);
   nmbrString *hypPtr;
   long hyp, hypStep;
 
@@ -1427,7 +1429,7 @@ void typeProof(long statemNum,
          "Proof of Theorem", which means we have to make the "Proof of
          Theorem" line separate and not the table caption, so that the
          "Distinct variables..." line does not become part of the table. */
-      let(&tmpStr, "");
+      free_vstring(tmpStr);
       tmpStr = htmlDummyVars(statemNum);
       if (tmpStr[0] != 0) {
         print2("<CENTER><B>Proof of Theorem <FONT\n");
@@ -1436,7 +1438,7 @@ void typeProof(long statemNum,
             "</FONT></B></CENTER>", NULL), "", "\"");
         /* Print the list of dummy variables */
         printLongLine(tmpStr, "", "\"");
-        let(&tmpStr, "");
+        free_vstring(tmpStr);
         print2("<CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR=%s\n",
             MINT_BACKGROUND_COLOR);
         print2("SUMMARY=\"Proof of theorem\">\n");
@@ -1647,7 +1649,7 @@ void typeProof(long statemNum,
         stmt = -1000 - stmt;
         /* stmt is now the step number a local label refers to */
         lens = (long)strlen(str((double)(localLabelNames[stmt])));
-        let(&tmpStr1, ""); /* Clear temp alloc stack for str function */
+        freeTempAlloc(); /* Clear temp alloc stack for str function */
       } else {
         if (stmt != -(long)'?') bug (219); /* the only other possibility */
         lens = 1; /* '?' (unknown step) */
@@ -2110,12 +2112,12 @@ void typeProof(long statemNum,
           }
 
           /* Deallocate memory */
-          nmbrLet(&nmbrTmpPtr2, NULL_NMBRSTRING);
-          nmbrLet(&nmbrTmpPtr1, NULL_NMBRSTRING);
+          free_nmbrString(nmbrTmpPtr2);
+          free_nmbrString(nmbrTmpPtr1);
         } /* next i */
         /* Deallocate memory in case we broke out above */
-        nmbrLet(&nmbrTmpPtr2, NULL_NMBRSTRING);
-        nmbrLet(&nmbrTmpPtr1, NULL_NMBRSTRING);
+        free_nmbrString(nmbrTmpPtr2);
+        free_nmbrString(nmbrTmpPtr1);
       } /* if (wffToken >= 0) */
       /* End of syntax hints section */
       /******************************************************************/
@@ -2131,7 +2133,7 @@ void typeProof(long statemNum,
           /* Get the main symbol in the syntax */
           /* This section can be deleted if not wanted - it is custom
              for set.mm and might not work with other .mm's */
-          let(&tmpStr1, "");
+          free_vstring(tmpStr1);
           for (i = 1 /* Skip |- */; i < g_Statement[stmt].mathStringLen; i++) {
             if (g_MathToken[(g_Statement[stmt].mathString)[i]].tokenType ==
                 (char)con_) {
@@ -2175,7 +2177,7 @@ void typeProof(long statemNum,
           let(&tmpStr, cat(tmpStr, " &nbsp;", tmpStr1, NULL));
           /* End section - Get the main symbol in the syntax */
 
-          let(&tmpStr1, "");
+          free_vstring(tmpStr1);
           tmpStr1 = pinkHTML(stmt);
           let(&tmpStr, cat(tmpStr, "<A HREF=\"",
               g_Statement[stmt].labelName, ".html\">",
@@ -2193,7 +2195,7 @@ void typeProof(long statemNum,
 
 
       /* Get list of axioms and definitions assumed by proof */
-      let(&statementUsedFlags, "");
+      free_vstring(statementUsedFlags);
       traceProofWork(statemNum,
           1, /*essentialFlag*/
           "", /*traceToList*/
@@ -2211,7 +2213,7 @@ void typeProof(long statemNum,
               let(&tmpStr, "<TR><TD ALIGN=LEFT><FONT SIZE=-1><B>"
                 "This theorem was proved from axioms:</B>");
             }
-            let(&tmpStr1, "");
+            free_vstring(tmpStr1);
             tmpStr1 = pinkHTML(stmt);
             let(&tmpStr, cat(tmpStr, " &nbsp;<A HREF=\"",
                 g_Statement[stmt].labelName, ".html\">",
@@ -2234,7 +2236,7 @@ void typeProof(long statemNum,
               let(&tmpStr,
  "<TR><TD ALIGN=LEFT><FONT SIZE=-1><B>This theorem depends on definitions:</B>");
             }
-            let(&tmpStr1, "");
+            free_vstring(tmpStr1);
             tmpStr1 = pinkHTML(stmt);
             let(&tmpStr, cat(tmpStr, " &nbsp;<A HREF=\"",
                 g_Statement[stmt].labelName, ".html\">",
@@ -2283,7 +2285,7 @@ void typeProof(long statemNum,
       if (g_printStringForReferencedBy[0]) {
         if (g_outputToString != 1) bug(257);
         printLongLine(g_printStringForReferencedBy, "", "\"");
-        let(&g_printStringForReferencedBy, "");
+        free_vstring(g_printStringForReferencedBy);
       } else {
         /* Since we always print ref-by list even if "(None)",
            g_printStringForReferencedBy should never be empty */
@@ -2298,30 +2300,30 @@ void typeProof(long statemNum,
   }
 
  typeProof_return:
-  let(&tmpStr, "");
-  let(&tmpStr1, "");
-  let(&statementUsedFlags, "");
-  let(&locLabDecl, "");
-  let(&tgtLabel, "");
-  let(&srcLabel, "");
-  let(&startPrefix, "");
-  let(&tgtPrefix, "");
-  let(&srcPrefix, "");
-  let(&userPrefix, "");
-  let(&contPrefix, "");
-  let(&hypStr, "");
-  let(&startStringWithNum, "");
-  let(&startStringWithoutNum, "");
-  nmbrLet(&unprovedList, NULL_NMBRSTRING);
-  nmbrLet(&localLabels, NULL_NMBRSTRING);
-  nmbrLet(&localLabelNames, NULL_NMBRSTRING);
-  nmbrLet(&proof, NULL_NMBRSTRING);
-  nmbrLet(&targetHyps, NULL_NMBRSTRING);
-  nmbrLet(&indentationLevel, NULL_NMBRSTRING);
-  nmbrLet(&essentialFlags, NULL_NMBRSTRING);
-  nmbrLet(&stepRenumber, NULL_NMBRSTRING);
-  nmbrLet(&notUnifiedFlags, NULL_NMBRSTRING);
-  nmbrLet(&relativeStepNums, NULL_NMBRSTRING);
+  free_vstring(tmpStr);
+  free_vstring(tmpStr1);
+  free_vstring(statementUsedFlags);
+  free_vstring(locLabDecl);
+  free_vstring(tgtLabel);
+  free_vstring(srcLabel);
+  free_vstring(startPrefix);
+  free_vstring(tgtPrefix);
+  free_vstring(srcPrefix);
+  free_vstring(userPrefix);
+  free_vstring(contPrefix);
+  free_vstring(hypStr);
+  free_vstring(startStringWithNum);
+  free_vstring(startStringWithoutNum);
+  free_nmbrString(unprovedList);
+  free_nmbrString(localLabels);
+  free_nmbrString(localLabelNames);
+  free_nmbrString(proof);
+  free_nmbrString(targetHyps);
+  free_nmbrString(indentationLevel);
+  free_nmbrString(essentialFlags);
+  free_nmbrString(stepRenumber);
+  free_nmbrString(notUnifiedFlags);
+  free_nmbrString(relativeStepNums);
 } /* typeProof() */
 
 /* Show details of one proof step */
@@ -2330,12 +2332,12 @@ void typeProof(long statemNum,
 void showDetailStep(long statemNum, long detailStep) {
 
   long i, j, plen, step, stmt, sourceStmt, targetStmt;
-  vstring tmpStr = "";
-  vstring tmpStr1 = "";
-  nmbrString *proof = NULL_NMBRSTRING;
-  nmbrString *localLabels = NULL_NMBRSTRING;
-  nmbrString *localLabelNames = NULL_NMBRSTRING;
-  nmbrString *targetHyps = NULL_NMBRSTRING;
+  vstring_def(tmpStr);
+  vstring_def(tmpStr1);
+  nmbrString_def(proof);
+  nmbrString_def(localLabels);
+  nmbrString_def(localLabelNames);
+  nmbrString_def(targetHyps);
   long nextLocLabNum = 1; /* Next number to be used for a local label */
   void *voidPtr; /* bsearch result */
   char type;
@@ -2609,19 +2611,19 @@ void showDetailStep(long statemNum, long detailStep) {
     nmbrLet((nmbrString **)(&getStep.targetSubstsPntr[i]),
         NULL_NMBRSTRING);
   }
-  nmbrLet(&getStep.sourceHyps, NULL_NMBRSTRING);
-  pntrLet(&getStep.sourceSubstsPntr, NULL_PNTRSTRING);
-  nmbrLet(&getStep.sourceSubstsNmbr, NULL_NMBRSTRING);
-  pntrLet(&getStep.targetSubstsPntr, NULL_PNTRSTRING);
-  nmbrLet(&getStep.targetSubstsNmbr, NULL_NMBRSTRING);
+  free_nmbrString(getStep.sourceHyps);
+  free_pntrString(getStep.sourceSubstsPntr);
+  free_nmbrString(getStep.sourceSubstsNmbr);
+  free_pntrString(getStep.targetSubstsPntr);
+  free_nmbrString(getStep.targetSubstsNmbr);
 
   /* Deallocate other strings */
-  let(&tmpStr, "");
-  let(&tmpStr1, "");
-  nmbrLet(&localLabels, NULL_NMBRSTRING);
-  nmbrLet(&localLabelNames, NULL_NMBRSTRING);
-  nmbrLet(&proof, NULL_NMBRSTRING);
-  nmbrLet(&targetHyps, NULL_NMBRSTRING);
+  free_vstring(tmpStr);
+  free_vstring(tmpStr1);
+  free_nmbrString(localLabels);
+  free_nmbrString(localLabelNames);
+  free_nmbrString(proof);
+  free_nmbrString(targetHyps);
 
 } /* showDetailStep */
 
@@ -2630,13 +2632,13 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
 
   long i, j, k, pos, stmt, plen, slen, step;
   char type;
-  vstring statementUsedFlags = ""; /* 'Y'/'N' flag that statement is used */
-  vstring str1 = "";
-  vstring str2 = "";
-  vstring str3 = "";
-  nmbrString *statementList = NULL_NMBRSTRING;
-  nmbrString *proof = NULL_NMBRSTRING;
-  nmbrString *essentialFlags = NULL_NMBRSTRING;
+  vstring_def(statementUsedFlags); /* 'Y'/'N' flag that statement is used */
+  vstring_def(str1);
+  vstring_def(str2);
+  vstring_def(str3);
+  nmbrString_def(statementList);
+  nmbrString_def(proof);
+  nmbrString_def(essentialFlags);
 
   /* This section is never called in HTML mode anymore.  The code is
      left in though just in case we somehow get here and the user continues
@@ -2663,7 +2665,7 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
     }
     g_outputToString = 0;
     fprintf(g_texFilePtr, "%s", g_printString);
-    let(&g_printString, "");
+    free_vstring(g_printString);
   }
 
   if (g_Statement[statemNum].type != p_) {
@@ -2747,10 +2749,10 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
         }
         g_outputToString = 0;
         fprintf(g_texFilePtr, "%s", g_printString);
-        let(&g_printString, "");
+        free_vstring(g_printString);
       }
 
-      let(&str1, "");
+      free_vstring(str1);
       str1 = getDescription(stmt);
       if (str1[0]) {
         if (!texFlag) {
@@ -2799,13 +2801,13 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
     } /* End if (statementUsedFlag[stmt] == 'Y') */
   } /* Next stmt */
 
-  let(&statementUsedFlags, ""); /* 'Y'/'N' flag that statement is used */
-  let(&str1, "");
-  let(&str2, "");
-  let(&str3, "");
-  nmbrLet(&statementList, NULL_NMBRSTRING);
-  nmbrLet(&proof, NULL_NMBRSTRING);
-  nmbrLet(&essentialFlags, NULL_NMBRSTRING);
+  free_vstring(statementUsedFlags); /* 'Y'/'N' flag that statement is used */
+  free_vstring(str1);
+  free_vstring(str2);
+  free_vstring(str3);
+  free_nmbrString(statementList);
+  free_nmbrString(proof);
+  free_nmbrString(essentialFlags);
 
 } /* proofStmtSumm */
 
@@ -2825,9 +2827,9 @@ flag traceProof(long statemNum,
 {
 
   long stmt, pos;
-  vstring statementUsedFlags = ""; /* y/n flags that statement is used */
-  vstring outputString = "";
-  nmbrString *unprovedList = NULL_NMBRSTRING;
+  vstring_def(statementUsedFlags); /* y/n flags that statement is used */
+  vstring_def(outputString);
+  nmbrString_def(unprovedList);
   flag foundFlag = 0;
 
   /* Make sure we're calling this with $p statements only */
@@ -2917,9 +2919,9 @@ flag traceProof(long statemNum,
 
  TRACE_RETURN:
   /* Deallocate */
-  let(&outputString, "");
-  let(&statementUsedFlags, "");
-  nmbrLet(&unprovedList, NULL_NMBRSTRING);
+  free_vstring(outputString);
+  free_vstring(statementUsedFlags);
+  free_nmbrString(unprovedList);
   return foundFlag;
 } /* traceProof */
 
@@ -2933,11 +2935,11 @@ void traceProofWork(long statemNum,
 {
 
   long pos, stmt, plen, slen, step;
-  nmbrString *statementList = NULL_NMBRSTRING;
-  nmbrString *proof = NULL_NMBRSTRING;
-  nmbrString *essentialFlags = NULL_NMBRSTRING;
-  vstring traceToFilter = "";
-  vstring str1 = "";
+  nmbrString_def(statementList);
+  nmbrString_def(proof);
+  nmbrString_def(essentialFlags);
+  vstring_def(traceToFilter);
+  vstring_def(str1);
   long j;
 
   /* Preprocess the "SHOW TRACE_BACK ... / TO" traceToList list if any */
@@ -2951,7 +2953,7 @@ void traceProofWork(long statemNum,
       /* Wildcard matching */
       if (!matchesList(g_Statement[stmt].labelName, traceToList, '*', '?'))
         continue;
-      let(&str1, "");
+      free_vstring(str1);
       str1 = traceUsage(stmt /*g_showStatement*/,
           1, /*recursiveFlag*/
           statemNum /* cutoffStmt */);
@@ -2969,7 +2971,7 @@ void traceProofWork(long statemNum,
   nmbrLet(&statementList, nmbrSpace(g_statements));
   statementList[0] = statemNum;
   slen = 1;
-  nmbrLet(&(*unprovedListP), NULL_NMBRSTRING); /* List of unproved statements */
+  free_nmbrString(*unprovedListP); /* List of unproved statements */
   let(&(*statementUsedFlagsP), string(g_statements + 1, 'N')); /* Init. to 'no' */
   (*statementUsedFlagsP)[statemNum] = 'Y';
   for (pos = 0; pos < slen; pos++) {
@@ -3028,16 +3030,15 @@ void traceProofWork(long statemNum,
   } /* Next pos */
 
   /* Deallocate */
-  nmbrLet(&essentialFlags, NULL_NMBRSTRING);
-  nmbrLet(&proof, NULL_NMBRSTRING);
-  nmbrLet(&statementList, NULL_NMBRSTRING);
-  let(&str1, "");
-  let(&str1, "");
+  free_nmbrString(essentialFlags);
+  free_nmbrString(proof);
+  free_nmbrString(statementList);
+  free_vstring(str1);
   return;
 
 } /* traceProofWork */
 
-nmbrString *stmtFoundList = NULL_NMBRSTRING;
+nmbrString_def(stmtFoundList);
 long indentShift = 0;
 
 /* Traces back the statements used by a proof, recursively, with tree display.*/
@@ -3058,10 +3059,10 @@ void traceProofTree(long statemNum,
       "", " ");
   print2("\n");
 
-  nmbrLet(&stmtFoundList, NULL_NMBRSTRING);
+  free_nmbrString(stmtFoundList);
   indentShift = 0;
   traceProofTreeRec(statemNum, essentialFlag, endIndent, 0);
-  nmbrLet(&stmtFoundList, NULL_NMBRSTRING);
+  free_nmbrString(stmtFoundList);
 } /* traceProofTree */
 
 
@@ -3069,15 +3070,15 @@ void traceProofTreeRec(long statemNum,
   flag essentialFlag, long endIndent, long recursDepth)
 {
   long i, pos, stmt, plen, slen, step;
-  vstring outputStr = "";
-  nmbrString *localFoundList = NULL_NMBRSTRING;
-  nmbrString *localPrintedList = NULL_NMBRSTRING;
+  vstring_def(outputStr);
+  nmbrString_def(localFoundList);
+  nmbrString_def(localPrintedList);
   flag unprovedFlag = 0;
-  nmbrString *proof = NULL_NMBRSTRING;
-  nmbrString *essentialFlags = NULL_NMBRSTRING;
+  nmbrString_def(proof);
+  nmbrString_def(essentialFlags);
 
 
-  let(&outputStr, "");
+  free_vstring(outputStr);
   outputStr = getDescription(statemNum); /* Get statement comment */
   let(&outputStr, edit(outputStr, 8 + 16 + 128)); /* Trim and reduce spaces */
   slen = len(outputStr);
@@ -3118,14 +3119,14 @@ void traceProofTreeRec(long statemNum,
   }
 
   if (g_Statement[statemNum].type != p_) {
-    let(&outputStr, "");
+    free_vstring(outputStr);
     return;
   }
 
   if (endIndent) {
     /* An indentation level limit is set */
     if (endIndent < recursDepth + 2) {
-      let(&outputStr, "");
+      free_vstring(outputStr);
       return;
     }
   }
@@ -3195,11 +3196,11 @@ void traceProofTreeRec(long statemNum,
       space(INDENT_INCR * (recursDepth + 2)), " ");
   }
 
-  let(&outputStr, "");
-  nmbrLet(&localFoundList, NULL_NMBRSTRING);
-  nmbrLet(&localPrintedList, NULL_NMBRSTRING);
-  nmbrLet(&proof, NULL_NMBRSTRING);
-  nmbrLet(&essentialFlags, NULL_NMBRSTRING);
+  free_vstring(outputStr);
+  free_nmbrString(localFoundList);
+  free_nmbrString(localPrintedList);
+  free_nmbrString(proof);
+  free_nmbrString(essentialFlags);
 
 } /* traceProofTreeRec */
 
@@ -3222,17 +3223,17 @@ double countSteps(long statemNum, flag essentialFlag)
 
   long stmt, plen, step, i, j, k;
   long essentialplen;
-  nmbrString *proof = NULL_NMBRSTRING;
+  nmbrString_def(proof);
   double stepCount; /* The total steps if fully expanded */
 
   static vstring *stmtBigCount; /* Unlimited precision stmtCount */
-  vstring stepBigCount = ""; /* Unlimited precision stepCount */
-  vstring tmpBig1 = "";
+  vstring_def(stepBigCount); /* Unlimited precision stepCount */
+  vstring_def(tmpBig1);
 
   double stepNodeCount;
   double stepDistSum;
-  nmbrString *essentialFlags = NULL_NMBRSTRING;
-  vstring tmpStr = "";
+  nmbrString_def(essentialFlags);
+  vstring_def(tmpStr);
   long actualSteps, actualSubTheorems;
   long actualSteps2, actualSubTheorems2;
 
@@ -3320,7 +3321,7 @@ double countSteps(long statemNum, flag essentialFlag)
         unprovedFlag = 1;
         stepCount = stepCount + 1;
 
-        let(&tmpBig1, "");
+        free_vstring(tmpBig1);
         tmpBig1 = bigAdd(stepBigCount, "1");
         let(&stepBigCount, tmpBig1);
 
@@ -3337,7 +3338,7 @@ double countSteps(long statemNum, flag essentialFlag)
       }
 
       /* In either case, stmtBigCount[stmt] will be populated now */
-      let(&tmpBig1, "");
+      free_vstring(tmpBig1);
       tmpBig1 = bigAdd(stepBigCount, stmtBigCount[stmt]);
       let(&stepBigCount, tmpBig1);
 
@@ -3349,7 +3350,7 @@ double countSteps(long statemNum, flag essentialFlag)
             stepCount--;
 
             /* In either case, stmtBigCount[stmt] will be populated now */
-            let(&tmpBig1, "");
+            free_vstring(tmpBig1);
             tmpBig1 = bigSub(stepBigCount, "1");
             let(&stepBigCount, tmpBig1);
 
@@ -3379,8 +3380,8 @@ double countSteps(long statemNum, flag essentialFlag)
   stmtAveDist[statemNum] = (double)stepDistSum / (double)essentialplen;
   stmtProofLen[statemNum] = essentialplen;
 
-  nmbrLet(&proof, NULL_NMBRSTRING);
-  nmbrLet(&essentialFlags, NULL_NMBRSTRING);
+  free_nmbrString(proof);
+  free_nmbrString(essentialFlags);
 
   level--;
   /* If this is the top level of recursion, deallocate */
@@ -3449,7 +3450,7 @@ double countSteps(long statemNum, flag essentialFlag)
        str((double)(stmtDist[statemNum])),
        ".  A longest path is:  ", right(tmpStr, 5), " .", NULL),
        "", " ");
-    let(&tmpStr, "");
+    free_vstring(tmpStr);
 
     free(stmtCount);
     free(stmtNodeCount);
@@ -3461,18 +3462,17 @@ double countSteps(long statemNum, flag essentialFlag)
 
     /* Deallocate the big number strings */
     for (stmt = 1; stmt < g_statements + 1; stmt++) {
-      let(&stmtBigCount[stmt], "");
+      free_vstring(stmtBigCount[stmt]);
     }
     free(stmtBigCount);
 
   }
 
   /* Deallocate local strings */
-  let(&tmpBig1, "");
-  let(&stepBigCount, "");
+  free_vstring(tmpBig1);
+  free_vstring(stepBigCount);
 
-  return(stepCount);
-
+  return stepCount;
 } /* countSteps */
 
 
@@ -3486,7 +3486,7 @@ double countSteps(long statemNum, flag essentialFlag)
 vstring bigAdd(vstring bignum1, vstring bignum2) {
   long len1, len2, maxlen, p, p1, p2, p3;
   char d1, d2, carry, dsum;
-  vstring bignum3 = "";
+  vstring_def(bignum3);
   len1 = (long)strlen(bignum1);
   len2 = (long)strlen(bignum2);
   maxlen = (len1 < len2 ? len2 : len1);
@@ -3525,8 +3525,8 @@ vstring bigAdd(vstring bignum1, vstring bignum2) {
 /* The arguments must be strings that will not be freed by unrelated 'let()' */
 vstring bigSub(vstring bignum1, vstring bignum2) {
   long len1, len3, p;
-  vstring bignum3 = "";
-  vstring bignum1cmpl = "";
+  vstring_def(bignum3);
+  vstring_def(bignum1cmpl);
   len1 = (long)strlen(bignum1);
   let(&bignum1cmpl, space(len1));
   for (p = 0; p <= len1 - 1; p++) {
@@ -3548,7 +3548,7 @@ vstring bigSub(vstring bignum1, vstring bignum2) {
     /* Supress leading 0s */
     let(&bignum3, right(bignum3, 2));
   }
-  let(&bignum1cmpl, ""); /* Deallocate */
+  free_vstring(bignum1cmpl); /* Deallocate */
   return bignum3;
 }
 
@@ -3567,7 +3567,7 @@ vstring bigSub(vstring bignum1, vstring bignum2) {
 vstring bigMulDigit(vstring bignum1, long digit) {
   long len1, p, p1, p3;
   char d1, carry, dprod;
-  vstring bignum3 = "";
+  vstring_def(bignum3);
   len1 = (long)strlen(bignum1);
   let(&bignum3, space(len1 + 1)); /@ +1 to allow for final carry @/
   carry = 0;
@@ -3602,27 +3602,27 @@ vstring bigMulDigit(vstring bignum1, long digit) {
 vstring bigMul(vstring bignum1, vstring bignum2) {
   long len2, p, p2;
   char d2;
-  vstring bignum3 = "";
-  vstring bigdprod = "";
-  vstring bigpprod = "";
+  vstring_def(bignum3);
+  vstring_def(bigdprod);
+  vstring_def(bigpprod);
   len2 = (long)strlen(bignum2);
   for (p = 1; p <= len2; p++) {
     p2 = len2 - p;
     d2 = (char)(bignum2[p2] - '0');
     if (d2 > 0) {
-      let(&bigdprod, "");
+      free_vstring(bigdprod);
       bigdprod = bigMulDigit(bignum1, d2);
       if (p > 1) {
         /@ Shift the digit product by adding trailing 0s @/
         let(&bigdprod, cat(bigdprod, string(p - 1, '0'), NULL));
       }
-      let(&bigpprod, "");
+      free_vstring(bigpprod);
       bigpprod = bigAdd(bignum3, bigdprod); /@ Accumulate partial product @/
       let(&bignum3, bigpprod);
     }
   } /@ next p @/
-  let(&bigdprod, "");
-  let(&bigpprod, "");
+  free_vstring(bigdprod);
+  free_vstring(bigpprod);
   return bignum3;
 }
 **** end commented out section added 12-Nov-2018 ***/
@@ -3642,9 +3642,9 @@ vstring traceUsage(long statemNum,
 
   long lastPos, stmt, slen, pos;
   flag tmpFlag;
-  vstring statementUsedFlags = ""; /* 'Y'/'N' flag that statement is used */
-  nmbrString *statementList = NULL_NMBRSTRING;
-  nmbrString *proof = NULL_NMBRSTRING;
+  vstring_def(statementUsedFlags); /* 'Y'/'N' flag that statement is used */
+  nmbrString_def(statementList);
+  nmbrString_def(proof);
 
   /* For speed-up code */
   char *fbPtr;
@@ -3748,7 +3748,7 @@ vstring traceUsage(long statemNum,
    processed separately in metamath.c). */
 void readInput(void)
 {
-  vstring fullInput_fn = "";
+  vstring_def(fullInput_fn);
 
   let(&fullInput_fn, cat(g_rootDirectory, g_input_fn, NULL));
 
@@ -3767,7 +3767,7 @@ void readInput(void)
   g_sourceHasBeenRead = 1;
 
  RETURN_POINT:
-  let(&fullInput_fn, "");
+  free_vstring(fullInput_fn);
 
 } /* readInput */
 
@@ -3787,8 +3787,8 @@ void writeSource(
 
   /* Temporary variables and strings */
   long i;
-  vstring buffer = "";
-  vstring fullOutput_fn = "";
+  vstring_def(buffer);
+  vstring_def(fullOutput_fn);
   FILE *fp;
 
   let(&fullOutput_fn, cat(g_rootDirectory, g_output_fn, NULL));
@@ -3816,14 +3816,14 @@ void writeSource(
     /* TODO: turn this into a REWRAP command */
     /* Process statements */
     for (i = 1; i <= g_statements + 1; i++) {
-      let(&buffer,""); /* Deallocate vstring */
+      free_vstring(buffer); /* Deallocate vstring */
 
       buffer = outputStatement(i, reformatFlag);
     } /* next i */
   } /* if (reformatFlag > 0) */
 
   /* Get put the g_Statement[] array into one linear buffer */
-  let(&buffer, "");
+  free_vstring(buffer);
   buffer = writeSourceToBuffer();
   if (splitFlag == 1) { /* Write includes as separate files */
 
@@ -3859,8 +3859,8 @@ void writeSource(
 
 
  RETURN_POINT:
-  let(&buffer,""); /* Deallocate vstring */
-  let(&fullOutput_fn,""); /* Deallocate vstring */
+  free_vstring(buffer); /* Deallocate vstring */
+  free_vstring(fullOutput_fn); /* Deallocate vstring */
   return;
 } /* writeSource */
 
@@ -3871,40 +3871,40 @@ void writeExtractedSource(
     vstring fullOutput_fn,
     flag noVersioningFlag)
 {
-  vstring statementUsedFlags = ""; /* Y/N flags that statement is used */
+  vstring_def(statementUsedFlags); /* Y/N flags that statement is used */
   long stmt, stmtj, scpStmt, strtScpStmt, endScpStmt, j, p1, p2, p3, p4;
-  vstring extractNeeded = "";
-  nmbrString *unprovedList = NULL_NMBRSTRING; /* Needed for traceProofWork()
+  vstring_def(extractNeeded);
+  nmbrString_def(unprovedList); /* Needed for traceProofWork()
                                                  but not used */
-  nmbrString *mstring = NULL_NMBRSTRING; /* Temporary holder for math string */
+  nmbrString_def(mstring); /* Temporary holder for math string */
   long maxStmt; /* The largest statement number (excluding $t) */
   long hyp, hyps, mtkn, mtkns, dv, dvs;
   long dollarTStmt; /* $t statement */
-  vstring dollarTCmt = ""; /* $t comment */
+  vstring_def(dollarTCmt); /* $t comment */
   char zapChar; /* For finding $t statement */
   char *tmpPtr; /* For finding $t statement */
-  vstring hugeHdrNeeded = ""; /* N/M/Y that output needs the huge header */
-  vstring bigHdrNeeded = "";                              /* big */
-  vstring smallHdrNeeded = "";                            /* small */
-  vstring tinyHdrNeeded = "";                             /* tiny */
+  vstring_def(hugeHdrNeeded); /* N/M/Y that output needs the huge header */
+  vstring_def(bigHdrNeeded);                              /* big */
+  vstring_def(smallHdrNeeded);                            /* small */
+  vstring_def(tinyHdrNeeded);                             /* tiny */
   char hdrNeeded;
   /* The following 8 are needed for getSectionHeadings() */
-  vstring hugeHdr = "";
-  vstring bigHdr = "";
-  vstring smallHdr = "";
-  vstring tinyHdr = "";
-  vstring hugeHdrComment = "";
-  vstring bigHdrComment = "";
-  vstring smallHdrComment = "";
-  vstring tinyHdrComment = "";
+  vstring_def(hugeHdr);
+  vstring_def(bigHdr);
+  vstring_def(smallHdr);
+  vstring_def(tinyHdr);
+  vstring_def(hugeHdrComment);
+  vstring_def(bigHdrComment);
+  vstring_def(smallHdrComment);
+  vstring_def(tinyHdrComment);
 
-  vstring mathTokenDeclared = "";
-  vstring undeclaredC = "";
-  vstring undeclaredV = "";
+  vstring_def(mathTokenDeclared);
+  vstring_def(undeclaredC);
+  vstring_def(undeclaredV);
   long extractedStmts;
-  vstring hdrSuffix = "";
+  vstring_def(hdrSuffix);
   FILE *fp;
-  vstring buf = "";
+  vstring_def(buf);
 
 
   /* Note that extractNeeded is 1-based to match 1-based
@@ -4307,7 +4307,7 @@ void writeExtractedSource(
           1, /*fineResolution*/
           1 /*fullComment*/
           );
-      let(&buf, "");
+      freeTempAlloc();
       if (hugeHdrNeeded[stmt] == 'Y') {
         fixUndefinedLabels(extractNeeded, &hugeHdrComment);
         fprintf(fp, "%s", cat(hugeHdr, hugeHdrComment, hdrSuffix, NULL));
@@ -4333,7 +4333,7 @@ void writeExtractedSource(
 
     /* Output statement if needed */
     if (extractNeeded[stmt] == 'Y') {
-      let(&buf, "");
+      free_vstring(buf);
       buf = getDescriptionAndLabel(stmt);
 
       fixUndefinedLabels(extractNeeded, &buf);
@@ -4392,7 +4392,7 @@ void writeExtractedSource(
   g_outputToString = 0;
   if (g_printString[0] != 0) {
     fprintf(fp, "%s", g_printString);
-    let(&g_printString, "");
+    free_vstring(g_printString);
   }
 
   /* Write the non-split output file */
@@ -4405,7 +4405,7 @@ void writeExtractedSource(
         p1++;
         if (!strcmp("ax-", left(g_Statement[stmt].labelName, 3))) p3++;
         if (!strcmp("df-", left(g_Statement[stmt].labelName, 3))) p4++;
-        let(&buf, ""); /* Deallocate stack created by left() */
+        freeTempAlloc(); /* Deallocate stack created by left() */
       }
       if (g_Statement[stmt].type == p_) p2++;
     }
@@ -4416,27 +4416,27 @@ void writeExtractedSource(
 
  EXTRACT_RETURN:
   /* Deallocate */
-  let(&extractNeeded, "");
-  let(&statementUsedFlags, "");
-  nmbrLet(&unprovedList, NULL_NMBRSTRING);
-  nmbrLet(&mstring, NULL_NMBRSTRING);
-  let(&dollarTCmt, "");
-  let(&hugeHdrNeeded, "");
-  let(&bigHdrNeeded, "");
-  let(&smallHdrNeeded, "");
-  let(&tinyHdrNeeded, "");
-  let(&hugeHdr, "");   /* Deallocate memory */
-  let(&bigHdr, "");   /* Deallocate memory */
-  let(&smallHdr, ""); /* Deallocate memory */
-  let(&tinyHdr, ""); /* Deallocate memory */
-  let(&hugeHdrComment, "");   /* Deallocate memory */
-  let(&bigHdrComment, "");   /* Deallocate memory */
-  let(&smallHdrComment, ""); /* Deallocate memory */
-  let(&tinyHdrComment, ""); /* Deallocate memory */
-  let(&mathTokenDeclared, "");
-  let(&undeclaredC, "");
-  let(&undeclaredV, "");
-  let(&buf, "");
+  free_vstring(extractNeeded);
+  free_vstring(statementUsedFlags);
+  free_nmbrString(unprovedList);
+  free_nmbrString(mstring);
+  free_vstring(dollarTCmt);
+  free_vstring(hugeHdrNeeded);
+  free_vstring(bigHdrNeeded);
+  free_vstring(smallHdrNeeded);
+  free_vstring(tinyHdrNeeded);
+  free_vstring(hugeHdr);   /* Deallocate memory */
+  free_vstring(bigHdr);   /* Deallocate memory */
+  free_vstring(smallHdr); /* Deallocate memory */
+  free_vstring(tinyHdr); /* Deallocate memory */
+  free_vstring(hugeHdrComment);   /* Deallocate memory */
+  free_vstring(bigHdrComment);   /* Deallocate memory */
+  free_vstring(smallHdrComment); /* Deallocate memory */
+  free_vstring(tinyHdrComment); /* Deallocate memory */
+  free_vstring(mathTokenDeclared);
+  free_vstring(undeclaredC);
+  free_vstring(undeclaredV);
+  free_vstring(buf);
   return;
 } /* getExtractionInfo */
 
@@ -4447,9 +4447,9 @@ void writeExtractedSource(
 void fixUndefinedLabels(vstring extractNeeded/*'Y'/'N' list*/,
     vstring *buf/*header comment*/) {
   long p1, p2, p3;
-  vstring label = "";
-  vstring newLabelWithTilde = "";
-  vstring restOfComment = "";
+  vstring_def(label);
+  vstring_def(newLabelWithTilde);
+  vstring_def(restOfComment);
   int mathMode; /* char gives Wconversion gcc warning */
 #define ASCII_4 4
 
@@ -4521,9 +4521,9 @@ void fixUndefinedLabels(vstring extractNeeded/*'Y'/'N' list*/,
     if ((*buf)[p2] == ASCII_4) (*buf)[p2] = '~';
   }
 
-  let(&label, ""); /* Deallocate */
-  let(&newLabelWithTilde, ""); /* Deallocate */
-  let(&restOfComment, ""); /* Deallocate */
+  free_vstring(label); /* Deallocate */
+  free_vstring(newLabelWithTilde); /* Deallocate */
+  free_vstring(restOfComment); /* Deallocate */
   return;
 } /* fixUndefinedLabels */
 
@@ -4538,7 +4538,7 @@ void writeDict(void)
 void eraseSource(void)    /* ERASE command */
 {
   long i;
-  vstring tmpStr = "";
+  vstring_def(tmpStr);
 
   /* Deallocate g_WrkProof structure if g_wrkProofMaxSize != 0 */
   /* Assigned in parseProof() in mmpars.c */
@@ -4564,9 +4564,9 @@ void eraseSource(void)    /* ERASE command */
   }
 
   for (i = 0; i <= g_includeCalls; i++) {
-    let(&g_IncludeCall[i].source_fn, "");
-    let(&g_IncludeCall[i].included_fn, "");
-    let(&g_IncludeCall[i].current_includeSource, "");
+    free_vstring(g_IncludeCall[i].source_fn);
+    free_vstring(g_IncludeCall[i].included_fn);
+    free_vstring(g_IncludeCall[i].current_includeSource);
   }
   g_includeCalls = -1;
 
@@ -4602,15 +4602,15 @@ void eraseSource(void)    /* ERASE command */
 
     if (g_Statement[i].labelSectionChanged == 1) {
       /* Deallocate text before label if not original source */
-      let(&(g_Statement[i].labelSectionPtr), "");
+      free_vstring(g_Statement[i].labelSectionPtr);
     }
     if (g_Statement[i].mathSectionChanged == 1) {
       /* Deallocate math symbol text if not original source */
-      let(&(g_Statement[i].mathSectionPtr), "");
+      free_vstring(g_Statement[i].mathSectionPtr);
     }
     if (g_Statement[i].proofSectionChanged == 1) {
       /* Deallocate proof if not original source */
-      let(&(g_Statement[i].proofSectionPtr), "");
+      free_vstring(g_Statement[i].proofSectionPtr);
     }
 
   } /* Next i (statement) */
@@ -4619,7 +4619,7 @@ void eraseSource(void)    /* ERASE command */
      parseMathDecl() by let().  eraseSource() should free every g_MathToken and
      there are (g_mathTokens + g_dummyVars) tokens. */
   for (i = 0; i <= g_mathTokens + g_dummyVars; i++) {
-    let(&(g_MathToken[i].tokenName), "");
+    free_vstring(g_MathToken[i].tokenName);
   }
 
   memFreePoolPurge(0);
@@ -4641,12 +4641,12 @@ void eraseSource(void)    /* ERASE command */
 
   /* Initialize and deallocate mathbox information */
   g_mathboxStmt = 0; /* Used by a non-zero test in mmwtex.c to see if assigned */
-  nmbrLet(&g_mathboxStart, NULL_NMBRSTRING);
-  nmbrLet(&g_mathboxEnd, NULL_NMBRSTRING);
+  free_nmbrString(g_mathboxStart);
+  free_nmbrString(g_mathboxEnd);
   for (i = 1; i <= g_mathboxes; i++) {
-    let((vstring *)(&g_mathboxUser[i - 1]), "");
+    free_vstring(*(vstring *)(&g_mathboxUser[i - 1]));
   }
-  pntrLet(&g_mathboxUser, NULL_PNTRSTRING);
+  free_pntrString(g_mathboxUser);
   g_mathboxes = 0;
 
   /* Allocate big arrays */
@@ -4658,15 +4658,15 @@ void eraseSource(void)    /* ERASE command */
   g_minSubstLen = 1; /* Initialize to the default SET EMPTY_SUBSTITUTION OFF */
   /* Clear g_firstConst to trigger clearing of g_lastConst and
      g_oneConst in mmunif.c */
-  nmbrLet(&g_firstConst, NULL_NMBRSTRING);
+  free_nmbrString(g_firstConst);
   /* Clear these directly so they will be truly deallocated for valgrind */
-  nmbrLet(&g_lastConst, NULL_NMBRSTRING);
-  nmbrLet(&g_oneConst, NULL_NMBRSTRING);
+  free_nmbrString(g_lastConst);
+  free_nmbrString(g_oneConst);
 
   getMarkupFlag(0, RESET); /* Erase the cached markup flag storage */
 
   /* Erase the contributor markup cache */
-  let(&tmpStr, "");
+  free_vstring(tmpStr);
   tmpStr = getContrib(0 /*stmt is ignored*/, GC_RESET);
 
   /* getContrib uses g_statements (global var), so don't do this earlier */
@@ -4678,21 +4678,21 @@ void eraseSource(void)    /* ERASE command */
 /* If verify = 0, parse the proofs only for gross error checking.
    If verify = 1, do the full verification. */
 void verifyProofs(vstring labelMatch, flag verifyFlag) {
-  vstring emptyProofList = "";
+  vstring_def(emptyProofList);
   long i, k;
   long lineLen = 0;
-  vstring header = "";
+  vstring_def(header);
   flag errorFound;
 #ifdef CLOCKS_PER_SEC
   clock_t clockStart;
 #endif
 
 #ifdef __WATCOMC__
-  vstring tmpStr="";
+  vstring_def(tmpStr);
 #endif
 
 #ifdef VAXC
-  vstring tmpStr="";
+  vstring_def(tmpStr);
 #endif
 
 #ifdef CLOCKS_PER_SEC
@@ -4702,7 +4702,7 @@ void verifyProofs(vstring labelMatch, flag verifyFlag) {
     /* Use status bar */
     let(&header, "0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%");
     print2("%s\n", header);
-    let(&header, "");
+    free_vstring(header);
   }
 
   errorFound = 0;
@@ -4761,7 +4761,7 @@ void verifyProofs(vstring labelMatch, flag verifyFlag) {
       print2("All proofs in the database passed the syntax-only check.\n");
     }
   }
-  let(&emptyProofList, ""); /* Deallocate */
+  free_vstring(emptyProofList); /* Deallocate */
 
 } /* verifyProofs */
 
@@ -4779,28 +4779,29 @@ void verifyMarkup(vstring labelMatch,
   long stmtNum, p1, p2, p3;
   long flen, lnum, lstart; /* For line length check */
 
-  vstring mmVersionDate = ""; /* Version date at top of .mm file */
-  vstring mostRecentDate = ""; /* For entire .mm file */
+  vstring_def(mmVersionDate); /* Version date at top of .mm file */
+  vstring_def(mostRecentDate); /* For entire .mm file */
   long mostRecentStmt = 0; /* For error message */
 
   /* For getSectionHeadings() call */
-  vstring hugeHdr = "";
-  vstring bigHdr = "";
-  vstring smallHdr = "";
-  vstring tinyHdr = "";
-  vstring hugeHdrComment = "";
-  vstring bigHdrComment = "";
-  vstring smallHdrComment = "";
-  vstring tinyHdrComment = "";
+  vstring_def(hugeHdr);
+  vstring_def(bigHdr);
+  vstring_def(smallHdr);
+  vstring_def(tinyHdr);
+  vstring_def(hugeHdrComment);
+  vstring_def(bigHdrComment);
+  vstring_def(smallHdrComment);
+  vstring_def(tinyHdrComment);
 
-  vstring descr = "";
-  vstring str1 = ""; vstring str2 = "";
+  vstring_def(descr);
+  vstring_def(str1);
+  vstring_def(str2);
 
   /* For mathbox check */
   long mbox, pmbox, stmt, pstmt, plen, step;
 
-  nmbrString *proof = NULL_NMBRSTRING;
-  vstring dupCheck = "";
+  nmbrString_def(proof);
+  vstring_def(dupCheck);
 
   saveHtmlFlag = g_htmlFlag;  saveAltHtmlFlag = g_altHtmlFlag;
 
@@ -4936,9 +4937,9 @@ void verifyMarkup(vstring labelMatch,
       continue;
     }
 
-    let(&str1, ""); /* Prevent string stack buildup/overflow in left() below */
     /* Look for "ax-*" axioms */
     if (strcmp("ax-", left(g_Statement[stmtNum].labelName, 3))) {
+      freeTempAlloc(); /* Prevent string stack buildup/overflow in left() */
       continue;
     }
 
@@ -5029,8 +5030,8 @@ void verifyMarkup(vstring labelMatch,
 
 
   /* Check line lengths */
-  let(&str1, ""); /* Prepare to use as pointer */
-  let(&str2, ""); /* Prepare to use as pointer */
+  free_vstring(str1); /* Prepare to use as pointer */
+  free_vstring(str2); /* Prepare to use as pointer */
   if (g_statements >= 0) {
     /* TODO - handle $[...$] */
     /* g_includeCalls is always nonzero now - but check
@@ -5078,7 +5079,7 @@ void verifyMarkup(vstring labelMatch,
               NULL), "    ", " ");
           print2("    %s...\n", left(str2, g_screenWidth - 7));
           errFound = 1;
-          let(&str2, ""); /* Deallocate string memory */
+          free_vstring(str2); /* Deallocate string memory */
         }
         lstart = p1 + 1;
       }
@@ -5137,7 +5138,7 @@ void verifyMarkup(vstring labelMatch,
     }
 
     /* Check the contributor */
-    let(&str1, "");
+    free_vstring(str1);
     str1 = getContrib(stmtNum, CONTRIBUTOR);
     if (!strcmp(str1, DEFAULT_CONTRIBUTOR)) {
       printLongLine(cat(
@@ -5146,7 +5147,7 @@ void verifyMarkup(vstring labelMatch,
           g_Statement[stmtNum].labelName, "\".", NULL), "    ", " ");
       errFound = 1;
     }
-    let(&str1, "");
+    free_vstring(str1);
     str1 = getContrib(stmtNum, REVISER);
     if (!strcmp(str1, DEFAULT_CONTRIBUTOR)) {
       printLongLine(cat(
@@ -5160,10 +5161,10 @@ void verifyMarkup(vstring labelMatch,
 
       /* Check date consistency of the statement */
       /* Use the error-checking feature of getContrib() extractor */
-      let(&str1, "");
+      free_vstring(str1);
       str1 = getContrib(stmtNum, GC_ERROR_CHECK_PRINT); /* Returns P or F */
       if (str1[0] == 'F') errFound = 1;
-      let(&str1, "");
+      free_vstring(str1);
       str1 = getContrib(stmtNum, MOST_RECENT_DATE);
 
       /* Save most recent date in file - used to check Version date below */
@@ -5174,7 +5175,7 @@ void verifyMarkup(vstring labelMatch,
 
     }
 
-    let(&descr, "");
+    free_vstring(descr);
     descr = getDescription(stmtNum);
 
     /* Check comment markup of the statement */
@@ -5272,14 +5273,14 @@ void verifyMarkup(vstring labelMatch,
       continue;
     }
 
-    let(&hugeHdr, "");
-    let(&bigHdr, "");
-    let(&smallHdr, "");
-    let(&tinyHdr, "");
-    let(&hugeHdrComment, "");
-    let(&bigHdrComment, "");
-    let(&smallHdrComment, "");
-    let(&tinyHdrComment, "");
+    free_vstring(hugeHdr);
+    free_vstring(bigHdr);
+    free_vstring(smallHdr);
+    free_vstring(tinyHdr);
+    free_vstring(hugeHdrComment);
+    free_vstring(bigHdrComment);
+    free_vstring(smallHdrComment);
+    free_vstring(tinyHdrComment);
     f = getSectionHeadings(stmtNum, &hugeHdr, &bigHdr, &smallHdr,
         &tinyHdr,
         &hugeHdrComment, &bigHdrComment, &smallHdrComment,
@@ -5398,8 +5399,8 @@ void verifyMarkup(vstring labelMatch,
       } /* next pstmt */
     } /* next pmbox */
     /* Deallocate */
-    let(&dupCheck, "");
-    nmbrLet(&proof, NULL_NMBRSTRING);
+    free_vstring(dupCheck);
+    free_nmbrString(proof);
   }
 
   if (errFound == 0) {
@@ -5411,19 +5412,19 @@ void verifyMarkup(vstring labelMatch,
   eraseTexDefs();
 
   /* Deallocate string memory */
-  let(&mostRecentDate, "");
-  let(&mmVersionDate, "");
-  let(&descr, "");
-  let(&str1, "");
-  let(&str2, "");
-  let(&hugeHdr, "");
-  let(&bigHdr, "");
-  let(&smallHdr, "");
-  let(&tinyHdr, "");
-  let(&hugeHdrComment, "");
-  let(&bigHdrComment, "");
-  let(&smallHdrComment, "");
-  let(&tinyHdrComment, "");
+  free_vstring(mostRecentDate);
+  free_vstring(mmVersionDate);
+  free_vstring(descr);
+  free_vstring(str1);
+  free_vstring(str2);
+  free_vstring(hugeHdr);
+  free_vstring(bigHdr);
+  free_vstring(smallHdr);
+  free_vstring(tinyHdr);
+  free_vstring(hugeHdrComment);
+  free_vstring(bigHdrComment);
+  free_vstring(smallHdrComment);
+  free_vstring(tinyHdrComment);
   return;
 
 } /* verifyMarkup */
@@ -5435,7 +5436,7 @@ void verifyMarkup(vstring labelMatch,
 void processMarkup(vstring inputFileName, vstring outputFileName,
     flag processCss, long actionBits) {
   FILE *outputFilePtr;
-  vstring inputFileContent = "";
+  vstring_def(inputFileContent);
   long size;
   long p;
 
@@ -5452,7 +5453,7 @@ void processMarkup(vstring inputFileName, vstring outputFileName,
 
   print2("Reading \"%s\"...\n", inputFileName);
 
-  let(&inputFileContent, "");
+  free_vstring(inputFileContent);
   inputFileContent = readFileToString(inputFileName, 1/*verbose*/, &size);
   if (inputFileContent == NULL) {
     /* Couldn't open the file; error msg provided by readFileToString */
@@ -5481,7 +5482,7 @@ void processMarkup(vstring inputFileName, vstring outputFileName,
   }
 
   g_outputToString = 0;
-  let(&g_printString, "");
+  free_vstring(g_printString);
   g_showStatement = 0; /* For printTexComment */
   g_texFilePtr = outputFilePtr; /* For printTexComment */
   printTexComment(  /* Sends result to g_texFilePtr */
@@ -5494,8 +5495,8 @@ void processMarkup(vstring inputFileName, vstring outputFileName,
 
  PROCESS_MARKUP_RETURN:
   /* Deallocate */
-  let(&inputFileContent, "");
-  let(&g_printString, "");
+  free_vstring(inputFileContent);
+  free_vstring(g_printString);
   return;
 }
 
@@ -5508,7 +5509,7 @@ void showDiscouraged(void) {
   long stmt, s, usageCount;
   long lowStmt = 0, highStmt = 0; /* For a slight speedup */
   flag notQuitPrint = 1; /* Goes to 0 if user typed 'q' at scroll prompt */
-  vstring str1 = "";
+  vstring_def(str1);
   for (stmt = 1; stmt <= g_statements; stmt++) {
 
     /* Since this command is slow, quit immediately if user typed 'q'
@@ -5530,7 +5531,7 @@ void showDiscouraged(void) {
     if (getMarkupFlag(stmt, USAGE_DISCOURAGED) == 1) {
       /* Discouraged usage */
       usageCount = 0;
-      let(&str1, "");
+      free_vstring(str1);
       str1 = traceUsage(stmt,
           0, /* recursiveFlag */
           0 /* cutoffStmt */);
@@ -5565,7 +5566,7 @@ void showDiscouraged(void) {
       } /* if (str1[0] == 'Y') */
     } /* if discouraged usage */
   } /* next stmt */
-  let(&str1, ""); /* Deallocate */
+  free_vstring(str1); /* Deallocate */
 } /* showDiscouraged */
 
 /* Take a relative step FIRST, LAST, +nn, -nn (relative to the unknown
@@ -5579,8 +5580,8 @@ long getStepNum(vstring relStep, /* User's argument */
 {
   long pfLen, i, j, relStepVal, actualStepVal;
   flag negFlag = 0;
-  nmbrString *essentialFlags = NULL_NMBRSTRING;
-  vstring relStepCaps = "";
+  nmbrString_def(essentialFlags);
+  vstring_def(relStepCaps);
 
   let(&relStepCaps, edit(relStep, 32/*upper case*/));
   pfLen = nmbrLen(pfInProgress); /* Proof length */
@@ -5682,8 +5683,8 @@ long getStepNum(vstring relStep, /* User's argument */
 
  RETURN_POINT:
   /* Deallocate memory */
-  let(&relStepCaps, "");
-  nmbrLet(&essentialFlags, NULL_NMBRSTRING);
+  free_vstring(relStepCaps);
+  free_nmbrString(*&essentialFlags);
 
   return actualStepVal;
 } /* getStepNum */
@@ -5696,8 +5697,8 @@ long getStepNum(vstring relStep, /* User's argument */
    unchanged.  */
 /* The caller must deallocate the returned nmbrString. */
 nmbrString *getRelStepNums(nmbrString *pfInProgress) {
-  nmbrString *essentialFlags = NULL_NMBRSTRING;
-  nmbrString *relSteps = NULL_NMBRSTRING;
+  nmbrString_def(essentialFlags);
+  nmbrString_def(relSteps);
   long i, j, pfLen;
 
   pfLen = nmbrLen(pfInProgress); /* Get proof length */
@@ -5715,7 +5716,7 @@ nmbrString *getRelStepNums(nmbrString *pfInProgress) {
   }
 
   /* Deallocate memory */
-  nmbrLet(&essentialFlags, NULL_NMBRSTRING);
+  free_nmbrString(*&essentialFlags);
 
   return relSteps;
 } /* getRelStepNums */
@@ -5952,7 +5953,7 @@ void outputMidi(long plen, nmbrString *indentationLevels,
   long midiTime; /* Midi time stamp */
   long midiPreviousFormulaStep; /* Note saved from previous step */
   long midiPreviousLogicalStep; /* Note saved from previous step */
-  vstring midiFileName = ""; /* All vstrings MUST be initialized to ""! */
+  vstring_def(midiFileName); /* All vstrings MUST be initialized to ""! */
   FILE *midiFilePtr; /* Output file pointer */
   long midiBaseline; /* Baseline note */
   long midiMaxIndent; /* Maximum indentation (to find dyn range of notes) */
@@ -5962,8 +5963,8 @@ void outputMidi(long plen, nmbrString *indentationLevels,
   flag midiSyncopate; /* 1 = syncopate the output */
   flag midiHesitate; /* 1 = silence all repeated notes */
   long midiTempo; /* larger = faster */
-  vstring midiLocalParam = ""; /* To manipulate user's parameter string */
-  vstring tmpStr = ""; /* Temporary string */
+  vstring_def(midiLocalParam); /* To manipulate user's parameter string */
+  vstring_def(tmpStr); /* Temporary string */
 #define ALLKEYSFLAG 1
 #define WHITEKEYSFLAG 2
 #define BLACKKEYSFLAG 3
@@ -6263,8 +6264,7 @@ void outputMidi(long plen, nmbrString *indentationLevels,
  midi_return:
   /* Important: all local vstrings must be deallocated to prevent
      memory leakage */
-  let(&midiFileName, "");
-  let(&tmpStr, "");
-  let(&midiLocalParam, "");
-
+  free_vstring(midiFileName);
+  free_vstring(tmpStr);
+  free_vstring(midiLocalParam);
 } /* outputMidi */

--- a/src/mmdata.c
+++ b/src/mmdata.c
@@ -25,11 +25,11 @@ flag g_toolsMode = 0; /* In metamath: 0 = metamath, 1 = text tools utility */
 
 
 /* For use by getMarkupFlag() */
-vstring g_proofDiscouragedMarkup = "";
-vstring g_usageDiscouragedMarkup = "";
+vstring_def(g_proofDiscouragedMarkup);
+vstring_def(g_usageDiscouragedMarkup);
 flag g_globalDiscouragement = 1; /* SET DISCOURAGEMENT ON */
 
-vstring g_contributorName = "";
+vstring_def(g_contributorName);
 
 /* Global variables related to current statement */
 int g_currentScope = 0;
@@ -434,20 +434,16 @@ long getFreeSpace(long max)
 
 /* Fatal memory allocation error */
 void outOfMemory(const char *msg) {
-  vstring tmpStr = "";
+  vstring_def(tmpStr);
   print2("*** FATAL ERROR:  Out of memory.\n");
-  print2("Internal identifier (for technical support):  %s\n",msg);
-  print2(
-"To solve this problem, remove some unnecessary statements or file\n");
-  print2(
-"inclusions to reduce the size of your input source.\n");
-  print2(
-"Monitor memory periodically with SHOW MEMORY.\n");
+  print2("Internal identifier (for technical support):  %s\n", msg);
+  print2("To solve this problem, remove some unnecessary statements or file\n");
+  print2("inclusions to reduce the size of your input source.\n");
+  print2("Monitor memory periodically with SHOW MEMORY.\n");
   print2("\n");
   print2("Press <return> to exit Metamath.\n");
   tmpStr = cmdInput1("");
-  /* let(&tmpStr, ""); */
-  let(&tmpStr, left(tmpStr, 0)); /* Prevent "not used" compiler warning */
+  free_vstring(tmpStr);
   /* Close the log to make sure error log is saved */
   if (g_logFileOpenFlag) {
     fclose(g_logFilePtr);
@@ -461,7 +457,7 @@ void outOfMemory(const char *msg) {
 /* Bug check */
 void bug(int bugNum)
 {
-  vstring tmpStr = "";
+  vstring_def(tmpStr);
   flag oldMode;
   long wrongAnswerCount = 0;
   static flag mode = 0; /* 1 = run to next bug, 2 = continue and ignore bugs */
@@ -478,22 +474,14 @@ void bug(int bugNum)
   print2("?BUG CHECK:  *** DETECTED BUG %ld\n", (long)bugNum);
   if (mode == 0) { /* Print detailed info for first bug */
     print2("\n");
-    print2(
-  "To get technical support, please open an issue \n");
-    print2(
-  "(https://github.com/metamath/metamath-exe/issues) with the\n");
-    print2(
-  "detailed command sequence or a command file that reproduces this bug,\n");
-    print2(
-  "along with the source file that was used.  See HELP LOG for help on\n");
-    print2(
-  "recording a session.  See HELP SUBMIT for help on command files.  Search\n");
-    print2(
-  "for \"bug(%ld)\" in the m*.c source code to find its origin.\n", bugNum);
-    print2(
-  "If earlier errors were reported, try fixing them first, because they\n");
-    print2(
-  "may occasionally lead to false bug detection\n");
+    print2("To get technical support, please open an issue \n");
+    print2("(https://github.com/metamath/metamath-exe/issues) with the\n");
+    print2("detailed command sequence or a command file that reproduces this bug,\n");
+    print2("along with the source file that was used.  See HELP LOG for help on\n");
+    print2("recording a session.  See HELP SUBMIT for help on command files.  Search\n");
+    print2("for \"bug(%ld)\" in the m*.c source code to find its origin.\n", bugNum);
+    print2("If earlier errors were reported, try fixing them first, because they\n");
+    print2("may occasionally lead to false bug detection\n");
     print2("\n");
   }
 
@@ -505,17 +493,15 @@ void bug(int bugNum)
          it in case we want to re-ask after wrong answers in the future */
       ) {
     if (wrongAnswerCount > 6) {
-      print2(
-"Too many wrong answers; program will be aborted to exit scripting loops.\n");
+      print2("Too many wrong answers; program will be aborted to exit scripting loops.\n");
       break;
     }
     if (wrongAnswerCount > 0) {
-      let(&tmpStr, "");
+      free_vstring(tmpStr);
       tmpStr = cmdInput1("Please answer I, S, or A:  ");
     } else {
-      print2(
- "Press S <return> to step to next bug, I <return> to ignore further bugs,\n");
-      let(&tmpStr, "");
+      print2("Press S <return> to step to next bug, I <return> to ignore further bugs,\n");
+      free_vstring(tmpStr);
       tmpStr = cmdInput1("or A <return> to abort program:  ");
     }
     wrongAnswerCount++;
@@ -527,18 +513,16 @@ void bug(int bugNum)
   if (oldMode == 0 && mode > 0) {
     /* Print dire warning after the first bug only */
     print2("\n");
-    print2(
-    "Warning!!!  A bug was detected, but you are continuing anyway.\n");
-    print2(
-    "The program may be corrupted, so you are proceeding at your own risk.\n");
+    print2("Warning!!!  A bug was detected, but you are continuing anyway.\n");
+    print2("The program may be corrupted, so you are proceeding at your own risk.\n");
     print2("\n");
-    let(&tmpStr, "");
+    free_vstring(tmpStr);
   }
   if (mode > 0) {
     g_outputToString = saveOutputToString; /* Restore for continuation */
     return;
   }
-  let(&tmpStr, "");
+  free_vstring(tmpStr);
 
   print2("\n");
   /* Close the log to make sure error log is saved */
@@ -561,7 +545,7 @@ flag matchesList(const char *testString, const char *pattern, char wildCard,
     char oneCharWildCard) {
   long entries, i;
   flag matchVal = 0;
-  vstring entryPattern = "";
+  vstring_def(entryPattern);
 
   /* Done so we can use string functions like left() in call arguments */
   long saveTempAllocStack;
@@ -577,9 +561,9 @@ flag matchesList(const char *testString, const char *pattern, char wildCard,
     if (matchVal) break;
   }
 
-  let(&entryPattern, ""); /* Deallocate */
+  free_vstring(entryPattern); /* Deallocate */
   g_startTempAllocStack = saveTempAllocStack;
-  return (matchVal);
+  return matchVal;
 }
 
 
@@ -590,7 +574,7 @@ flag matchesList(const char *testString, const char *pattern, char wildCard,
 flag matches(const char *testString, const char *pattern, char wildCard,
     char oneCharWildCard) {
   long i, ppos, pctr, tpos, s1, s2, s3;
-  vstring tmpStr = "";
+  vstring_def(tmpStr);
 
   if (wildCard == '*') {
     /* Checking for wildCard = * meaning this is only for labels, not
@@ -616,7 +600,7 @@ flag matches(const char *testString, const char *pattern, char wildCard,
       } else {
         s3 = lookupLabel(right(pattern, i + 1));
       }
-      let(&tmpStr, ""); /* Clean up temporary allocations of left and right */
+      free_vstring(tmpStr); /* Clean up temporary allocations of left and right */
       return ((s1 >= 1 && s2 >= 1 && s3 >= 1 && s1 <= s2 && s2 <= s3)
           ? 1 : 0);
     }
@@ -765,8 +749,7 @@ temp_nmbrString *nmbrTempAlloc(long size)
 temp_nmbrString *nmbrMakeTempAlloc(nmbrString *s)
 {
   if (g_nmbrTempAllocStackTop>=(M_MAX_ALLOC_STACK-1)) {
-    printf(
-    "*** FATAL ERROR ***  Temporary nmbrString stack overflow in nmbrMakeTempAlloc()\n");
+    printf("*** FATAL ERROR ***  Temporary nmbrString stack overflow in nmbrMakeTempAlloc()\n");
 #if __STDC__
     fflush(stdout);
 #endif
@@ -1103,25 +1086,23 @@ long nmbrRevInstr(long start_position, const nmbrString *string1,
     const nmbrString *string2)
 {
    long ls1, ls2;
-   nmbrString *tmp = NULL_NMBRSTRING;
    ls1 = nmbrLen(string1);
    ls2 = nmbrLen(string2);
    if (start_position > ls1 - ls2 + 1) start_position = ls1 - ls2 + 2;
    if (start_position<1) return 0;
    while (!nmbrEq(string2, nmbrMid(string1, start_position, ls2))) {
      start_position--;
-     nmbrLet(&tmp, NULL_NMBRSTRING);
-              /* Clear nmbrString buffer to prevent overflow caused by "mid" */
+     nmbrTempAlloc(0); /* Clear temporaries to prevent overflow caused by "mid" */
      if (start_position < 1) return 0;
    }
-   return (start_position);
+   return start_position;
 }
 
 
 /* Converts nmbrString to a vstring with one space between tokens */
 temp_vstring nmbrCvtMToVString(const nmbrString *s) {
   long i, j, outputLen, mstrLen;
-  vstring tmpStr = "";
+  vstring_def(tmpStr);
   vstring ptr;
   vstring ptr2;
 
@@ -1157,14 +1138,14 @@ temp_vstring nmbrCvtRToVString(const nmbrString *proof,
 {
   long i, j, plen, maxLabelLen, maxLocalLen, step, stmt;
   long maxTargetLabelLen;
-  vstring proofStr = "";
-  vstring tmpStr = "";
+  vstring_def(proofStr);
+  vstring_def(tmpStr);
   vstring ptr;
-  nmbrString *localLabels = NULL_NMBRSTRING;
-  nmbrString *localLabelNames = NULL_NMBRSTRING;
+  nmbrString_def(localLabels);
+  nmbrString_def(localLabelNames);
   long nextLocLabNum = 1; /* Next number to be used for a local label */
   void *voidPtr; /* bsearch result */
-  nmbrString *targetHyps = NULL_NMBRSTRING; /* Targets for /EXPLICIT format */
+  nmbrString_def(targetHyps); /* Targets for /EXPLICIT format */
 
   long saveTempAllocStack;
   long nmbrSaveTempAllocStack;
@@ -1265,7 +1246,7 @@ temp_vstring nmbrCvtRToVString(const nmbrString *proof,
       let(&tmpStr, cat("??", str((double)stmt), " ", NULL)); /* For safety */
 
     } else {
-      let(&tmpStr,"");
+      free_vstring(tmpStr);
       if (nmbrElementIn(1, localLabels, step)) {
         /* This statement declares a local label */
         /* First, get a name for the local label, using the next integer that
@@ -1299,9 +1280,9 @@ temp_vstring nmbrCvtRToVString(const nmbrString *proof,
   } else {
     let(&proofStr, "");
   }
-  let(&tmpStr, "");
-  nmbrLet(&localLabels, NULL_NMBRSTRING);
-  nmbrLet(&localLabelNames, NULL_NMBRSTRING);
+  free_vstring(tmpStr);
+  free_nmbrString(localLabels);
+  free_nmbrString(localLabelNames);
 
   g_startTempAllocStack = saveTempAllocStack;
   g_nmbrStartTempAllocStack = nmbrSaveTempAllocStack;
@@ -1313,11 +1294,11 @@ temp_vstring nmbrCvtRToVString(const nmbrString *proof,
    step numbers assigned to tokens which are steps, and 0 otherwise.
    The returned string is allocated; THE CALLER MUST DEALLOCATE IT. */
 nmbrString *nmbrGetProofStepNumbs(const nmbrString *reason) {
-  nmbrString *stepNumbs = NULL_NMBRSTRING;
+  nmbrString_def(stepNumbs);
   long rlen, start, end, i, step;
 
   rlen = nmbrLen(reason);
-  nmbrLet(&stepNumbs,nmbrSpace(rlen)); /* All stepNumbs[] are initialized
+  nmbrLet(&stepNumbs, nmbrSpace(rlen)); /* All stepNumbs[] are initialized
                                         to 0 by nmbrSpace() */
   if (!rlen) return (stepNumbs);
   if (reason[1] == -(long)'=') {
@@ -1349,7 +1330,7 @@ nmbrString *nmbrGetProofStepNumbs(const nmbrString *reason) {
       stepNumbs[i] = step;
     }
   }
-  return (stepNumbs);
+  return stepNumbs;
 }
 
 
@@ -1357,7 +1338,7 @@ nmbrString *nmbrGetProofStepNumbs(const nmbrString *reason) {
    -- used for debugging only. */
 temp_vstring nmbrCvtAnyToVString(const nmbrString *s) {
   long i;
-  vstring tmpStr = "";
+  vstring_def(tmpStr);
 
   long saveTempAllocStack;
   saveTempAllocStack = g_startTempAllocStack; /* For let() stack cleanup */
@@ -1521,9 +1502,9 @@ long nmbrGetSubproofLen(const nmbrString *proof, long step)
 /* This function returns a packed or "squished" proof, putting in local label
    references to previous subproofs. */
 temp_nmbrString *nmbrSquishProof(const nmbrString *proof) {
-  nmbrString *newProof = NULL_NMBRSTRING;
-  nmbrString *dummyProof = NULL_NMBRSTRING;
-  nmbrString *subProof = NULL_NMBRSTRING;
+  nmbrString_def(newProof);
+  nmbrString_def(dummyProof);
+  nmbrString_def(subProof);
   long step, dummyStep, subPrfLen, matchStep, plen;
   flag foundFlag;
 
@@ -1563,8 +1544,8 @@ temp_nmbrString *nmbrSquishProof(const nmbrString *proof) {
     }
     dummyStep++;
   } /* Next step */
-  nmbrLet(&subProof, NULL_NMBRSTRING);
-  nmbrLet(&dummyProof, NULL_NMBRSTRING);
+  free_nmbrString(subProof);
+  free_nmbrString(dummyProof);
   return nmbrMakeTempAlloc(newProof); /* Flag it for deallocation */
 }
 
@@ -1572,8 +1553,8 @@ temp_nmbrString *nmbrSquishProof(const nmbrString *proof) {
 /* This function unpacks a "squished" proof, replacing local label references
    to previous subproofs by the subproofs themselves. */
 temp_nmbrString *nmbrUnsquishProof(const nmbrString *proof) {
-  nmbrString *newProof = NULL_NMBRSTRING;
-  nmbrString *subProof = NULL_NMBRSTRING;
+  nmbrString_def(newProof);
+  nmbrString_def(subProof);
   long step, plen, subPrfLen, stmt;
 
   nmbrLet(&newProof, proof);
@@ -1589,7 +1570,7 @@ temp_nmbrString *nmbrUnsquishProof(const nmbrString *proof) {
         nmbrRight(newProof, step + 2), NULL));
     step = step + subPrfLen - 1;
   }
-  nmbrLet(&subProof, NULL_NMBRSTRING);
+  free_nmbrString(subProof);
   return nmbrMakeTempAlloc(newProof); /* Flag it for deallocation */
 }
 
@@ -1603,9 +1584,9 @@ temp_nmbrString *nmbrUnsquishProof(const nmbrString *proof) {
 temp_nmbrString *nmbrGetIndentation(const nmbrString *proof, long startingLevel) {
   long plen, stmt, pos, splen, hyps, i, j;
   char type;
-  nmbrString *indentationLevel = NULL_NMBRSTRING;
-  nmbrString *subProof = NULL_NMBRSTRING;
-  nmbrString *nmbrTmp = NULL_NMBRSTRING;
+  nmbrString_def(indentationLevel);
+  nmbrString_def(subProof);
+  nmbrString_def(nmbrTmp);
 
   plen = nmbrLen(proof);
   stmt = proof[plen - 1];
@@ -1633,10 +1614,10 @@ temp_nmbrString *nmbrGetIndentation(const nmbrString *proof, long startingLevel)
     }
     pos = pos - splen;
   }
-  if (pos != -1) bug (333);
+  if (pos != -1) bug(333);
 
-  nmbrLet(&subProof,NULL_NMBRSTRING); /* Deallocate */
-  nmbrLet(&nmbrTmp, NULL_NMBRSTRING); /* Deallocate */
+  free_nmbrString(subProof); /* Deallocate */
+  free_nmbrString(nmbrTmp); /* Deallocate */
   return nmbrMakeTempAlloc(indentationLevel); /* Flag it for deallocation */
 } /* nmbrGetIndentation */
 
@@ -1649,9 +1630,9 @@ temp_nmbrString *nmbrGetIndentation(const nmbrString *proof, long startingLevel)
 nmbrString *nmbrGetEssential(const nmbrString *proof) {
   long plen, stmt, pos, splen, hyps, i, j;
   char type;
-  nmbrString *essentialFlags = NULL_NMBRSTRING;
-  nmbrString *subProof = NULL_NMBRSTRING;
-  nmbrString *nmbrTmp = NULL_NMBRSTRING;
+  nmbrString_def(essentialFlags);
+  nmbrString_def(subProof);
+  nmbrString_def(nmbrTmp);
   nmbrString *nmbrTmpPtr2;
 
   plen = nmbrLen(proof);
@@ -1690,8 +1671,8 @@ nmbrString *nmbrGetEssential(const nmbrString *proof) {
   }
   if (pos != -1) bug (1338);
 
-  nmbrLet(&subProof,NULL_NMBRSTRING); /* Deallocate */
-  nmbrLet(&nmbrTmp, NULL_NMBRSTRING); /* Deallocate */
+  free_nmbrString(subProof); /* Deallocate */
+  free_nmbrString(nmbrTmp); /* Deallocate */
   return nmbrMakeTempAlloc(essentialFlags); /* Flag it for deallocation */
 } /* nmbrGetEssential */
 
@@ -1705,9 +1686,9 @@ nmbrString *nmbrGetEssential(const nmbrString *proof) {
 temp_nmbrString *nmbrGetTargetHyp(const nmbrString *proof, long statemNum) {
   long plen, stmt, pos, splen, hyps, i, j;
   char type;
-  nmbrString *targetHyp = NULL_NMBRSTRING;
-  nmbrString *subProof = NULL_NMBRSTRING;
-  nmbrString *nmbrTmp = NULL_NMBRSTRING;
+  nmbrString_def(targetHyp);
+  nmbrString_def(subProof);
+  nmbrString_def(nmbrTmp);
 
   plen = nmbrLen(proof);
   stmt = proof[plen - 1];
@@ -1750,8 +1731,8 @@ temp_nmbrString *nmbrGetTargetHyp(const nmbrString *proof, long statemNum) {
   }
   if (pos != -1) bug (343);
 
-  nmbrLet(&subProof,NULL_NMBRSTRING); /* Deallocate */
-  nmbrLet(&nmbrTmp, NULL_NMBRSTRING); /* Deallocate */
+  free_nmbrString(subProof); /* Deallocate */
+  free_nmbrString(nmbrTmp); /* Deallocate */
   return nmbrMakeTempAlloc(targetHyp); /* Flag it for deallocation */
 } /* nmbrGetTargetHyp */
 
@@ -1766,15 +1747,15 @@ temp_nmbrString *nmbrGetTargetHyp(const nmbrString *proof, long statemNum) {
    could be "( a1i a1d ) ACBCADEF". */
 temp_vstring compressProof(const nmbrString *proof, long statemNum,
     flag oldCompressionAlgorithm) {
-  vstring output = "";
+  vstring_def(output);
   long outputLen;
   long outputAllocated;
-  nmbrString *saveProof = NULL_NMBRSTRING;
-  nmbrString *labelList = NULL_NMBRSTRING;
-  nmbrString *hypList = NULL_NMBRSTRING;
-  nmbrString *assertionList = NULL_NMBRSTRING;
-  nmbrString *localList = NULL_NMBRSTRING;
-  nmbrString *localLabelFlags = NULL_NMBRSTRING;
+  nmbrString_def(saveProof);
+  nmbrString_def(labelList);
+  nmbrString_def(hypList);
+  nmbrString_def(assertionList);
+  nmbrString_def(localList);
+  nmbrString_def(localLabelFlags);
   long hypLabels, assertionLabels, localLabels;
   long plen, step, stmt, labelLen, lab, numchrs;
   long i, j, k;
@@ -1783,24 +1764,24 @@ temp_vstring compressProof(const nmbrString *proof, long statemNum,
   static char *letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
   static char labelChar = ':';
 
-  nmbrString *explList = NULL_NMBRSTRING;
+  nmbrString_def(explList);
   long explLabels;
-  nmbrString *explRefCount = NULL_NMBRSTRING;
-  nmbrString *labelRefCount = NULL_NMBRSTRING;
+  nmbrString_def(explRefCount);
+  nmbrString_def(labelRefCount);
   long maxExplRefCount;
-  nmbrString *explComprLen = NULL_NMBRSTRING;
+  nmbrString_def(explComprLen);
   long explSortPosition;
   long maxExplComprLen;
-  vstring explUsedFlag = "";
-  nmbrString *explLabelLen = NULL_NMBRSTRING;
-  nmbrString *newExplList = NULL_NMBRSTRING;
+  vstring_def(explUsedFlag);
+  nmbrString_def(explLabelLen);
+  nmbrString_def(newExplList);
   long newExplPosition;
   long indentation;
   long explOffset;
   long explUnassignedCount;
-  nmbrString *explWorth = NULL_NMBRSTRING;
+  nmbrString_def(explWorth);
   long explWidth;
-  vstring explIncluded = "";
+  vstring_def(explIncluded);
 
 
   /* Compression standard with all cap letters */
@@ -1917,7 +1898,7 @@ temp_vstring compressProof(const nmbrString *proof, long statemNum,
     }
   }
   /* We're done with giant labelRefCount array; deallocate */
-  nmbrLet(&labelRefCount, NULL_NMBRSTRING);
+  free_nmbrString(labelRefCount);
 
   /* Assign compressed label lengths starting from most used to least
      used label */
@@ -2168,21 +2149,21 @@ temp_vstring compressProof(const nmbrString *proof, long statemNum,
                 0 /*statemNum used only if explicitTargets*/),
       " ) ", left(output, outputLen), NULL));
 
-  nmbrLet(&saveProof, NULL_NMBRSTRING);
-  nmbrLet(&labelList, NULL_NMBRSTRING);
-  nmbrLet(&hypList, NULL_NMBRSTRING);
-  nmbrLet(&assertionList, NULL_NMBRSTRING);
-  nmbrLet(&localList, NULL_NMBRSTRING);
-  nmbrLet(&localLabelFlags, NULL_NMBRSTRING);
-  nmbrLet(&explList, NULL_NMBRSTRING);
-  nmbrLet(&explRefCount, NULL_NMBRSTRING);
-  nmbrLet(&labelRefCount, NULL_NMBRSTRING);
-  nmbrLet(&explComprLen, NULL_NMBRSTRING);
-  let(&explUsedFlag, "");
-  nmbrLet(&explLabelLen, NULL_NMBRSTRING);
-  nmbrLet(&newExplList, NULL_NMBRSTRING);
-  nmbrLet(&explWorth, NULL_NMBRSTRING);
-  let(&explIncluded, "");
+  free_nmbrString(saveProof);
+  free_nmbrString(labelList);
+  free_nmbrString(hypList);
+  free_nmbrString(assertionList);
+  free_nmbrString(localList);
+  free_nmbrString(localLabelFlags);
+  free_nmbrString(explList);
+  free_nmbrString(explRefCount);
+  free_nmbrString(labelRefCount);
+  free_nmbrString(explComprLen);
+  free_vstring(explUsedFlag);
+  free_nmbrString(explLabelLen);
+  free_nmbrString(newExplList);
+  free_nmbrString(explWorth);
+  free_vstring(explIncluded);
 
   return makeTempAlloc(output); /* Flag it for deallocation */
 } /* compressProof */
@@ -2192,8 +2173,8 @@ temp_vstring compressProof(const nmbrString *proof, long statemNum,
    and return its size in bytes. */
 /* TODO: call this in MINIMIZE_WITH in metamath.c */
 long compressedProofSize(const nmbrString *proof, long statemNum) {
-  vstring tmpStr = "";
-  nmbrString *tmpNmbr = NULL_NMBRSTRING;
+  nmbrString_def(tmpNmbr);
+  vstring_def(tmpStr);
   long bytes;
   nmbrLet(&tmpNmbr, nmbrSquishProof(proof));
   let(&tmpStr, compressProof(tmpNmbr,
@@ -2202,8 +2183,8 @@ long compressedProofSize(const nmbrString *proof, long statemNum) {
           ));
   bytes = (long)strlen(tmpStr);
   /* Deallocate memory */
-  let(&tmpStr, "");
-  nmbrLet(&tmpNmbr, NULL_NMBRSTRING);
+  free_vstring(tmpStr);
+  free_nmbrString(tmpNmbr);
   return bytes;
 } /* compressedProofSize */
 
@@ -2616,15 +2597,14 @@ long pntrRevInstr(long start_position, const pntrString *string1,
     const pntrString *string2)
 {
    long ls1,ls2;
-   pntrString *tmp = NULL_PNTRSTRING;
    ls1=pntrLen(string1);
    ls2=pntrLen(string2);
    if (start_position>ls1-ls2+1) start_position=ls1-ls2+2;
    if (start_position<1) return 0;
    while (!pntrEq(string2,pntrMid(string1,start_position,ls2))) {
      start_position--;
-     pntrLet(&tmp,NULL_PNTRSTRING);
-                /* Clear pntrString buffer to prevent overflow caused by "mid" */
+     pntrTempAlloc(0);
+        /* Clear temporaries to prevent overflow caused by "mid" */
      if (start_position < 1) return 0;
    }
    return (start_position);
@@ -2794,7 +2774,7 @@ long getSourceIndentation(long statemNum) {
    a statement.  This is used to provide the user with information in the SHOW
    STATEMENT command.  The caller must deallocate the result. */
 vstring getDescription(long statemNum) {
-  vstring description = "";
+  vstring_def(description);
   long p1, p2;
 
   let(&description, space(g_Statement[statemNum].labelSectionLen));
@@ -2820,7 +2800,7 @@ vstring getDescription(long statemNum) {
    EXPAND command, we also suppress section headers if they are the last
    comment.  The caller must deallocate the result. */
 vstring getDescriptionAndLabel(long stmt) {
-  vstring descriptionAndLabel = "";
+  vstring_def(descriptionAndLabel);
   long p1, p2;
   flag dontUseComment = 0;
 
@@ -2884,15 +2864,15 @@ flag getMarkupFlag(long statemNum, flag mode) {
      matches only the first time, then saves the result for subsequent calls
      for that statement. */
   static char init = 0;
-  static vstring commentSearchedFlags = ""; /* Y if comment was searched */
-  static vstring proofFlags = "";  /* Y if proof discouragement, else N */
-  static vstring usageFlags = "";  /* Y if usage discouragement, else N */
-  vstring str1 = "";
+  static vstring_def(commentSearchedFlags); /* Y if comment was searched */
+  static vstring_def(proofFlags);  /* Y if proof discouragement, else N */
+  static vstring_def(usageFlags);  /* Y if usage discouragement, else N */
+  vstring_def(str1);
 
   if (mode == RESET) { /* Deallocate */ /* Should be called by ERASE command */
-    let(&commentSearchedFlags, "");
-    let(&proofFlags, "");
-    let(&usageFlags, "");
+    free_vstring(commentSearchedFlags);
+    free_vstring(proofFlags);
+    free_vstring(usageFlags);
     init = 0;
     return 0;
   }
@@ -2939,7 +2919,7 @@ flag getMarkupFlag(long statemNum, flag mode) {
       } else {
         usageFlags[statemNum] = 'N';
       }
-      let(&str1, ""); /* Deallocate */
+      free_vstring(str1); /* Deallocate */
     }
     commentSearchedFlags[statemNum] = 'Y';
   }
@@ -2989,35 +2969,35 @@ vstring getContrib(long stmtNum, char mode) {
      for that statement. */
   static char init = 0;
 
-  vstring contributor = "";
-  vstring contribDate = "";
-  vstring reviser = "";
-  vstring reviseDate = "";
-  vstring shortener = "";
-  vstring shortenDate = "";
-  vstring mostRecentDate = "";   /* The most recent of all 3 dates */
+  vstring_def(contributor);
+  vstring_def(contribDate);
+  vstring_def(reviser);
+  vstring_def(reviseDate);
+  vstring_def(shortener);
+  vstring_def(shortenDate);
+  vstring_def(mostRecentDate);   /* The most recent of all 3 dates */
 
-  static vstring commentSearchedFlags = ""; /* Y if comment was searched */
-  static pntrString *contributorList = NULL_PNTRSTRING;
-  static pntrString *contribDateList = NULL_PNTRSTRING;
-  static pntrString *reviserList = NULL_PNTRSTRING;
-  static pntrString *reviseDateList = NULL_PNTRSTRING;
-  static pntrString *shortenerList = NULL_PNTRSTRING;
-  static pntrString *shortenDateList = NULL_PNTRSTRING;
-  static pntrString *mostRecentDateList = NULL_PNTRSTRING;
+  static vstring_def(commentSearchedFlags); /* Y if comment was searched */
+  static pntrString_def(contributorList);
+  static pntrString_def(contribDateList);
+  static pntrString_def(reviserList);
+  static pntrString_def(reviseDateList);
+  static pntrString_def(shortenerList);
+  static pntrString_def(shortenDateList);
+  static pntrString_def(mostRecentDateList);
 
   long cStart = 0, cMid = 0, cEnd = 0;
   long rStart = 0, rMid = 0, rEnd = 0;
   long sStart = 0, sMid = 0, sEnd = 0;
   long firstR = 0, firstS = 0;
-  vstring description = "";
-  vstring tmpDate0 = "";
-  vstring tmpDate1 = "";
-  vstring tmpDate2 = "";
+  vstring_def(description);
+  vstring_def(tmpDate0);
+  vstring_def(tmpDate1);
+  vstring_def(tmpDate2);
   long stmt, p, dd, mmm, yyyy;
   flag errorCheckFlag = 0;
   flag err = 0;
-  vstring returnStr = ""; /* Return value */
+  vstring_def(returnStr); /* Return value */
 #define CONTRIB_MATCH " (Contributed by "
 #define REVISE_MATCH " (Revised by "
 #define SHORTEN_MATCH " (Proof shortened by "
@@ -3039,24 +3019,24 @@ vstring getContrib(long stmtNum, char mode) {
       for (stmt = 1; stmt <= g_statements; stmt++) {
         if (commentSearchedFlags[stmt] == 'Y') {
           /* Deallocate cached strings */
-          let((vstring *)(&(contributorList[stmt])), "");
-          let((vstring *)(&(contribDateList[stmt])), "");
-          let((vstring *)(&(reviserList[stmt])), "");
-          let((vstring *)(&(reviseDateList[stmt])), "");
-          let((vstring *)(&(shortenerList[stmt])), "");
-          let((vstring *)(&(shortenDateList[stmt])), "");
-          let((vstring *)(&(mostRecentDateList[stmt])), "");
+          free_vstring(*(vstring *)(&contributorList[stmt]));
+          free_vstring(*(vstring *)(&contribDateList[stmt]));
+          free_vstring(*(vstring *)(&reviserList[stmt]));
+          free_vstring(*(vstring *)(&reviseDateList[stmt]));
+          free_vstring(*(vstring *)(&shortenerList[stmt]));
+          free_vstring(*(vstring *)(&shortenDateList[stmt]));
+          free_vstring(*(vstring *)(&mostRecentDateList[stmt]));
         }
       }
       /* Deallocate the lists of pointers to cached strings */
-      pntrLet(&contributorList, NULL_PNTRSTRING);
-      pntrLet(&contribDateList, NULL_PNTRSTRING);
-      pntrLet(&reviserList, NULL_PNTRSTRING);
-      pntrLet(&reviseDateList, NULL_PNTRSTRING);
-      pntrLet(&shortenerList, NULL_PNTRSTRING);
-      pntrLet(&shortenDateList, NULL_PNTRSTRING);
-      pntrLet(&mostRecentDateList, NULL_PNTRSTRING);
-      let(&commentSearchedFlags, "");
+      free_pntrString(contributorList);
+      free_pntrString(contribDateList);
+      free_pntrString(reviserList);
+      free_pntrString(reviseDateList);
+      free_pntrString(shortenerList);
+      free_pntrString(shortenDateList);
+      free_pntrString(mostRecentDateList);
+      free_vstring(commentSearchedFlags);
       init = 0;
     } /* if (init != 0) */
     return "";
@@ -3074,13 +3054,13 @@ vstring getContrib(long stmtNum, char mode) {
       }
       if (commentSearchedFlags[stmtNum] == 'Y') {
         /* Deallocate cached strings */
-        let((vstring *)(&(contributorList[stmtNum])), "");
-        let((vstring *)(&(contribDateList[stmtNum])), "");
-        let((vstring *)(&(reviserList[stmtNum])), "");
-        let((vstring *)(&(reviseDateList[stmtNum])), "");
-        let((vstring *)(&(shortenerList[stmtNum])), "");
-        let((vstring *)(&(shortenDateList[stmtNum])), "");
-        let((vstring *)(&(mostRecentDateList[stmtNum])), "");
+        free_vstring(*(vstring *)(&contributorList[stmtNum]));
+        free_vstring(*(vstring *)(&contribDateList[stmtNum]));
+        free_vstring(*(vstring *)(&reviserList[stmtNum]));
+        free_vstring(*(vstring *)(&reviseDateList[stmtNum]));
+        free_vstring(*(vstring *)(&shortenerList[stmtNum]));
+        free_vstring(*(vstring *)(&shortenDateList[stmtNum]));
+        free_vstring(*(vstring *)(&mostRecentDateList[stmtNum]));
         commentSearchedFlags[stmtNum] = 'N';
       }
     } /* if (init != 0) */
@@ -3112,7 +3092,7 @@ vstring getContrib(long stmtNum, char mode) {
       || errorCheckFlag == 1 /* Needed to get sStart, rStart, cStart */) {
     /* It wasn't cached, so we extract from the statement's comment */
 
-    let(&description, "");
+    free_vstring(description);
     description = getDescription(stmtNum);
     let(&description, edit(description,
         4/*ctrl*/ + 8/*leading*/ + 16/*reduce*/ + 128/*trailing*/));
@@ -3494,19 +3474,19 @@ vstring getContrib(long stmtNum, char mode) {
 
  RETURN_POINT:
 
-  let(&description, "");
+  free_vstring(description);
 
   if (errorCheckFlag == 1) { /* Slight speedup */
-    let(&contributor, "");
-    let(&contribDate, "");
-    let(&reviser, "");
-    let(&reviseDate, "");
-    let(&shortener, "");
-    let(&shortenDate, "");
-    let(&mostRecentDate, "");
-    let(&tmpDate0, "");
-    let(&tmpDate1, "");
-    let(&tmpDate2, "");
+    free_vstring(contributor);
+    free_vstring(contribDate);
+    free_vstring(reviser);
+    free_vstring(reviseDate);
+    free_vstring(shortener);
+    free_vstring(shortenDate);
+    free_vstring(mostRecentDate);
+    free_vstring(tmpDate0);
+    free_vstring(tmpDate1);
+    free_vstring(tmpDate2);
   }
 
   return returnStr;
@@ -3518,7 +3498,7 @@ vstring getContrib(long stmtNum, char mode) {
    THIS WILL BECOME OBSOLETE WHEN WE START TO USE DATES IN THE
    DESCRIPTION. */
 void getProofDate(long stmtNum, vstring *date1, vstring *date2) {
-  vstring textAfterProof = "";
+  vstring_def(textAfterProof);
   long p1, p2;
   let(&textAfterProof, space(g_Statement[stmtNum + 1].labelSectionLen));
   memcpy(textAfterProof, g_Statement[stmtNum + 1].labelSectionPtr,
@@ -3539,7 +3519,7 @@ void getProofDate(long stmtNum, vstring *date1, vstring *date2) {
     let(&(*date1), ""); /* No 1st or 2nd date stamp */
     let(&(*date2), "");
   }
-  let(&textAfterProof, ""); /* Deallocate */
+  free_vstring(textAfterProof); /* Deallocate */
   return;
 } /* getProofDate */
 
@@ -3617,7 +3597,7 @@ flag compareDates(vstring date1, vstring date2) {
    start at the beginning of each line. */
 int qsortStringCmp(const void *p1, const void *p2)
 {
-  vstring tmp = "";
+  vstring_def(tmp);
   long n1, n2;
   int r;
   /* Returns -1 if p1 < p2, 0 if equal, 1 if p1 > p2 */
@@ -3630,7 +3610,7 @@ int qsortStringCmp(const void *p1, const void *p2)
     r = strcmp(
         right(*(char * const *)p1, n1),
         right(*(char * const *)p2, n2));
-    let(&tmp, ""); /* Deallocate temp string stack */
+    free_vstring(tmp); /* Deallocate temp string stack */
     return r;
   }
 }

--- a/src/mmdata.h
+++ b/src/mmdata.h
@@ -208,6 +208,8 @@ struct nullNmbrStruct {
     nmbrString nullElement; };
 extern struct nullNmbrStruct g_NmbrNull;
 #define NULL_NMBRSTRING &(g_NmbrNull.nullElement)
+#define nmbrString_def(x) nmbrString *x = NULL_NMBRSTRING
+#define free_nmbrString(x) nmbrLet(&x, NULL_NMBRSTRING)
 
 /* Null pntrString -- NULL flags the end of a pntrString */
 struct nullPntrStruct {
@@ -217,6 +219,8 @@ struct nullPntrStruct {
     pntrString nullElement; };
 extern struct nullPntrStruct g_PntrNull;
 #define NULL_PNTRSTRING &(g_PntrNull.nullElement)
+#define pntrString_def(x) pntrString *x = NULL_PNTRSTRING
+#define free_pntrString(x) pntrLet(&x, NULL_PNTRSTRING)
 
 
 /* This function returns a 1 if any entry in a comma-separated list

--- a/src/mmhlpa.c
+++ b/src/mmhlpa.c
@@ -20,7 +20,7 @@
 /* help0 is mostly for TOOLS help */
 void help0(vstring helpCmd) {
 
-vstring saveHelpCmd = "";
+vstring_def(saveHelpCmd);
 /* help0() may be called with a temporarily allocated argument (left(),
    cat(), etc.), and the let()s in the eventual print2() calls will
    deallocate and possibly corrupt helpCmd.  So, we grab a non-temporarily
@@ -346,7 +346,7 @@ H("For your convenience, the trailing quote is optional, for example:");
 H("    Tools> 'ls | more");
 H("");
 
-let(&saveHelpCmd, ""); /* Deallocate memory */
+free_vstring(saveHelpCmd); /* Deallocate memory */
 
 return;
 } /* help0 */
@@ -355,7 +355,7 @@ return;
 /* Note: help1 should contain Metamath help */
 void help1(vstring helpCmd) {
 
-vstring saveHelpCmd = "";
+vstring_def(saveHelpCmd);
 /* help1() may be called with a temporarily allocated argument (left(),
    cat(), etc.), and the let()s in the eventual print2() calls will
    deallocate and possibly corrupt helpCmd.  So, we grab a non-temporarily
@@ -1142,7 +1142,7 @@ H("GIF format unless ALT_HTML was previously set as shown in SHOW SETTINGS.");
 H("");
 
 
-let(&saveHelpCmd, ""); /* Deallocate memory */
+free_vstring(saveHelpCmd); /* Deallocate memory */
 return;
 
 } /* help1 */

--- a/src/mmhlpb.c
+++ b/src/mmhlpb.c
@@ -18,7 +18,7 @@
 void help2(vstring helpCmd)
 {
 
-vstring saveHelpCmd = "";
+vstring_def(saveHelpCmd);
 /* help2() may be called with a temporarily allocated argument (left(),
    cat(), etc.), and the let()s in the eventual print2() calls will
    deallocate and possibly corrupt helpCmd.  So, we grab a non-temporarily
@@ -348,7 +348,7 @@ H("        statements are excluded when <label-match> contains wildcard");
 H("        characters.");
 H("");
 
-let(&saveHelpCmd, ""); /* Deallocate memory */
+free_vstring(saveHelpCmd); /* Deallocate memory */
 
 return;
 } /* help2 */
@@ -357,7 +357,7 @@ return;
 /* Split up help2 into help2 and help3 so lcc optimizer wouldn't overflow */
 void help3(vstring helpCmd) {
 
-vstring saveHelpCmd = "";
+vstring_def(saveHelpCmd);
 /* help3() may be called with a temporarily allocated argument (left(),
    cat(), etc.), and the let()s in the eventual print2() calls will
    deallocate and possibly corrupt helpCmd.  So, we grab a non-temporarily
@@ -1398,6 +1398,6 @@ H("will show all statements with subset then union in them.");
 H("");
 
 if (strcmp(helpCmd, saveHelpCmd)) bug(1401); /* helpCmd got corrupted */
-let(&saveHelpCmd, ""); /* Deallocate memory */
+free_vstring(saveHelpCmd); /* Deallocate memory */
 
 }

--- a/src/mmpars.c
+++ b/src/mmpars.c
@@ -720,7 +720,7 @@ void parseStatements(void) {
   long reqHyps, optHyps, reqVars, optVars;
   flag reqFlag;
   int undeclErrorCount = 0;
-  vstring tmpStr = "";
+  vstring_def(tmpStr);
 
   nmbrString *nmbrTmpPtr;
 
@@ -1920,7 +1920,7 @@ void parseStatements(void) {
   free(wrkNmbrPtr);
   free(wrkStrPtr);
   free(symbolLenExists);
-  let(&tmpStr, "");
+  free_vstring(tmpStr);
 }
 
 
@@ -1946,18 +1946,18 @@ char parseProof(long statemNum)
 
   flag explicitTargets = 0; /* Proof is of form <target>=<source> */
   /* Source file pointers and token sizes for targets in a /EXPLICIT proof */
-  pntrString *targetPntr = NULL_PNTRSTRING; /* Pointers to target tokens */
-  nmbrString *targetNmbr = NULL_NMBRSTRING; /* Size of target tokens */
+  pntrString_def(targetPntr); /* Pointers to target tokens */
+  nmbrString_def(targetNmbr); /* Size of target tokens */
   /* Variables for rearranging /EXPLICIT proof */
-  nmbrString *wrkProofString = NULL_NMBRSTRING; /* Holds g_WrkProof.proofString */
+  nmbrString_def(wrkProofString); /* Holds g_WrkProof.proofString */
   long hypStepNum, hypSubProofLen, conclSubProofLen;
   long matchingHyp;
-  nmbrString *oldStepNums = NULL_NMBRSTRING; /* Just numbers 0 to numSteps-1 */
-  pntrString *reqHypSubProof = NULL_PNTRSTRING; /* Subproofs of hypotheses */
-  pntrString *reqHypOldStepNums = NULL_PNTRSTRING; /* Local label flag for
+  nmbrString_def(oldStepNums); /* Just numbers 0 to numSteps-1 */
+  pntrString_def(reqHypSubProof); /* Subproofs of hypotheses */
+  pntrString_def(reqHypOldStepNums); /* Local label flag for
                                                      subproofs of hypotheses */
-  nmbrString *rearrangedSubProofs = NULL_NMBRSTRING;
-  nmbrString *rearrangedOldStepNums = NULL_NMBRSTRING;
+  nmbrString_def(rearrangedSubProofs);
+  nmbrString_def(rearrangedOldStepNums);
   flag subProofMoved; /* Flag to restart scan after moving subproof */
 
   if (g_Statement[statemNum].type != p_) {
@@ -2495,7 +2495,7 @@ char parseProof(long statemNum)
             str((double)step + 1),", statement \"",
             g_Statement[j].labelName,"\" requires ",
             tmpStrPtr,".",NULL));
-        let(&tmpStrPtr, "");
+        free_vstring(tmpStrPtr);
       }
       /* Treat it like an unknown step so stack won't get exhausted */
       g_WrkProof.errorCount++;
@@ -2540,7 +2540,7 @@ char parseProof(long statemNum)
                         /* Uncomment above if bad proof triggers this bug */
         bug(1731);
       }
-      nmbrLet(&rearrangedSubProofs, NULL_NMBRSTRING);
+      free_nmbrString(rearrangedSubProofs);
       matchingHyp = -1; /* In case there are no hypotheses */
       for (i = 0; i < numReqHyp; i++) {
         matchingHyp = -1;
@@ -2607,14 +2607,14 @@ char parseProof(long statemNum)
 
       /* Deallocate */
       for (i = 0; i < numReqHyp; i++) {
-        nmbrLet((nmbrString **)(&(reqHypSubProof[i])), NULL_NMBRSTRING);
-        nmbrLet((nmbrString **)(&(reqHypOldStepNums[i])), NULL_NMBRSTRING);
+        free_nmbrString(*(nmbrString **)(&(reqHypSubProof[i])));
+        free_nmbrString(*(nmbrString **)(&(reqHypOldStepNums[i])));
       }
-      pntrLet(&reqHypSubProof, NULL_PNTRSTRING);
-      pntrLet(&reqHypOldStepNums, NULL_PNTRSTRING);
-      nmbrLet(&rearrangedSubProofs, NULL_NMBRSTRING);
-      nmbrLet(&rearrangedOldStepNums, NULL_NMBRSTRING);
-      nmbrLet(&wrkProofString, NULL_NMBRSTRING);
+      free_pntrString(reqHypSubProof);
+      free_pntrString(reqHypOldStepNums);
+      free_nmbrString(rearrangedSubProofs);
+      free_nmbrString(rearrangedOldStepNums);
+      free_nmbrString(wrkProofString);
     } /* if explicitTargets */
 
     numReqHyp = g_Statement[j].numReqHyp;
@@ -2768,10 +2768,10 @@ char parseProof(long statemNum)
     } while (subProofMoved);
 
     /* Deallocate */
-    pntrLet(&targetPntr, NULL_PNTRSTRING);
-    nmbrLet(&targetNmbr, NULL_NMBRSTRING);
-    nmbrLet(&oldStepNums, NULL_NMBRSTRING);
-    nmbrLet(&wrkProofString, NULL_NMBRSTRING);
+    free_pntrString(targetPntr);
+    free_nmbrString(targetNmbr);
+    free_nmbrString(oldStepNums);
+    free_nmbrString(wrkProofString);
   } /* if (explicitTargets) */
 
   g_WrkProof.errorSeverity = returnFlag;
@@ -3209,7 +3209,7 @@ char parseCompressedProof(long statemNum)
                   str((double)(g_WrkProof.numSteps + 1)),", statement \"",
                   g_Statement[stmt].labelName,"\" requires ",
                   tmpStrPtr,".",NULL));
-              let(&tmpStrPtr, "");
+              free_vstring(tmpStrPtr);
             }
             /* Treat it like an unknown step so stack won't get exhausted */
             g_WrkProof.errorCount++;
@@ -3441,7 +3441,7 @@ char parseCompressedProof(long statemNum)
 /* TODO: use this function to simplify some code that calls parseProof
    directly. */
 nmbrString *getProof(long statemNum, flag printFlag) {
-  nmbrString *proof = NULL_NMBRSTRING;
+  nmbrString_def(proof);
   parseProof(statemNum);
   /* We do not need verifyProof() since we don't care about the math
      strings for the proof steps in this function. */
@@ -3467,9 +3467,9 @@ nmbrString *getProof(long statemNum, flag printFlag) {
 void rawSourceError(char *startFile, char *ptr, long tokLen, vstring errMsg) {
   char *startLine;
   char *endLine;
-  vstring errLine = "";
-  vstring errorMsg = "";
-  vstring fileName = "";
+  vstring_def(errLine);
+  vstring_def(errorMsg);
+  vstring_def(fileName);
   long lineNum;
 
   let(&errorMsg, errMsg); /* Prevent deallocation of errMsg */
@@ -3494,9 +3494,9 @@ void rawSourceError(char *startFile, char *ptr, long tokLen, vstring errMsg) {
   errorMessage(errLine, lineNum, ptr - startLine + 1, tokLen, errorMsg,
       fileName, 0, (char)error_);
   print2("\n");
-  let(&errLine, "");
-  let(&errorMsg, "");
-  let(&fileName, "");
+  free_vstring(errLine);
+  free_vstring(errorMsg);
+  free_vstring(fileName);
 } /* rawSourceError */
 
 /* The global g_sourcePtr is assumed to point to the start of the raw input
@@ -3507,10 +3507,10 @@ void sourceError(char *ptr, long tokLen, long stmtNum, vstring errMsg)
 {
   char *startLine;
   char *endLine;
-  vstring errLine = "";
+  vstring_def(errLine);
   long lineNum;
-  vstring fileName = "";
-  vstring errorMsg = "";
+  vstring_def(fileName);
+  vstring_def(errorMsg);
 
   /* Used for the case where a source file section has been modified */
   char *locSourcePtr;
@@ -3554,7 +3554,7 @@ void sourceError(char *ptr, long tokLen, long stmtNum, vstring errMsg)
     goto SKIP_LINE_NUM;
   }
 
-  /*let(&fileName, "");*/ /* No need - already assigned to empty string */
+  /*free_vstring(fileName);*/ /* No need - already assigned to empty string */
   fileName = getFileAndLineNum(locSourcePtr/*=g_sourcePtr here*/, ptr, &lineNum);
 
  SKIP_LINE_NUM:
@@ -3595,9 +3595,9 @@ void sourceError(char *ptr, long tokLen, long stmtNum, vstring errMsg)
         stmtNum,
         (char)error_ /* severity */);
   }
-  let(&errLine, "");
-  let(&errorMsg, "");
-  let(&fileName, "");
+  free_vstring(errLine);
+  free_vstring(errorMsg);
+  free_vstring(fileName);
 } /* sourceError */
 
 
@@ -3621,8 +3621,8 @@ void mathTokenError(long tokenNum /* 0 is 1st one */,
 
 vstring shortDumpRPNStack(void) {
   /* The caller must deallocate the returned string. */
-  vstring tmpStr = "";
-  vstring tmpStr2 = "";
+  vstring_def(tmpStr);
+  vstring_def(tmpStr2);
   long i, k, m;
 
   for (i = 0; i < g_WrkProof.RPNStackPtr; i++) {
@@ -3653,7 +3653,7 @@ vstring shortDumpRPNStack(void) {
   }
   let(&tmpStr2,cat("RPN stack contains ",tmpStr2,NULL));
   if (g_WrkProof.RPNStackPtr == 0) let(&tmpStr2,"RPN stack is empty");
-  let(&tmpStr, "");
+  free_vstring(tmpStr);
   return tmpStr2;
 } /* shortDumpRPNStack */
 
@@ -3668,36 +3668,35 @@ long lookupLabel(const char *label)
   voidPtr = (void *)bsearch(label, g_labelKeyBase, (size_t)g_numLabelKeys,
       sizeof(long), labelSrchCmp);
   if (!voidPtr) {
-    return (-1);
+    return -1;
   }
   statemNum = (*(long *)voidPtr); /* Statement number */
   if (g_Statement[statemNum].type != a_ && g_Statement[statemNum].type != p_)
-      bug(1718);
-  return (statemNum);
+    bug(1718);
+  return statemNum;
 } /* lookupLabel */
 
 
 /* Label comparison for qsort */
 int labelSortCmp(const void *key1, const void *key2) {
   /* Returns -1 if key1 < key2, 0 if equal, 1 if key1 > key2 */
-  return (strcmp(g_Statement[ *((long *)key1) ].labelName,
-      g_Statement[ *((long *)key2) ].labelName));
+  return strcmp(g_Statement[ *((long *)key1) ].labelName,
+      g_Statement[ *((long *)key2) ].labelName);
 } /* labelSortCmp */
 
 
 /* Label comparison for bsearch */
 int labelSrchCmp(const void *key, const void *data) {
   /* Returns -1 if key < data, 0 if equal, 1 if key > data */
-  return (strcmp(key,
-      g_Statement[ *((long *)data) ].labelName));
+  return strcmp(key, g_Statement[ *((long *)data) ].labelName);
 } /* labelSrchCmp */
 
 
 /* Math symbol comparison for qsort */
 int mathSortCmp(const void *key1, const void *key2) {
   /* Returns -1 if key1 < key2, 0 if equal, 1 if key1 > key2 */
-  return (strcmp(g_MathToken[ *((long *)key1) ].tokenName,
-      g_MathToken[ *((long *)key2) ].tokenName));
+  return strcmp(g_MathToken[ *((long *)key1) ].tokenName,
+      g_MathToken[ *((long *)key2) ].tokenName);
 }
 
 
@@ -3705,15 +3704,16 @@ int mathSortCmp(const void *key1, const void *key2) {
 /* Here, key is pointer to a character string. */
 int mathSrchCmp(const void *key, const void *data) {
   /* Returns -1 if key < data, 0 if equal, 1 if key > data */
-  return (strcmp(key, g_MathToken[ *((long *)data) ].tokenName));
+  return strcmp(key, g_MathToken[ *((long *)data) ].tokenName);
 }
 
 
 /* Hypotheses and local label comparison for qsort */
 int hypAndLocSortCmp(const void *key1, const void *key2) {
   /* Returns -1 if key1 < key2, 0 if equal, 1 if key1 > key2 */
-  return (strcmp( ((struct sortHypAndLoc *)key1)->labelName,
-      ((struct sortHypAndLoc *)key2)->labelName));
+  return strcmp(
+    ((struct sortHypAndLoc *)key1)->labelName,
+    ((struct sortHypAndLoc *)key2)->labelName);
 }
 
 
@@ -3721,7 +3721,7 @@ int hypAndLocSortCmp(const void *key1, const void *key2) {
 /* Here, key is pointer to a character string. */
 int hypAndLocSrchCmp(const void *key, const void *data) {
   /* Returns -1 if key < data, 0 if equal, 1 if key > data */
-  return (strcmp(key, ((struct sortHypAndLoc *)data)->labelName));
+  return strcmp(key, ((struct sortHypAndLoc *)data)->labelName);
 }
 
 
@@ -3931,13 +3931,13 @@ long countLines(const char *start, long length) {
    since the previous statement is needed to populate dollarDpos
    and previousType */
 vstring outputStatement(long stmt, flag reformatFlag) {
-  vstring labelSection = "";
-  vstring mathSection = "";
-  vstring proofSection = "";
-  vstring labelSectionSave = "";
-  vstring mathSectionSave = "";
-  vstring proofSectionSave = "";
-  vstring output = "";
+  vstring_def(labelSection);
+  vstring_def(mathSection);
+  vstring_def(proofSection);
+  vstring_def(labelSectionSave);
+  vstring_def(mathSectionSave);
+  vstring_def(proofSectionSave);
+  vstring_def(output);
   /* For reformatting: */
   long slen; /* To save local string length */
   long pos;
@@ -3946,8 +3946,8 @@ vstring outputStatement(long stmt, flag reformatFlag) {
   static char previousType = illegal_;  /* '?' in mmdata.h */
   long commentStart;
   long commentEnd;
-  vstring comment = "";
-  vstring str1 = "";
+  vstring_def(comment);
+  vstring_def(str1);
   long length;
   flag nowrapHtml;
 
@@ -4154,7 +4154,7 @@ vstring outputStatement(long stmt, flag reformatFlag) {
 
           if (reformatFlag == 2) {
             /* If / REWRAP was specified, unwrap and rewrap the line */
-            let(&str1, "");
+            free_vstring(str1);
             str1 = rewrapComment(comment);
             let(&comment, str1);
           }
@@ -4183,12 +4183,12 @@ vstring outputStatement(long stmt, flag reformatFlag) {
           /* Reformat the comment to wrap if necessary */
           if (g_outputToString == 1) bug(1726);
           g_outputToString = 1;
-          let(&g_printString, "");
+          free_vstring(g_printString);
 
           printLongLine(cat(space(indent), comment, NULL),
               space(indent + 3), " ");
           let(&comment, g_printString);
-          let(&g_printString, "");
+          free_vstring(g_printString);
           g_outputToString = 0;
 #define ASCII_4 4
           /* Restore ASCII_4 characters put in by rewrapComment() to space */
@@ -4364,14 +4364,14 @@ vstring outputStatement(long stmt, flag reformatFlag) {
     }
   }
 
-  let(&labelSection, "");
-  let(&mathSection, "");
-  let(&proofSection, "");
-  let(&labelSectionSave, "");
-  let(&mathSectionSave, "");
-  let(&proofSectionSave, "");
-  let(&comment, "");
-  let(&str1, "");
+  free_vstring(labelSection);
+  free_vstring(mathSection);
+  free_vstring(proofSection);
+  free_vstring(labelSectionSave);
+  free_vstring(mathSectionSave);
+  free_vstring(proofSectionSave);
+  free_vstring(comment);
+  free_vstring(str1);
   return output; /* The calling routine must deallocate this vstring */
 } /* outputStatement */
 
@@ -4385,8 +4385,8 @@ vstring rewrapComment(const char *comment1) {
 /* #define CLOSING_PUNCTUATION ".,;)?!:]'\"_-" */
 #define CLOSING_PUNCTUATION ".,;)?!:]'\""
 #define SENTENCE_END_PUNCTUATION ")'\""
-  vstring comment = "";
-  vstring commentTemplate = ""; /* Non-breaking space template */
+  vstring_def(comment);
+  vstring_def(commentTemplate); /* Non-breaking space template */
   long length, pos, i, j;
   vstring ch; /* Pointer only; do not allocate */
   flag mathmode = 0;
@@ -4610,8 +4610,7 @@ vstring rewrapComment(const char *comment1) {
     if (commentTemplate[pos] == ASCII_4) comment[pos] = ASCII_4;
   }
 
-  let(&commentTemplate, "");
-
+  free_vstring(commentTemplate);
   return comment;
 } /* rewrapComment */
 
@@ -4641,8 +4640,8 @@ nmbrString *parseMathTokens(vstring userText, long statemNum)
   int maxScope;
   flag errorFlag = 0; /* Prevents bad token from being added to output */
   int errCount = 0; /* Cumulative error count */
-  vstring tmpStr = "";
-  vstring nlUserText = "";
+  vstring_def(tmpStr);
+  vstring_def(nlUserText);
 
 
   long *mathTokenSameAs; /* Flag that symbol is unique (for speed up) */
@@ -4655,7 +4654,7 @@ nmbrString *parseMathTokens(vstring userText, long statemNum)
   char *wrkStrPtr;
 
   /* The answer */
-  nmbrString *mathString = NULL_NMBRSTRING;
+  nmbrString_def(mathString);
 
   long maxSymbolLen; /* Longest math symbol (for speedup) */
   flag *symbolLenExists; /* A symbol with this length exists (for speedup) */
@@ -4883,8 +4882,8 @@ nmbrString *parseMathTokens(vstring userText, long statemNum)
   free(wrkNmbrPtr);
   free(wrkStrPtr);
   free(symbolLenExists);
-  let(&tmpStr, "");
-  let(&nlUserText, "");
+  free_vstring(tmpStr);
+  free_vstring(nlUserText);
 
   return nmbrMakeTempAlloc(mathString); /* Flag for dealloc */
 } /* parseMathTokens */
@@ -5142,7 +5141,7 @@ cmdType = 'S':
   } else {
     *cmdType = 'N'; /* no include was found */
     *cmdPos1 = 0; *cmdPos2 = 0; *endPos1 = 0; *endPos2 = 0;
-    let(&(*fileName), "");
+    free_vstring(*fileName);
   }
   return;
 
@@ -5154,10 +5153,9 @@ cmdType = 'S':
    to a linear buffer in preparation for creating the output file.
    Any changes such as modified proofs will be updated in the buffer. */
 /* The caller is responsible for deallocating the returned string. */
-vstring writeSourceToBuffer(void)
-{
+vstring writeSourceToBuffer(void) {
   long stmt, size;
-  vstring buf = "";
+  vstring_def(buf);
   char *ptr;
 
   /* Compute the size of the buffer */
@@ -5274,11 +5272,11 @@ vstring writeSourceToBuffer(void)
 /*flag(TODO)*/ void writeSplitSource(vstring *fileBuf, const char *fileName,
     flag noVersioningFlag, flag noDeleteFlag) {
   FILE *fp;
-  vstring tmpStr1 = "";
-  vstring tmpFileName = "";
-  vstring includeBuf = "";
-  vstring includeFn = "";
-  vstring fileNameWithPath = "";
+  vstring_def(tmpStr1);
+  vstring_def(tmpFileName);
+  vstring_def(includeBuf);
+  vstring_def(includeFn);
+  vstring_def(fileNameWithPath);
   long size;
   flag writeFlag;
   long startOffset;
@@ -5309,7 +5307,7 @@ vstring writeSourceToBuffer(void)
       } else {
         /* We're writing an included file */
         /* See if the file already exists */
-        let(&tmpStr1, "");
+        free_vstring(tmpStr1);
         tmpStr1 = readFileToString(fileNameWithPath, 0/*quiet*/, &size);
         if (tmpStr1 == NULL) {
           tmpStr1 = ""; /* Prevent seg fault */
@@ -5399,12 +5397,12 @@ vstring writeSourceToBuffer(void)
     }
   } /* while (1) */
   /* Deallocate memory */
-  /*let(&(*fileBuf), "");*/ /* Let caller decide whether to do this */
-  let(&tmpStr1, "");
-  let(&tmpFileName, "");
-  let(&includeFn, "");
-  let(&includeBuf, "");
-  let(&fileNameWithPath, "");
+  /* free_vstring(*fileBuf); */ /* Let caller decide whether to do this */
+  free_vstring(tmpStr1);
+  free_vstring(tmpFileName);
+  free_vstring(includeFn);
+  free_vstring(includeBuf);
+  free_vstring(fileNameWithPath);
 } /* writeSplitSource */
 
 
@@ -5413,8 +5411,8 @@ vstring writeSourceToBuffer(void)
    to ~1) since their content will be in the main output file. */
 /*flag(TODO)*/ void deleteSplits(vstring *fileBuf, flag noVersioningFlag) {
   FILE *fp;
-  vstring includeFn = "";
-  vstring fileNameWithPath = "";
+  vstring_def(includeFn);
+  vstring_def(fileNameWithPath);
   long startOffset;
   long cmdPos1;
   long cmdPos2;
@@ -5472,9 +5470,9 @@ vstring writeSourceToBuffer(void)
     continue;
   } /* while (1) */
   /* Deallocate memory */
-  /*let(&(*fileBuf), "");*/ /* Let caller decide whether to do this */
-  let(&includeFn, "");
-  let(&fileNameWithPath, "");
+  /* free_vstring(*fileBuf); */ /* Let caller decide whether to do this */
+  free_vstring(includeFn);
+  free_vstring(fileNameWithPath);
   return;
 } /* deleteSplits */
 
@@ -5486,7 +5484,7 @@ vstring getFileAndLineNum(const char *buffPtr /* start of read buffer */,
     const char *currentPtr /* place at which to get file name and line no */,
     long *lineNum /* return argument */) {
   long i, smallestOffset, smallestNdx;
-  vstring fileName = "";
+  vstring_def(fileName);
 
   /* Make sure it's not outside the read buffer */
   if (currentPtr < buffPtr
@@ -5549,12 +5547,12 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
 {
   long i;
   long inclSize;
-  vstring newFileBuf = "";
-  vstring inclPrefix = "";
-  vstring tmpSource = "";
-  vstring inclSource = "";
-  vstring oldSource = "";
-  vstring inclSuffix = "";
+  vstring_def(newFileBuf);
+  vstring_def(inclPrefix);
+  vstring_def(tmpSource);
+  vstring_def(inclSource);
+  vstring_def(oldSource);
+  vstring_def(inclSuffix);
 
   long startOffset;
   long cmdPos1;
@@ -5566,9 +5564,9 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
   long newInclSize = 0; /* Init to avoid compiler warning */
   long befInclLineNum;
   long aftInclLineNum;
-  vstring includeFn = "";
-  vstring fullInputFn = "";
-  vstring fullIncludeFn = "";
+  vstring_def(includeFn);
+  vstring_def(fullInputFn);
+  vstring_def(fullIncludeFn);
   long alreadyInclBy;
   long saveInclCalls;
 
@@ -5712,7 +5710,7 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
 
           /* Call recursively to expand any includes in the included source */
           /* Use parentLineNum since the inclusion source is in the parent file */
-          let(&inclSource, "");
+          free_vstring(inclSource);
           inclSource = readInclude(tmpSource,
               fileBufOffset + cmdPos1 - 1 + (long)strlen(inclPrefix), /*new offset*/
               /*includeFn,*/ sourceFileName,
@@ -5731,7 +5729,7 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
         case 'I':
           /* Read the included file */
           let(&fullIncludeFn, cat(g_rootDirectory, includeFn, NULL));
-          let(&tmpSource, "");
+          free_vstring(tmpSource);
           tmpSource = readFileToString(fullIncludeFn, 0/*verbose*/, &inclSize);
           if (tmpSource == NULL) {
             /* TODO: print better error msg?*/
@@ -5769,7 +5767,7 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
 
           /* Call recursively to expand includes in the included source */
           /* Start at line 1 since source is in external file */
-          let(&inclSource, "");
+          free_vstring(inclSource);
           inclSource = readInclude(tmpSource,
               fileBufOffset + cmdPos1 - 1 + (long)strlen(inclPrefix), /*new offset*/
               /*includeFn,*/ includeFn,
@@ -5802,7 +5800,7 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
         case 'S':
           /* Read the included file */
           let(&fullIncludeFn, cat(g_rootDirectory, includeFn, NULL));
-          let(&tmpSource, "");
+          free_vstring(tmpSource);
           tmpSource = readFileToString(fullIncludeFn, 1/*verbose*/, &inclSize);
           if (tmpSource == NULL) {
             /* TODO: print better error msg */
@@ -5832,7 +5830,7 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
 
           /* Call recursively to expand includes in the included source */
           /* Start at line 1 since source is in external file */
-          let(&inclSource, "");
+          free_vstring(inclSource);
           inclSource = readInclude(tmpSource,
               fileBufOffset + cmdPos1 - 1 + (long)strlen(inclPrefix), /*new offset*/
               /*includeFn,*/ includeFn,
@@ -5865,7 +5863,7 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
           let(&inclSource,
               seg(newFileBuf, cmdPos2, endPos1 - 1));
           /* Make sure it's content matches */
-          let(&oldSource, "");
+          free_vstring(oldSource);
           oldSource = g_IncludeCall[  /* Connect to source for brevity */
                   alreadyInclBy
                   ].current_includeSource;
@@ -6014,14 +6012,14 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
   } /* while (1) */
 
   /* Deallocate strings */
-  let(&inclSource, "");
-  let(&tmpSource, "");
-  let(&oldSource, "");
-  let(&inclPrefix, "");
-  let(&inclSuffix, "");
-  let(&includeFn, "");
-  let(&fullInputFn, "");
-  let(&fullIncludeFn, "");
+  free_vstring(inclSource);
+  free_vstring(tmpSource);
+  free_vstring(oldSource);
+  free_vstring(inclPrefix);
+  free_vstring(inclSuffix);
+  free_vstring(includeFn);
+  free_vstring(fullInputFn);
+  free_vstring(fullIncludeFn);
 
   return newFileBuf;
 } /* readInclude */
@@ -6035,19 +6033,18 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
 vstring readSourceAndIncludes(const char *inputFn /*input*/, long *size /*output*/) {
   long i;
 /*D*//*long j;*/
-/*D*//*vstring s=""; */
-  vstring fileBuf = "";
-  vstring newFileBuf = "";
+/*D*//*vstring_def(s); */
+  vstring_def(fileBuf);
+  vstring_def(newFileBuf);
 
-  vstring fullInputFn = "";
+  vstring_def(fullInputFn);
   flag errorFlag = 0;
 
   /* Read starting file */
   let(&fullInputFn, cat(g_rootDirectory, inputFn, NULL));
   fileBuf = readFileToString(fullInputFn, 1/*verbose*/, &(*size));
   if (fileBuf == NULL) {
-    print2(
-        "?Error: file \"%s\" was not found\n", fullInputFn);
+    print2("?Error: file \"%s\" was not found\n", fullInputFn);
     fileBuf = "";
     *size = 0;
     errorFlag = 1;
@@ -6109,19 +6106,19 @@ vstring readSourceAndIncludes(const char *inputFn /*input*/, long *size /*output
       Here, it points to the nonexistent character just beyond end of main file
       (after all includes are expanded).
       Note that readInclude() may change g_includeCalls, so use 1 explicitly. */
-  let(&fileBuf, ""); /* Deallocate */
+  free_vstring(fileBuf); /* Deallocate */
 /*D*//*printf("*size=%ld\n",*size);                                       */
 /*D*//*for(i=0;i<*size;i++){                                              */
-/*D*//*let(&s,"");                                                        */
+/*D*//*free_vstring(s);                                                        */
 /*D*//*s=getFileAndLineNum(newFileBuf,newFileBuf+i,&j);                   */
 /*D*//*printf("i=%ld ln=%ld fn=%s ch=%c\n",i,j,s,(newFileBuf+i)[0]);  }   */
   if (errorFlag == 1) {
     /* The read should be aborted by the caller. */
     /* Deallocate the strings in the g_IncludeCall[] structure. */
     for (i = 0; i <= g_includeCalls; i++) {
-      let(&g_IncludeCall[i].source_fn, "");
-      let(&g_IncludeCall[i].included_fn, "");
-      let(&g_IncludeCall[i].current_includeSource, "");
+      free_vstring(g_IncludeCall[i].source_fn);
+      free_vstring(g_IncludeCall[i].included_fn);
+      free_vstring(g_IncludeCall[i].current_includeSource);
       g_includeCalls = -1; /* For the eraseSource() function in mmcmds.c */
     }
     return NULL;

--- a/src/mmpfas.c
+++ b/src/mmpfas.c
@@ -47,15 +47,15 @@ void interactiveMatch(long step, long maxEssential)
   long matchCount = 0;
   long timeoutCount = 0;
   long essHypCount, hyp;
-  vstring matchFlags = "";
-  vstring timeoutFlags = "";
+  vstring_def(matchFlags);
+  vstring_def(timeoutFlags);
   char unifFlag;
-  vstring tmpStr1 = "";
-  vstring tmpStr4 = "";
-  vstring tmpStr2 = "";
-  vstring tmpStr3 = "";
-  nmbrString *matchList = NULL_NMBRSTRING;
-  nmbrString *timeoutList = NULL_NMBRSTRING;
+  vstring_def(tmpStr1);
+  vstring_def(tmpStr4);
+  vstring_def(tmpStr2);
+  vstring_def(tmpStr3);
+  nmbrString_def(matchList);
+  nmbrString_def(timeoutList);
   long stmt, matchListPos, timeoutListPos;
 
   printLongLine(cat("Step ", str((double)step + 1), ":  ", nmbrCvtMToVString(
@@ -103,8 +103,8 @@ void interactiveMatch(long step, long maxEssential)
   if (matchCount == 0 && timeoutCount == 0) {
     print2("No statements match step %ld.  The proof has an error.\n",
         (long)(step + 1));
-    let(&matchFlags, "");
-    let(&timeoutFlags, "");
+    free_vstring(matchFlags);
+    free_vstring(timeoutFlags);
     return;
   }
 
@@ -113,12 +113,12 @@ void interactiveMatch(long step, long maxEssential)
     let(&tmpStr1, cat("There are ", str((double)matchCount), " matches for step ",
       str((double)step + 1), ".  View them (Y, N) <N>? ", NULL));
     tmpStr2 = cmdInput1(tmpStr1);
-    let(&tmpStr1, "");
+    free_vstring(tmpStr1);
 
     if (tmpStr2[0] != 'Y' && tmpStr2[0] != 'y') {
-      let(&tmpStr2, "");
-      let(&matchFlags, "");
-      let(&timeoutFlags, "");
+      free_vstring(tmpStr2);
+      free_vstring(matchFlags);
+      free_vstring(timeoutFlags);
       return;
     }
 
@@ -170,16 +170,16 @@ void interactiveMatch(long step, long maxEssential)
       let(&tmpStr3, cat("What statement to select for step ", str((double)step + 1),
           " (<return> to bypass)? ", NULL));
       tmpStr2 = cmdInput1(tmpStr3);
-      let(&tmpStr3, "");
+      free_vstring(tmpStr3);
 
       if (tmpStr2[0] == 0) {
-        let(&tmpStr1, "");
-        let(&tmpStr4, "");
-        let(&tmpStr2, "");
-        let(&matchFlags, "");
-        let(&timeoutFlags, "");
-        nmbrLet(&matchList, NULL_NMBRSTRING);
-        nmbrLet(&timeoutList, NULL_NMBRSTRING);
+        free_vstring(tmpStr1);
+        free_vstring(tmpStr4);
+        free_vstring(tmpStr2);
+        free_vstring(matchFlags);
+        free_vstring(timeoutFlags);
+        free_nmbrString(matchList);
+        free_nmbrString(timeoutList);
         return;
       }
       if (!instr(1, cat(" ", tmpStr1, " ", tmpStr4, " ", NULL),
@@ -214,13 +214,13 @@ void interactiveMatch(long step, long maxEssential)
   assignStatement(matchList[matchListPos], step);
   g_proofChangedFlag = 1; /* Flag for 'undo' stack */
 
-  let(&tmpStr1, "");
-  let(&tmpStr4, "");
-  let(&tmpStr2, "");
-  let(&matchFlags, "");
-  let(&timeoutFlags, "");
-  nmbrLet(&matchList, NULL_NMBRSTRING);
-  nmbrLet(&timeoutList, NULL_NMBRSTRING);
+  free_vstring(tmpStr1);
+  free_vstring(tmpStr4);
+  free_vstring(tmpStr2);
+  free_vstring(matchFlags);
+  free_vstring(timeoutFlags);
+  free_nmbrString(matchList);
+  free_nmbrString(timeoutList);
   return;
 
 } /* interactiveMatch */
@@ -231,7 +231,7 @@ void interactiveMatch(long step, long maxEssential)
 void assignStatement(long statemNum, long step)
 {
   long hyp;
-  nmbrString *hypList = NULL_NMBRSTRING;
+  nmbrString_def(hypList);
 
   if ((g_ProofInProgress.proof)[step] != -(long)'?') bug(1802);
 
@@ -244,7 +244,7 @@ void assignStatement(long statemNum, long step)
   hypList[g_Statement[statemNum].numReqHyp] = statemNum; /* The added statement */
   addSubProof(hypList, step);
   initStep(step + g_Statement[statemNum].numReqHyp);
-  nmbrLet(&hypList, NULL_NMBRSTRING);
+  free_nmbrString(hypList);
   return;
 } /* assignStatement */
 
@@ -269,7 +269,7 @@ nmbrString *proveByReplacement(long prfStmt,
 
   long trialStmt;
   nmbrString *prfMath;
-  nmbrString *trialPrf = NULL_NMBRSTRING;
+  nmbrString_def(trialPrf);
   long prfMbox;
 
   prfMath = (g_ProofInProgress.target)[prfStep];
@@ -325,7 +325,7 @@ nmbrString *proveByReplacement(long prfStmt,
       return trialPrf;
     }
     /* Don't need to do this because it is already null */
-    /* nmbrLet(&trialPrf, NULL_NMBRSTRING); */
+    /* free_nmbrString(trialPrf); */
   }
   return trialPrf;  /* Proof not found - return empty proof */
 }
@@ -344,20 +344,20 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
   nmbrString *prfMath; /* Pointer only */
   long reqHyps;
   long hyp, sym, var, i, j, k, trialStep;
-  nmbrString *proof = NULL_NMBRSTRING;
-  nmbrString *scheme = NULL_NMBRSTRING;
-  pntrString *hypList = NULL_PNTRSTRING;
-  nmbrString *hypSortMap = NULL_NMBRSTRING; /* Order remapping for speedup */
-  pntrString *hypProofList = NULL_PNTRSTRING;
-  pntrString *stateVector = NULL_PNTRSTRING;
+  nmbrString_def(proof);
+  nmbrString_def(scheme);
+  pntrString_def(hypList);
+  nmbrString_def(hypSortMap); /* Order remapping for speedup */
+  pntrString_def(hypProofList);
+  pntrString_def(stateVector);
   nmbrString *replStmtSchemePtr;
   nmbrString *hypSchemePtr;
   nmbrString *hypProofPtr;
   nmbrString *makeSubstPtr;
-  pntrString *hypMakeSubstList = NULL_PNTRSTRING;
-  pntrString *hypStateVectorList = NULL_PNTRSTRING;
-  vstring hypReEntryFlagList = "";
-  nmbrString *hypStepList = NULL_NMBRSTRING;
+  pntrString_def(hypMakeSubstList);
+  pntrString_def(hypStateVectorList);
+  vstring_def(hypReEntryFlagList);
+  nmbrString_def(hypStepList);
   flag reEntryFlag;
   flag tmpFlag;
   flag noHypMatch;
@@ -370,13 +370,13 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
                         dummy variables */
   nmbrString *hypTestPtr; /* Points to what we are testing hyp. against */
   flag hypOrSubproofFlag; /* 0 means testing against hyp., 1 against proof*/
-  vstring indepKnownSteps = ""; /* 'Y' = ok to try step; 'N' = not ok */
+  vstring_def(indepKnownSteps); /* 'Y' = ok to try step; 'N' = not ok */
   long pfLen;
   long scanLen;
   long scanUpperBound;
   long scanLowerBound;
-  vstring hasFloatingProof = "";  /* 'N' or 'Y' for $e hyps */
-  vstring tryFloatingProofLater = "";  /* 'N' or 'Y' */
+  vstring_def(hasFloatingProof);  /* 'N' or 'Y' for $e hyps */
+  vstring_def(tryFloatingProofLater);  /* 'N' or 'Y' */
   flag hasDummyVar;
 
   /* If we are overriding discouraged usage, a warning has already been
@@ -493,7 +493,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
        matches. */
     /* Get a list of the possible steps to look at that are not dependent
        on the prfStep.  A value of 'Y'  means we can try the step. */
-    let(&indepKnownSteps, "");
+    free_vstring(indepKnownSteps);
     indepKnownSteps = getIndepKnownSteps(provStmtNum, prfStep);
   }
 
@@ -531,7 +531,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
 
     /* Make substitutions into each hypothesis, and try to prove that
        hypothesis */
-    nmbrLet(&proof, NULL_NMBRSTRING);
+    free_nmbrString(proof);
     noHypMatch = 0;
     for (hyp = 0; hyp < schReqHyps; hyp++) {
 
@@ -684,8 +684,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
         if (!tmpFlag || tmpFlag == 2) {
           /* (Next) unification not possible or timeout */
           if (tmpFlag == 2) {
-            print2(
-"Unification timed out.  SET UNIFICATION_TIMEOUT larger for better results.\n");
+            print2("Unification timed out.  SET UNIFICATION_TIMEOUT larger for better results.\n");
             g_unifTrialCount = 1; /* Reset unification timeout */
             /* Deallocate unification state vector */
             purgeStateVector(
@@ -749,8 +748,7 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
               /* This subproof step was already considered earlier, so
                  we can skip considering it again. */
               /* Deallocate unification state vector */
-              purgeStateVector(
-                  (pntrString **)(&(hypStateVectorList[hypSortMap[hyp]])));
+              purgeStateVector((pntrString **)(&(hypStateVectorList[hypSortMap[hyp]])));
               continue;
             }
           } /* end if not reentry */
@@ -938,39 +936,39 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
 
   } /* End while (next unifyH() call for main replacement statement) */
 
-  nmbrLet(&proof, NULL_NMBRSTRING);  /* Proof not possible */
+  free_nmbrString(proof);  /* Proof not possible */
 
  returnPoint:
 
   /* Deallocate hypothesis schemes and proofs */
   for (hyp = 0; hyp < schReqHyps; hyp++) {
-    nmbrLet((nmbrString **)(&(hypList[hyp])), NULL_NMBRSTRING);
-    nmbrLet((nmbrString **)(&(hypProofList[hyp])), NULL_NMBRSTRING);
-    nmbrLet((nmbrString **)(&(hypMakeSubstList[hyp])), NULL_NMBRSTRING);
-    purgeStateVector((pntrString **)(&(hypStateVectorList[hyp])));
+    free_nmbrString(*(nmbrString **)(&hypList[hyp]));
+    free_nmbrString(*(nmbrString **)(&hypProofList[hyp]));
+    free_nmbrString(*(nmbrString **)(&hypMakeSubstList[hyp]));
+    purgeStateVector((pntrString **)(&hypStateVectorList[hyp]));
   }
 
   /* Deallocate unification state vector */
   purgeStateVector(&stateVector);
 
-  nmbrLet(&scheme, NULL_NMBRSTRING);
-  pntrLet(&hypList, NULL_PNTRSTRING);
-  nmbrLet(&hypSortMap, NULL_NMBRSTRING);
-  pntrLet(&hypProofList, NULL_PNTRSTRING);
-  pntrLet(&hypMakeSubstList, NULL_PNTRSTRING);
-  pntrLet(&hypStateVectorList, NULL_PNTRSTRING);
-  let(&hypReEntryFlagList, "");
-  nmbrLet(&hypStepList, NULL_NMBRSTRING);
-  let(&indepKnownSteps, "");
-  let(&hasFloatingProof, "");
-  let(&tryFloatingProofLater, "");
+  free_nmbrString(scheme);
+  free_pntrString(hypList);
+  free_nmbrString(hypSortMap);
+  free_pntrString(hypProofList);
+  free_pntrString(hypMakeSubstList);
+  free_pntrString(hypStateVectorList);
+  free_vstring(hypReEntryFlagList);
+  free_nmbrString(hypStepList);
+  free_vstring(indepKnownSteps);
+  free_vstring(hasFloatingProof);
+  free_vstring(tryFloatingProofLater);
 
 
 /*E*/if(db8)print2("%s\n", cat("Returned: ",
 /*E*/   nmbrCvtRToVString(proof,
 /*E*/                0, /*explicitTargets*/
 /*E*/                0 /*statemNum, used only if explicitTargets*/), NULL));
-  return (proof); /* Caller must deallocate */
+  return proof; /* Caller must deallocate */
 } /* replaceStatement */
 
 
@@ -987,8 +985,8 @@ vstring getIndepKnownSteps(long proofStmt, long refStep)
   long proofLen, prfStep, step2;
   long wrkSubPfLen, mathLen;
   nmbrString *proofStepContent;
-  vstring indepSteps = "";
-  vstring unkSubPrfSteps = ""; /* 'K' if subproof is known, 'U' if unknown */
+  vstring_def(indepSteps);
+  vstring_def(unkSubPrfSteps); /* 'K' if subproof is known, 'U' if unknown */
 
   /* g_ProofInProgress is global */
   proofLen = nmbrLen(g_ProofInProgress.proof);
@@ -1065,7 +1063,7 @@ vstring getIndepKnownSteps(long proofStmt, long refStep)
     if (unkSubPrfSteps[prfStep] == 'U') indepSteps[prfStep] = 'N';
   }
 
-  let(&unkSubPrfSteps, ""); /* Deallocate */
+  free_vstring(unkSubPrfSteps); /* Deallocate */
 
   return indepSteps; /* Caller must deallocate */
 
@@ -1080,8 +1078,8 @@ vstring getIndepKnownSteps(long proofStmt, long refStep)
 vstring getKnownSubProofs(void)
 {
   long proofLen, hyp;
-  vstring unkSubPrfSteps = ""; /* 'K' if subproof is known, 'U' if unknown */
-  vstring unkSubPrfStack = ""; /* 'K' if subproof is known, 'U' if unknown */
+  vstring_def(unkSubPrfSteps); /* 'K' if subproof is known, 'U' if unknown */
+  vstring_def(unkSubPrfStack); /* 'K' if subproof is known, 'U' if unknown */
   long stackPtr, prfStep, stmt;
 
   /* g_ProofInProgress is global */
@@ -1123,7 +1121,7 @@ vstring getKnownSubProofs(void)
     unkSubPrfStack[stackPtr] = unkSubPrfSteps[prfStep];
   } /* next prfStep */
   if (stackPtr != 0) bug(1841);
-  let(&unkSubPrfStack, ""); /* Deallocate */
+  free_vstring(unkSubPrfStack); /* Deallocate */
   return unkSubPrfSteps; /* Caller must deallocate */
 
 } /* getKnownSubProofs */
@@ -1146,7 +1144,7 @@ void addSubProof(const nmbrString *subProof, long step) {
       step + 1), NULL));
   /* Deallocate .source in case not empty (if not, though, it's a bug) */
   if (nmbrLen((g_ProofInProgress.source)[step])) bug(1804);
- /*nmbrLet((nmbrString **)(&((g_ProofInProgress.source)[step])), NULL_NMBRSTRING);*/
+  /*free_nmbrString(*(nmbrString **)(&g_ProofInProgress.source[step]));*/
   pntrLet(&g_ProofInProgress.source, pntrCat(pntrLeft(g_ProofInProgress.source,
       step), pntrNSpace(sbPfLen - 1), pntrRight(g_ProofInProgress.source,
       step + 1), NULL));
@@ -1167,12 +1165,12 @@ nmbrString *expandProof(
     const nmbrString *rawTargetProof, /* May be compressed or uncompressed */
     long sourceStmtNum   /* The statement whose proof will be expanded */
     /* , long targetStmtNum */) { /* The statement begin proved */
-  nmbrString *origTargetProof = NULL_NMBRSTRING;
-  nmbrString *targetProof = NULL_NMBRSTRING;
-  nmbrString *sourceProof = NULL_NMBRSTRING;
-  nmbrString *expandedTargetProof = NULL_NMBRSTRING;
-  pntrString *hypSubproofs = NULL_PNTRSTRING;
-  nmbrString *expandedSubproof = NULL_NMBRSTRING;
+  nmbrString_def(origTargetProof);
+  nmbrString_def(targetProof);
+  nmbrString_def(sourceProof);
+  nmbrString_def(expandedTargetProof);
+  pntrString_def(hypSubproofs);
+  nmbrString_def(expandedSubproof);
   long targetStep, srcHyp, hypStep, totalSubpLen, subpLen, srcStep;
   long sourcePLen, sourceHyps, targetPLen, targetSubpLen;
   flag hasDummyVar = 0;
@@ -1232,7 +1230,7 @@ nmbrString *expandProof(
       }
 
       /* Build the expanded subproof */
-      nmbrLet(&expandedSubproof, NULL_NMBRSTRING);
+      free_nmbrString(expandedSubproof);
       /* Scan the proof of the statement to be expanded */
       for (srcStep = 0; srcStep < sourcePLen; srcStep++) {
         if (sourceProof[srcStep] < 0) {
@@ -1332,16 +1330,16 @@ nmbrString *expandProof(
     }
   }
   /* Deallocate memory */
-  nmbrLet(&sourceProof, NULL_NMBRSTRING);
-  nmbrLet(&origTargetProof, NULL_NMBRSTRING);
-  nmbrLet(&targetProof, NULL_NMBRSTRING);
-  nmbrLet(&expandedSubproof, NULL_NMBRSTRING);
+  free_nmbrString(sourceProof);
+  free_nmbrString(origTargetProof);
+  free_nmbrString(targetProof);
+  free_nmbrString(expandedSubproof);
   /* Deallocate array entries */
   for (srcHyp = 0; srcHyp < sourceHyps; srcHyp++) {
-    nmbrLet((nmbrString **)(&(hypSubproofs[srcHyp])), NULL_NMBRSTRING);
+    free_nmbrString(*(nmbrString **)(&hypSubproofs[srcHyp]));
   }
   /* Deallocate array */
-  pntrLet(&hypSubproofs, NULL_PNTRSTRING);
+  free_pntrString(hypSubproofs);
   return expandedTargetProof;
 } /* expandProof */
 
@@ -1362,11 +1360,11 @@ void deleteSubProof(long step) {
   for (pos = step - sbPfLen + 1; pos <= step; pos++) {
     if (pos < step) {
       /* Deallocate .target and .user */
-      nmbrLet((nmbrString **)(&((g_ProofInProgress.target)[pos])), NULL_NMBRSTRING);
-      nmbrLet((nmbrString **)(&((g_ProofInProgress.user)[pos])), NULL_NMBRSTRING);
+      free_nmbrString(*(nmbrString **)(&g_ProofInProgress.target[pos]));
+      free_nmbrString(*(nmbrString **)(&g_ProofInProgress.user[pos]));
     }
     /* Deallocate .source */
-    nmbrLet((nmbrString **)(&((g_ProofInProgress.source)[pos])), NULL_NMBRSTRING);
+    free_nmbrString(*(nmbrString **)(&g_ProofInProgress.source[pos]));
   }
   pntrLet(&g_ProofInProgress.target, pntrCat(pntrLeft(g_ProofInProgress.target,
       step - sbPfLen + 1), pntrRight(g_ProofInProgress.target,
@@ -1387,9 +1385,9 @@ char checkStmtMatch(long statemNum, long step)
 {
   char targetFlag;
   char userFlag = 1; /* Default if no user field */
-  pntrString *stateVector = NULL_PNTRSTRING;
+  pntrString_def(stateVector);
   nmbrString *mString; /* Pointer only; not allocated */
-  nmbrString *scheme = NULL_NMBRSTRING;
+  nmbrString_def(scheme);
   long targetLen, mStringLen, reqVars, stsym, tasym, sym, var, hyp, numHyps;
   flag breakFlag;
   flag firstSymbsAreConstsFlag;
@@ -1509,7 +1507,7 @@ char checkStmtMatch(long statemNum, long step)
   }
 
  returnPoint:
-  nmbrLet(&scheme, NULL_NMBRSTRING);
+  free_nmbrString(scheme);
   purgeStateVector(&stateVector);
 
   if (!targetFlag || !userFlag) return (0);
@@ -1522,7 +1520,7 @@ char checkStmtMatch(long statemNum, long step)
    g_ProofInProgress.target (or .user) of an step.  Returns 1 if match, 0 if
    not, 2 if unification timed out. */
 char checkMStringMatch(const nmbrString *mString, long step) {
-  pntrString *stateVector = NULL_PNTRSTRING;
+  pntrString_def(stateVector);
   char targetFlag;
   char sourceFlag = 1; /* Default if no .source */
 
@@ -1557,12 +1555,12 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
 
   long reqHyps, optHyps;
   long hyp, stmt, sym, var, i, j;
-  nmbrString *proof = NULL_NMBRSTRING;
-  nmbrString *scheme = NULL_NMBRSTRING;
-  pntrString *hypList = NULL_PNTRSTRING;
-  nmbrString *hypOrdMap = NULL_NMBRSTRING; /* Order remapping for speedup */
-  pntrString *hypProofList = NULL_PNTRSTRING;
-  pntrString *stateVector = NULL_PNTRSTRING;
+  nmbrString_def(proof);
+  nmbrString_def(scheme);
+  pntrString_def(hypList);
+  nmbrString_def(hypOrdMap); /* Order remapping for speedup */
+  pntrString_def(hypProofList);
+  pntrString_def(stateVector);
   nmbrString *stmtMathPtr;
   nmbrString *hypSchemePtr;
   nmbrString *hypProofPtr;
@@ -1594,7 +1592,7 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
   }
   depth++; /* Update backtracking depth */
   if (trials > g_userMaxProveFloat) {
-    nmbrLet(&proof, NULL_NMBRSTRING);
+    free_nmbrString(proof);
     print2(
 "Exceeded trial limit at step %ld.  You may increase with SET SEARCH_LIMIT.\n",
         (long)(step + 1));
@@ -1603,13 +1601,13 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
 
   if (maxDepthExceeded) {
     /* Pop out of the recursive calls to avoid an infinite loop */
-    nmbrLet(&proof, NULL_NMBRSTRING);
+    free_nmbrString(proof);
     goto returnPoint;
   }
 
 #define MAX_DEPTH 40  /* > this, infinite loop assumed */ /*???User setting?*/
   if (depth > MAX_DEPTH) {
-    nmbrLet(&proof, NULL_NMBRSTRING);
+    free_nmbrString(proof);
 /*??? Document in Metamath manual. */
     printLongLine(cat(
        "?Warning: A possible infinite loop was found in $f hypothesis ",
@@ -1668,7 +1666,7 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
       /* Check to see that the subproof has no unknown steps. */
       if (nmbrElementIn(1, proof, -(long)'?')) {
         /* Clear out the trial proof */
-        nmbrLet(&proof, NULL_NMBRSTRING);
+        free_nmbrString(proof);
         /* And give up this trial */
         continue; /* next selfScanStep */
       }
@@ -1818,7 +1816,7 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
 
       /* Make substitutions into each hypothesis, and try to prove that
          hypothesis */
-      nmbrLet(&proof, NULL_NMBRSTRING);
+      free_nmbrString(proof);
       breakFlag = 0;
       for (hyp = 0; hyp < schReqHyps; hyp++) {
 /*E*/if (db8)print2("%s\n", cat(space(depth+2), "Proving hyp. ",
@@ -1834,7 +1832,7 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
             noDistinct, overrideFlag, mathboxFlag);
         g_unifTrialCount = saveUnifTrialCount; /* Restore unification timeout */
 
-        nmbrLet(&makeSubstPtr, NULL_NMBRSTRING); /* Deallocate */
+        free_nmbrString(makeSubstPtr); /* Deallocate */
         if (!nmbrLen(hypProofPtr)) {
           /* Not possible */
           breakFlag = 1;
@@ -1855,11 +1853,11 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
        if (trials > g_userMaxProveFloat) {
          /* Deallocate hypothesis schemes and proofs */
          for (hyp = 0; hyp < schReqHyps; hyp++) {
-           nmbrLet((nmbrString **)(&hypList[hyp]), NULL_NMBRSTRING);
-           nmbrLet((nmbrString **)(&hypProofList[hyp]), NULL_NMBRSTRING);
+           free_nmbrString(*(nmbrString **)(&hypList[hyp]));
+           free_nmbrString(*(nmbrString **)(&hypProofList[hyp]));
          }
          /* The error message has already been printed. */
-         nmbrLet(&proof, NULL_NMBRSTRING);
+         free_nmbrString(proof);
          goto returnPoint;
        }
 
@@ -1919,8 +1917,8 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
 
       /* Deallocate hypothesis schemes and proofs */
       for (hyp = 0; hyp < schReqHyps; hyp++) {
-        nmbrLet((nmbrString **)(&hypList[hyp]), NULL_NMBRSTRING);
-        nmbrLet((nmbrString **)(&hypProofList[hyp]), NULL_NMBRSTRING);
+        free_nmbrString(*(nmbrString **)(&hypList[hyp]));
+        free_nmbrString(*(nmbrString **)(&hypProofList[hyp]));
       }
       goto returnPoint;
 
@@ -1928,22 +1926,22 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
 
     /* Deallocate hypothesis schemes and proofs */
     for (hyp = 0; hyp < schReqHyps; hyp++) {
-      nmbrLet((nmbrString **)(&hypList[hyp]), NULL_NMBRSTRING);
-      nmbrLet((nmbrString **)(&hypProofList[hyp]), NULL_NMBRSTRING);
+      free_nmbrString(*(nmbrString **)(&hypList[hyp]));
+      free_nmbrString(*(nmbrString **)(&hypProofList[hyp]));
     }
 
   } /* Next stmt */
 
-  nmbrLet(&proof, NULL_NMBRSTRING);  /* Proof not possible */
+  free_nmbrString(proof);  /* Proof not possible */
 
  returnPoint:
   /* Deallocate unification state vector */
   purgeStateVector(&stateVector);
 
-  nmbrLet(&scheme, NULL_NMBRSTRING);
-  pntrLet(&hypList, NULL_PNTRSTRING);
-  nmbrLet(&hypOrdMap, NULL_NMBRSTRING);
-  pntrLet(&hypProofList, NULL_PNTRSTRING);
+  free_nmbrString(scheme);
+  free_pntrString(hypList);
+  free_nmbrString(hypOrdMap);
+  free_pntrString(hypProofList);
   depth--; /* Restore backtracking depth */
 /*E*/if(db8)print2("%s\n", cat(space(depth+2), "Returned: ",
 /*E*/   nmbrCvtRToVString(proof,
@@ -2067,7 +2065,7 @@ void minimizeProof(long repStatemNum, long prvStatemNum,
   long startingPlen = 0;
   flag foundFlag, breakFlag;
   nmbrString *mString; /* Pointer only; not allocated */
-  nmbrString *newSubProofPtr = NULL_NMBRSTRING; /* Pointer only; not allocated;
+  nmbrString_def(newSubProofPtr); /* Pointer only; not allocated;
                 however initialize for nmbrLen function before it's assigned */
   if (allowGrowthFlag) startingPlen = nmbrLen(g_ProofInProgress.proof);
 
@@ -2123,7 +2121,7 @@ void minimizeProof(long repStatemNum, long prvStatemNum,
            steps - this causes assignKnownSteps to abort, and it's not
            clear if we should do that anyway since it doesn't necessarily
            minimize the proof */
-        nmbrLet(&newSubProofPtr, NULL_NMBRSTRING); /* Deallocate */
+        free_nmbrString(newSubProofPtr); /* Deallocate */
         continue;
       }
 
@@ -2142,11 +2140,11 @@ void minimizeProof(long repStatemNum, long prvStatemNum,
         addSubProof(newSubProofPtr, step - sublen + 1);
         assignKnownSteps(step - sublen + 1, nmbrLen(newSubProofPtr));
         foundFlag = 1;
-        nmbrLet(&newSubProofPtr, NULL_NMBRSTRING);
+        free_nmbrString(newSubProofPtr);
         break;
       }
 
-      nmbrLet(&newSubProofPtr, NULL_NMBRSTRING);
+      free_nmbrString(newSubProofPtr);
     } /* next step */
 
     if (!foundFlag) break; /* Done */
@@ -2170,7 +2168,7 @@ void minimizeProof(long repStatemNum, long prvStatemNum,
 void initStep(long step)
 {
   long stmt, reqHyps, pos, hyp, sym, reqVars, var, mlen;
-  nmbrString *reqHypPos = NULL_NMBRSTRING;
+  nmbrString_def(reqHypPos);
   nmbrString *nmbrTmpPtr; /* Pointer only; not allocated */
 
   stmt = (g_ProofInProgress.proof)[step];
@@ -2249,7 +2247,7 @@ void initStep(long step)
   /* Update the number of dummy vars used so far */
   g_pipDummyVars = g_pipDummyVars + reqVars;
 
-  nmbrLet(&reqHypPos, NULL_NMBRSTRING); /* Deallocate */
+  free_nmbrString(reqHypPos); /* Deallocate */
 
   return;
 } /* initStep */
@@ -2298,14 +2296,14 @@ void assignKnownSteps(long startStep, long sbProofLen)
 {
 
   long stackPtr, st;
-  nmbrString *stack = NULL_NMBRSTRING;
-  nmbrString *instance = NULL_NMBRSTRING;
-  nmbrString *scheme = NULL_NMBRSTRING;
-  nmbrString *assertion = NULL_NMBRSTRING;
+  nmbrString_def(stack);
+  nmbrString_def(instance);
+  nmbrString_def(scheme);
+  nmbrString_def(assertion);
   long pos, stmt, reqHyps, instLen, instPos, schemeLen, schemePos, hypLen,
       hypPos, hyp, reqVars, var, assLen, assPos;
   flag tmpFlag;
-  pntrString *stateVector = NULL_PNTRSTRING;
+  pntrString_def(stateVector);
 
   nmbrLet(&stack, nmbrSpace(sbProofLen));
   stackPtr = 0;
@@ -2426,9 +2424,8 @@ void assignKnownSteps(long startStep, long sbProofLen)
         goto returnPoint;
       }
       /* Substitute and assign assertion to proof in progress */
-      nmbrLet((nmbrString **)(&((g_ProofInProgress.source)[pos])), NULL_NMBRSTRING);
-      (g_ProofInProgress.source)[pos] = makeSubstUnif(&tmpFlag, assertion,
-          stateVector);
+      free_nmbrString(*(nmbrString **)(&g_ProofInProgress.source[pos]));
+      g_ProofInProgress.source[pos] = makeSubstUnif(&tmpFlag, assertion, stateVector);
       if (tmpFlag) bug(1814); /* All vars s.b. assigned */
 
       /* Verify unification is unique; also deallocates stateVector */
@@ -2452,10 +2449,10 @@ void assignKnownSteps(long startStep, long sbProofLen)
   }
 
   /* Deallocate (stateVector was deallocated by 2nd unif. call) */
-  nmbrLet(&stack, NULL_NMBRSTRING);
-  nmbrLet(&instance, NULL_NMBRSTRING);
-  nmbrLet(&scheme, NULL_NMBRSTRING);
-  nmbrLet(&assertion, NULL_NMBRSTRING);
+  free_nmbrString(stack);
+  free_nmbrString(instance);
+  free_nmbrString(scheme);
+  free_nmbrString(assertion);
   return;
 } /* assignKnownSteps */
 
@@ -2470,7 +2467,7 @@ void assignKnownSteps(long startStep, long sbProofLen)
    if step is already unified. */
 void interactiveUnifyStep(long step, char messageFlag)
 {
-  pntrString *stateVector = NULL_PNTRSTRING;
+  pntrString_def(stateVector);
   char unifFlag;
 
   /* Target should never be empty */
@@ -2547,21 +2544,21 @@ char interactiveUnify(const nmbrString *schemeA, const nmbrString *schemeB,
   nmbrString *stackUnkVarLen; /* Pointer only - not allocated */
   nmbrString *stackUnkVarStart; /* Pointer only - not allocated */
   long stackTop;
-  vstring tmpStr = "";
-  nmbrString *nmbrTmp = NULL_NMBRSTRING;
+  vstring_def(tmpStr);
+  nmbrString_def(nmbrTmp);
   char returnValue;
 
   /* Present unifications in increasing order of the number
      of symbols in the unified result.  It seems that usually the unification
      with the fewest symbols in the correct one. */
-  nmbrString *unifWeight = NULL_NMBRSTRING; /* Symbol count in unification */
+  nmbrString_def(unifWeight); /* Symbol count in unification */
   long unifTrialWeight;
   long maxUnifWeight;
   long minUnifWeight;
   long unifTrials;
   long thisUnifWeight;
   long onesCount;
-  nmbrString *substResult = NULL_NMBRSTRING;
+  nmbrString_def(substResult);
   long unkCount;
 
   if (nmbrEq(schemeA, schemeB)) bug(1818); /* No reason to call this */
@@ -2694,8 +2691,8 @@ char interactiveUnify(const nmbrString *schemeA, const nmbrString *schemeB,
                 nmbrMid(unifiedScheme,stackUnkVarStart[var] + 1,
                 stackUnkVarLen[var])), "\"", NULL),"    "," ");
         /* Clear temporary string allocation during print */
-        let(&tmpStr,"");
-        nmbrLet(&nmbrTmp,NULL_NMBRSTRING);
+        free_vstring(tmpStr);
+        free_nmbrString(nmbrTmp);
       } /* Next var */
 
       while(1) {
@@ -2707,7 +2704,7 @@ char interactiveUnify(const nmbrString *schemeA, const nmbrString *schemeB,
         }
         if (tmpStr[0] == 'R' || tmpStr[0] == 'r') {
           if (!tmpStr[1]) {
-            let(&tmpStr, "");
+            free_vstring(tmpStr);
             break;
           }
         }
@@ -2725,7 +2722,7 @@ char interactiveUnify(const nmbrString *schemeA, const nmbrString *schemeB,
             goto returnPoint;
           }
         }
-        let(&tmpStr, "");
+        free_vstring(tmpStr);
       }
 
     } /* Next unifNum */
@@ -2740,9 +2737,9 @@ char interactiveUnify(const nmbrString *schemeA, const nmbrString *schemeB,
   goto returnPoint;
 
  returnPoint:
-  let(&tmpStr, ""); /* Deallocate */
-  nmbrLet(&unifWeight, NULL_NMBRSTRING); /* Deallocate */
-  nmbrLet(&substResult, NULL_NMBRSTRING); /* Deallocate */
+  free_vstring(tmpStr); /* Deallocate */
+  free_nmbrString(unifWeight); /* Deallocate */
+  free_nmbrString(substResult); /* Deallocate */
   return returnValue;
 
 } /* interactiveUnify */
@@ -2759,7 +2756,7 @@ void autoUnify(flag congrats)
   int pass;
   nmbrString *schemeAPtr; /* Pointer only; not allocated */
   nmbrString *schemeBPtr; /* Pointer only; not allocated */
-  pntrString *stateVector = NULL_PNTRSTRING;
+  pntrString_def(stateVector);
   flag somethingNotUnified = 0;
 
   /* Initialization to avoid compiler warning (should not be theoretically
@@ -2860,20 +2857,20 @@ void makeSubstAll(pntrString *stateVector) {
     nmbrTmpPtr = (g_ProofInProgress.target)[step];
     (g_ProofInProgress.target)[step] = makeSubstUnif(&tmpFlag, nmbrTmpPtr,
       stateVector);
-    nmbrLet(&nmbrTmpPtr, NULL_NMBRSTRING);
+    free_nmbrString(nmbrTmpPtr);
 
     nmbrTmpPtr = (g_ProofInProgress.source)[step];
     if (nmbrLen(nmbrTmpPtr)) {
       (g_ProofInProgress.source)[step] = makeSubstUnif(&tmpFlag, nmbrTmpPtr,
         stateVector);
-      nmbrLet(&nmbrTmpPtr, NULL_NMBRSTRING);
+      free_nmbrString(nmbrTmpPtr);
     }
 
     nmbrTmpPtr = (g_ProofInProgress.user)[step];
     if (nmbrLen(nmbrTmpPtr)) {
       (g_ProofInProgress.user)[step] = makeSubstUnif(&tmpFlag, nmbrTmpPtr,
         stateVector);
-      nmbrLet(&nmbrTmpPtr, NULL_NMBRSTRING);
+      free_nmbrString(nmbrTmpPtr);
     }
 
   } /* Next step */
@@ -2974,12 +2971,11 @@ long subproofLen(const nmbrString *proof, long endStep) {
    if testStep has isolated dummy variables (that don't affect rest of
    proof), return 1;
    if testStep has dummy variables used elsewhere in proof, return 2 */
-char checkDummyVarIsolation(long testStep) /* 0=1st step, 1=2nd, etc. */
-{
+char checkDummyVarIsolation(long testStep) { /* 0=1st step, 1=2nd, etc. */
   long proofLen, hyp, parentStep, tokpos, token;
   char dummyVarIndicator;
   long prfStep, parentStmt;
-  nmbrString *dummyVarList = NULL_NMBRSTRING;
+  nmbrString_def(dummyVarList);
   flag bugCheckFlag;
   char hypType;
 
@@ -3065,7 +3061,7 @@ char checkDummyVarIsolation(long testStep) /* 0=1st step, 1=2nd, etc. */
   dummyVarIndicator = 1;
 
  RETURN_POINT:
-  nmbrLet(&dummyVarList, NULL_NMBRSTRING); /* Deallocate */
+  free_nmbrString(dummyVarList); /* Deallocate */
   return dummyVarIndicator;
 } /* checkDummyVarIsolation */
 
@@ -3160,7 +3156,7 @@ void copyProofStruct(struct pip_struct *outProofStruct,
   long proofLen, j;
   /* First, make sure the output structure is empty to prevent memory
      leaks. */
-  deallocProofStruct(&(*outProofStruct));
+  deallocProofStruct(outProofStruct);
 
   /* Get the proof length of the input structure */
   proofLen = nmbrLen(inProofStruct.proof);
@@ -3198,7 +3194,7 @@ void copyProofStruct(struct pip_struct *outProofStruct,
 void initProofStruct(struct pip_struct *proofStruct, const nmbrString *proof,
     long proveStmt)
 {
-  nmbrString *tmpProof = NULL_NMBRSTRING;
+  nmbrString_def(tmpProof);
   long plen, step;
   /* Right now, only non-packed proofs are handled. */
   nmbrLet(&tmpProof, nmbrUnsquishProof(proof));
@@ -3226,7 +3222,7 @@ void initProofStruct(struct pip_struct *proofStruct, const nmbrString *proof,
   autoUnify(0); /* 0 means no "congrats" message */
 
   /* Deallocate memory */
-  nmbrLet(&tmpProof, NULL_NMBRSTRING);
+  free_nmbrString(tmpProof);
   return;
 } /* initProofStruct */
 
@@ -3241,17 +3237,17 @@ void deallocProofStruct(struct pip_struct *proofStruct)
 {
   long proofLen, j;
   /* Deallocate proof structure */
-  proofLen = nmbrLen((*proofStruct).proof);
+  proofLen = nmbrLen(proofStruct->proof);
   if (proofLen == 0) return;  /* Already deallocated */
-  nmbrLet(&((*proofStruct).proof), NULL_NMBRSTRING);
+  free_nmbrString(proofStruct->proof);
   for (j = 0; j < proofLen; j++) {
-    nmbrLet((nmbrString **)(&(((*proofStruct).target)[j])), NULL_NMBRSTRING);
-    nmbrLet((nmbrString **)(&(((*proofStruct).source)[j])), NULL_NMBRSTRING);
-    nmbrLet((nmbrString **)(&(((*proofStruct).user)[j])), NULL_NMBRSTRING);
+    free_nmbrString(*(nmbrString **)(&proofStruct->target[j]));
+    free_nmbrString(*(nmbrString **)(&proofStruct->source[j]));
+    free_nmbrString(*(nmbrString **)(&proofStruct->user[j]));
   }
-  pntrLet(&((*proofStruct).target), NULL_PNTRSTRING);
-  pntrLet(&((*proofStruct).source), NULL_PNTRSTRING);
-  pntrLet(&((*proofStruct).user), NULL_PNTRSTRING);
+  free_pntrString(proofStruct->target);
+  free_pntrString(proofStruct->source);
+  free_pntrString(proofStruct->user);
   return;
 } /* deallocProofStruct */
 
@@ -3300,7 +3296,7 @@ long processUndoStack(struct pip_struct *proofStruct,
 {
 
   static struct pip_struct *proofStack = NULL;
-  static pntrString *infoStack = NULL_PNTRSTRING; /* UNDO/REDO command info */
+  static pntrString_def(infoStack); /* UNDO/REDO command info */
   static long stackSize = DEFAULT_UNDO_STACK_SIZE; /* Change w/ SET UNDO */
   static long stackEnd = -1;
   static long stackPtr = -1;
@@ -3338,8 +3334,8 @@ long processUndoStack(struct pip_struct *proofStruct,
     case PUS_NEW_SIZE:
       /* Deallocate old contents */
       for (i = 0; i <= stackEnd; i++) {
-        deallocProofStruct(&(proofStack[i]));
-        let((vstring *)(&(infoStack[i])), "");
+        deallocProofStruct(&proofStack[i]);
+        free_vstring(*(vstring *)(&infoStack[i]));
       }
 
       /* If UNDOs weren't exhausted and thus are abandoned due to size change,
@@ -3390,7 +3386,7 @@ long processUndoStack(struct pip_struct *proofStruct,
       if (stackPtr < stackEnd) {
         for (i = stackPtr + 1; i <= stackEnd; i++) {
           deallocProofStruct(&(proofStack[i]));
-          let((vstring *)(&(infoStack[i])), "");
+          free_vstring(*(vstring *)(&infoStack[i]));
         }
         stackEnd = stackPtr;
       }
@@ -3400,7 +3396,7 @@ long processUndoStack(struct pip_struct *proofStruct,
       if (stackPtr == stackSize - 1) {
         stackOverflowed = 1; /* To  modify user message if UNDO exhausted */
         deallocProofStruct(&(proofStack[0])); /* Deallocate the bottom entry */
-        let((vstring *)(&(infoStack[0])), "");
+        free_vstring(*(vstring *)(&(infoStack[0])));
         for (i = 0; i < stackSize - 1; i++) {
           /* Instead of
                "copyProofStruct(&(proofStack[i]), proofStack[i + 1]);

--- a/src/mmunif.c
+++ b/src/mmunif.c
@@ -140,9 +140,9 @@ int maxNestingLevel = -1;
 int nestingLevel = 0;
 
 /* For improving rejection of impossible substitutions */
-nmbrString *g_firstConst = NULL_NMBRSTRING;
-nmbrString *g_lastConst = NULL_NMBRSTRING;
-nmbrString *g_oneConst = NULL_NMBRSTRING;
+nmbrString_def(g_firstConst);
+nmbrString_def(g_lastConst);
+nmbrString_def(g_oneConst);
 
 
 
@@ -162,14 +162,14 @@ nmbrString *makeSubstUnif(flag *newVarFlag,
 {
   long p,q,i,j,k,m,tokenNum;
   long schemeLen;
-  nmbrString *result = NULL_NMBRSTRING;
-  nmbrString *stackUnkVar = NULL_NMBRSTRING;
+  nmbrString_def(result);
+  nmbrString_def(stackUnkVar);
   nmbrString *unifiedScheme; /* Pointer only - not allocated */
   nmbrString *stackUnkVarLen; /* Pointer only - not allocated */
   nmbrString *stackUnkVarStart; /* Pointer only - not allocated */
   long stackTop;
 /*E*/long d;
-/*E*/vstring tmpStr = "";
+/*E*/vstring_def(tmpStr);
 /*E*/let(&tmpStr,tmpStr);
 
   stackTop = ((nmbrString *)(stateVector[11]))[1];
@@ -262,7 +262,7 @@ nmbrString *makeSubstUnif(flag *newVarFlag,
 /*E*/if(db7)print2("after newVarFlag %d\n",(int)*newVarFlag);
 /*E*/if(db7)print2("final len is %ld\n",q);
 /*E*/if(db7)printLongLine(cat("result ",nmbrCvtMToVString(result),NULL),""," ");
-  nmbrLet(&stackUnkVar, NULL_NMBRSTRING); /* Deallocate */
+  free_nmbrString(stackUnkVar); /* Deallocate */
   return (result);
 } /* makeSubstUnif */
 
@@ -321,12 +321,12 @@ char unify(
   nmbrString *unifiedScheme; /* Final result */
   long p; /* Current position in schemeA or schemeB */
   long substToken; /* Token from schemeA or schemeB that will be substituted */
-  nmbrString *substitution = NULL_NMBRSTRING;
+  nmbrString_def(substitution);
                                        /* String to be subst. for substToken */
   nmbrString *nmbrTmpPtr; /* temp pointer only */
   pntrString *pntrTmpPtr; /* temp pointer only */
-  nmbrString *schA = NULL_NMBRSTRING; /* schemeA with dummy token at end */
-  nmbrString *schB = NULL_NMBRSTRING; /* schemeB with dummy token at end */
+  nmbrString_def(schA); /* schemeA with dummy token at end */
+  nmbrString_def(schB); /* schemeB with dummy token at end */
   long i,j,k,m, pairingMismatches;
   flag breakFlag;
   flag schemeAFlag;
@@ -345,7 +345,7 @@ char unify(
 
 
 /*E*/long d;
-/*E*/vstring tmpStr = "";
+/*E*/vstring_def(tmpStr);
 /*E*/let(&tmpStr,tmpStr);
 /*E*/if(db5)print2("Entering unify() with reEntryFlag = %ld.\n",
 /*E*/  (long)reEntryFlag);
@@ -1135,18 +1135,18 @@ char unify(
 
 /*E*/if(db5)printSubst(*stateVector);
   /* Deallocate nmbrStrings */
-  nmbrLet(&schA, NULL_NMBRSTRING);
-  nmbrLet(&schB, NULL_NMBRSTRING);
-  nmbrLet(&substitution, NULL_NMBRSTRING);
+  free_nmbrString(schA);
+  free_nmbrString(schB);
+  free_nmbrString(substitution);
   return (1);
 
  abort:
 /*E*/if(db5)print2("Backtrack count was %ld\n",g_unifTrialCount);
   /* Deallocate stateVector contents */
-  nmbrLet(&unkVars,NULL_NMBRSTRING);
-  nmbrLet(&stackUnkVar,NULL_NMBRSTRING);
-  nmbrLet(&stackUnkVarStart,NULL_NMBRSTRING);
-  nmbrLet(&stackUnkVarLen,NULL_NMBRSTRING);
+  free_nmbrString(unkVars);
+  free_nmbrString(stackUnkVar);
+  free_nmbrString(stackUnkVarStart);
+  free_nmbrString(stackUnkVarLen);
   for (i = 0; i < unkVarsLen; i++) {
     /* Deallocate the stack space for these */
     nmbrLet((nmbrString **)(&stackSaveUnkVarStart[i]),
@@ -1158,35 +1158,33 @@ char unify(
     nmbrLet((nmbrString **)(&stackSaveSchemeB[i]),
         NULL_NMBRSTRING);
   }
-  pntrLet(&stackSaveUnkVarStart,NULL_PNTRSTRING);
-  pntrLet(&stackSaveUnkVarLen,NULL_PNTRSTRING);
-  pntrLet(&stackSaveSchemeA,NULL_PNTRSTRING);
-  pntrLet(&stackSaveSchemeB,NULL_PNTRSTRING);
-  nmbrLet(&unifiedScheme,NULL_NMBRSTRING);
+  free_pntrString(stackSaveUnkVarStart);
+  free_pntrString(stackSaveUnkVarLen);
+  free_pntrString(stackSaveSchemeA);
+  free_pntrString(stackSaveSchemeB);
+  free_nmbrString(unifiedScheme);
   /* Deallocate entries used by oneDirUnif() */
-  nmbrLet((nmbrString **)(&(*stateVector)[9]),NULL_NMBRSTRING);
-  nmbrLet((nmbrString **)(&(*stateVector)[10]),NULL_NMBRSTRING);
+  free_nmbrString(*(nmbrString **)(&(*stateVector)[9]));
+  free_nmbrString(*(nmbrString **)(&(*stateVector)[10]));
   /* Deallocate entries used by unifyH() */
   k = pntrLen((pntrString *)((*stateVector)[12]));
   for (i = 12; i < 16; i++) {
     pntrTmpPtr = (pntrString *)((*stateVector)[i]);
     for (j = 0; j < k; j++) {
-      nmbrLet((nmbrString **)(&pntrTmpPtr[j]),
-          NULL_NMBRSTRING);
+      free_nmbrString(*(nmbrString **)(&pntrTmpPtr[j]));
     }
-    pntrLet((pntrString **)(&(*stateVector)[i]),
-        NULL_PNTRSTRING);
+    free_pntrString(*(pntrString **)(&(*stateVector)[i]));
   }
   /* Deallocate the stateVector itself */
   ((nmbrString *)((*stateVector)[11]))[1] = 0;
       /* stackTop: Make sure it's not -1 before calling nmbrLet() */
-  nmbrLet((nmbrString **)(&(*stateVector)[11]),NULL_NMBRSTRING);
-  pntrLet(&(*stateVector),NULL_PNTRSTRING);
+  free_nmbrString(*(nmbrString **)(&(*stateVector)[11]));
+  free_pntrString(*stateVector);
 
   /* Deallocate nmbrStrings */
-  nmbrLet(&schA,NULL_NMBRSTRING);
-  nmbrLet(&schB,NULL_NMBRSTRING);
-  nmbrLet(&substitution,NULL_NMBRSTRING);
+  free_nmbrString(schA);
+  free_nmbrString(schB);
+  free_nmbrString(substitution);
 
   if (timeoutAbortFlag) {
     return (2);
@@ -1270,7 +1268,7 @@ char uniqueUnif(
     const nmbrString *schemeB,
     pntrString **stateVector)
 {
-  pntrString *saveStateVector = NULL_PNTRSTRING;
+  pntrString_def(saveStateVector);
   pntrString *pntrTmpPtr1; /* Pointer only; not allocated */
   pntrString *pntrTmpPtr2; /* Pointer only; not allocated */
   long i, j, k;
@@ -1352,32 +1350,27 @@ char uniqueUnif(
     pntrTmpPtr1 = (pntrString *)(saveStateVector[i]);
     for (j = 0; j < ((nmbrString *)(saveStateVector[11]))[0]; j++) {
                       /* ((nmbrString *)(saveStateVector[11]))[0] is unkVarsLen */
-      nmbrLet((nmbrString **)(&pntrTmpPtr1[j]), NULL_NMBRSTRING);
+      free_nmbrString(*(nmbrString **)(&pntrTmpPtr1[j]));
     }
   }
   for (i = 0; i <= 3; i++) {
-    nmbrLet((nmbrString **)(&saveStateVector[i]),
-        NULL_NMBRSTRING);
+    free_nmbrString(*(nmbrString **)(&saveStateVector[i]));
   }
   for (i = 4; i <= 7; i++) {
-    pntrLet((pntrString **)(&saveStateVector[i]),
-        NULL_PNTRSTRING);
+    free_pntrString(*(pntrString **)(&saveStateVector[i]));
   }
   for (i = 8; i <= 11; i++) {
-    nmbrLet((nmbrString **)(&saveStateVector[i]),
-        NULL_NMBRSTRING);
+    free_nmbrString(*(nmbrString **)(&saveStateVector[i]));
   }
   k = pntrLen((pntrString *)(saveStateVector[12]));
   for (i = 12; i < 16; i++) {
     pntrTmpPtr1 = (pntrString *)(saveStateVector[i]);
     for (j = 0; j < k; j++) {
-      nmbrLet((nmbrString **)(&pntrTmpPtr1[j]),
-          NULL_NMBRSTRING);
+      free_nmbrString(*(nmbrString **)(&pntrTmpPtr1[j]));
     }
-    pntrLet((pntrString **)(&saveStateVector[i]),
-        NULL_PNTRSTRING);
+    free_pntrString(*(pntrString **)(&saveStateVector[i]));
   }
-  pntrLet(&saveStateVector, NULL_PNTRSTRING);
+  free_pntrString(saveStateVector);
 
   if (tmpFlag == 2) {
     return (2); /* Unification timed out */
@@ -1405,32 +1398,27 @@ void purgeStateVector(pntrString **stateVector) {
     pntrTmpPtr1 = (pntrString *)((*stateVector)[i]);
     for (j = 0; j < ((nmbrString *)((*stateVector)[11]))[0]; j++) {
                       /* ((nmbrString *)((*stateVector)[11]))[0] is unkVarsLen */
-      nmbrLet((nmbrString **)(&pntrTmpPtr1[j]), NULL_NMBRSTRING);
+      free_nmbrString(*(nmbrString **)(&pntrTmpPtr1[j]));
     }
   }
   for (i = 0; i <= 3; i++) {
-    nmbrLet((nmbrString **)(&(*stateVector)[i]),
-        NULL_NMBRSTRING);
+    free_nmbrString(*(nmbrString **)(&(*stateVector)[i]));
   }
   for (i = 4; i <= 7; i++) {
-    pntrLet((pntrString **)(&(*stateVector)[i]),
-        NULL_PNTRSTRING);
+    free_pntrString(*(pntrString **)(&(*stateVector)[i]));
   }
   for (i = 8; i <= 11; i++) {
-    nmbrLet((nmbrString **)(&(*stateVector)[i]),
-        NULL_NMBRSTRING);
+    free_nmbrString(*(nmbrString **)(&(*stateVector)[i]));
   }
   k = pntrLen((pntrString *)((*stateVector)[12]));
   for (i = 12; i < 16; i++) {
     pntrTmpPtr1 = (pntrString *)((*stateVector)[i]);
     for (j = 0; j < k; j++) {
-      nmbrLet((nmbrString **)(&pntrTmpPtr1[j]),
-          NULL_NMBRSTRING);
+      free_nmbrString(*(nmbrString **)(&pntrTmpPtr1[j]));
     }
-    pntrLet((pntrString **)(&(*stateVector)[i]),
-        NULL_PNTRSTRING);
+    free_pntrString(*(pntrString **)(&(*stateVector)[i]));
   }
-  pntrLet(&(*stateVector), NULL_PNTRSTRING);
+  free_pntrString(*stateVector);
 
   return;
 
@@ -1445,8 +1433,8 @@ void printSubst(pntrString *stateVector) {
   nmbrString *stackUnkVarLen; /* Pointer only - not allocated */
   nmbrString *stackUnkVarStart; /* Pointer only - not allocated */
   long stackTop;
-  vstring tmpStr = "";
-  nmbrString *nmbrTmp = NULL_NMBRSTRING;
+  vstring_def(tmpStr);
+  nmbrString_def(nmbrTmp);
 
   stackTop = ((nmbrString *)(stateVector[11]))[1];
   stackUnkVar = (nmbrString *)(stateVector[1]);
@@ -1461,8 +1449,8 @@ void printSubst(pntrString *stateVector) {
             nmbrMid(unifiedScheme,stackUnkVarStart[d] + 1,
             stackUnkVarLen[d])),"'.",NULL),"    "," ");
     /* Clear temporary string allocation */
-    let(&tmpStr,"");
-    nmbrLet(&nmbrTmp,NULL_NMBRSTRING);
+    free_vstring(tmpStr);
+    free_nmbrString(nmbrTmp);
   }
 } /* printSubst */
 
@@ -1480,10 +1468,10 @@ char unifyH(
     long reEntryFlag)
 {
   char tmpFlag;
-  nmbrString *hentyVars = NULL_NMBRSTRING;
-  nmbrString *hentyVarStart = NULL_NMBRSTRING;
-  nmbrString *hentyVarLen = NULL_NMBRSTRING;
-  nmbrString *hentySubstList = NULL_NMBRSTRING;
+  nmbrString_def(hentyVars);
+  nmbrString_def(hentyVarStart);
+  nmbrString_def(hentyVarLen);
+  nmbrString_def(hentySubstList);
 
   /* Bypass this filter if SET HENTY_FILTER OFF is selected. */
   if (!g_hentyFilter) return unify(schemeA, schemeB, stateVector, reEntryFlag);
@@ -1538,10 +1526,10 @@ char unifyH(
     /* Deallocate memory (when reEntryFlag is 1 and (not possible or timeout)).
        (In the other cases, hentyVars and hentySubsts pointers are assigned
        directly to stateVector so they should not be deallocated) */
-    nmbrLet(&hentyVars, NULL_NMBRSTRING);
-    nmbrLet(&hentyVarStart, NULL_NMBRSTRING);
-    nmbrLet(&hentyVarLen, NULL_NMBRSTRING);
-    nmbrLet(&hentySubstList, NULL_NMBRSTRING);
+    free_nmbrString(hentyVars);
+    free_nmbrString(hentyVarStart);
+    free_nmbrString(hentyVarLen);
+    free_nmbrString(hentySubstList);
     return (tmpFlag);
 
   }
@@ -1555,7 +1543,7 @@ void hentyNormalize(nmbrString **hentyVars, nmbrString **hentyVarStart,
   long vars, var1, var2, schLen;
   long n, el, rra, rrb, rrc, ir, i, j; /* Variables for heap sort */
   long totalSubstLen, pos;
-  nmbrString *substList = NULL_NMBRSTRING;
+  nmbrString_def(substList);
 
   /* Extract the substitutions. */
   vars = ((nmbrString *)((*stateVector)[11]))[1] + 1; /* stackTop + 1 */
@@ -1665,7 +1653,7 @@ void hentyNormalize(nmbrString **hentyVars, nmbrString **hentyVarStart,
   nmbrLet((nmbrString **)(&(*hentySubstList)), substList);
 
   /* Deallocate memory */
-  nmbrLet(&substList, NULL_NMBRSTRING);
+  free_nmbrString(substList);
 
   return;
 

--- a/src/mmveri.c
+++ b/src/mmveri.c
@@ -34,10 +34,10 @@ char verifyProof(long statemNum)
   char returnFlag = 0;
   nmbrString *nmbrTmpPtr;
   nmbrString *nmbrHypPtr;
-  nmbrString *bigSubstSchemeHyp = NULL_NMBRSTRING;
-  nmbrString *bigSubstInstHyp = NULL_NMBRSTRING;
+  nmbrString_def(bigSubstSchemeHyp);
+  nmbrString_def(bigSubstInstHyp);
   flag unkHypFlag;
-  nmbrString *nmbrTmp = NULL_NMBRSTRING; /* Used to force tmp stack dealloc */
+  nmbrString_def(nmbrTmp); /* Used to force tmp stack dealloc */
 
   if (g_Statement[statemNum].type != p_) return (4); /* Do nothing if not $p */
 
@@ -173,7 +173,7 @@ char verifyProof(long statemNum)
 /*E*/    nmbrCvtMToVString(nmbrTmpPtr), NULL), "", " ");
 
     /* Deallocate stack built up if there are many $d violations */
-    nmbrLet(&nmbrTmp, NULL_NMBRSTRING);
+    free_nmbrString(nmbrTmp);
 
     /* Assign the substituted assertion (must be deallocated by
          cleanWrkProof()!) */
@@ -218,8 +218,8 @@ char verifyProof(long statemNum)
     }
   }
 
-  nmbrLet(&bigSubstSchemeHyp, NULL_NMBRSTRING);
-  nmbrLet(&bigSubstInstHyp, NULL_NMBRSTRING);
+  free_nmbrString(bigSubstSchemeHyp);
+  free_nmbrString(bigSubstInstHyp);
 
   return (returnFlag);
 
@@ -235,19 +235,19 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
   /* For error messages: */
   long statementNum, long step, flag unkHypFlag)
 {
-  nmbrString *bigSubstSchemeVars = NULL_NMBRSTRING;
-  nmbrString *substSchemeFrstVarOcc = NULL_NMBRSTRING;
-  nmbrString *varAssLen = NULL_NMBRSTRING;
-  nmbrString *substInstFrstVarOcc = NULL_NMBRSTRING;
-  nmbrString *result = NULL_NMBRSTRING; /* value returned */
+  nmbrString_def(bigSubstSchemeVars);
+  nmbrString_def(substSchemeFrstVarOcc);
+  nmbrString_def(varAssLen);
+  nmbrString_def(substInstFrstVarOcc);
+  nmbrString_def(result); /* value returned */
   long bigSubstSchemeLen,bigSubstInstLen,bigSubstSchemeVarLen,substSchemeLen,
       resultLen;
   long i,v,v1,p,q,tokenNum;
   flag breakFlag, contFlag;
-  vstring tmpStr = "";
-  vstring tmpStr2 = "";
+  vstring_def(tmpStr);
+  vstring_def(tmpStr2);
   flag ambiguityCheckFlag = 0;
-  nmbrString *saveResult = NULL_NMBRSTRING;
+  nmbrString_def(saveResult);
 
   /* Variables for disjoint variable ($d) check */
   nmbrString *nmbrTmpPtrAS;
@@ -266,7 +266,7 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
   long numReqHyp;
   nmbrString *nmbrHypPtr;
 
-  nmbrString *nmbrTmp = NULL_NMBRSTRING; /* Used to force tmp stack dealloc */
+  nmbrString_def(nmbrTmp); /* Used to force tmp stack dealloc */
 
   long nmbrSaveTempAllocStack;
 
@@ -363,7 +363,7 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
 /*E*/    nmbrMid(bigSubstInstAss,substInstFrstVarOcc[v]+1,
 /*E*/    varAssLen[v])), NULL), "", " ");
 /*E*/if(db7)nmbrLet(&bigSubstInstAss,bigSubstInstAss);
-/*E*/if(db7){print2("Enter scan: v=%ld,p=%ld,q=%ld\n",v,p,q); let(&tmpStr,"");}
+/*E*/if(db7){print2("Enter scan: v=%ld,p=%ld,q=%ld\n",v,p,q); free_vstring(tmpStr);}
     tokenNum = bigSubstSchemeAss[p];
     if (g_MathToken[tokenNum].tokenType == (char)con_) {
       /* Constants must match in both substScheme and definiendum assumptions */
@@ -524,8 +524,8 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
           " hypotheses.  The ",tmpStr,
           ".  Type \"SHOW PROOF ",g_Statement[statementNum].labelName,
           "\" to see the proof attempt.",NULL)); */ /* Old version */
-      let(&tmpStr, "");
-      let(&tmpStr2, "");
+      free_vstring(tmpStr);
+      free_vstring(tmpStr2);
     }
     g_WrkProof.errorCount++;
     goto returnPoint;
@@ -539,11 +539,11 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
     if (unkHypFlag) {
       /* If a hypothesis was unknown, the fact that the unification is ambiguous
          doesn't matter, so just return with an empty (unknown) answer. */
-      nmbrLet(&result,NULL_NMBRSTRING);
+      free_nmbrString(result);
       goto returnPoint;
     }
     nmbrLet(&saveResult, result);
-    nmbrLet(&result, NULL_NMBRSTRING);
+    free_nmbrString(result);
   }
 
 
@@ -679,8 +679,8 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
                   g_MathToken[aToken].tokenName,
                   "\" in common.",
                   NULL));
-              let(&tmpStr, ""); /* Force tmp string stack dealloc */
-              nmbrLet(&nmbrTmp,NULL_NMBRSTRING); /* Force tmp stack dealloc */
+              freeTempAlloc(); /* Force tmp string stack dealloc */
+              free_nmbrString(nmbrTmp); /* Force tmp stack dealloc */
             } /* (End if (!g_WrkProof.errorCount) ) */
           } else { /* aToken != bToken */
             /* The variables are different.  We're still not done though:  We
@@ -764,8 +764,8 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
                     "assertion being proved, \"",
                     g_Statement[statementNum].labelName,
                     "\".", NULL), "", " ");
-                let(&tmpStr, ""); /* Force tmp string stack dealloc */
-                nmbrLet(&nmbrTmp,NULL_NMBRSTRING); /* Force tmp stack dealloc */
+                freeTempAlloc(); /* Force tmp string stack dealloc */
+                free_nmbrString(nmbrTmp); /* Force tmp stack dealloc */
               } /* (End if (!g_WrkProof.errorCount) ) */
             } /* (End if (!foundFlag)) */
           } /* (End if (aToken == bToken)) */
@@ -852,14 +852,14 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
     varAssLen[i] = 0;
     substInstFrstVarOcc[i] = 0;
   }
-  nmbrLet(&bigSubstSchemeVars,NULL_NMBRSTRING);
-  nmbrLet(&substSchemeFrstVarOcc,NULL_NMBRSTRING);
-  nmbrLet(&varAssLen,NULL_NMBRSTRING);
-  nmbrLet(&substInstFrstVarOcc,NULL_NMBRSTRING);
-  nmbrLet(&saveResult,NULL_NMBRSTRING);
+  free_nmbrString(bigSubstSchemeVars);
+  free_nmbrString(substSchemeFrstVarOcc);
+  free_nmbrString(varAssLen);
+  free_nmbrString(substInstFrstVarOcc);
+  free_nmbrString(saveResult);
 
   g_nmbrStartTempAllocStack = nmbrSaveTempAllocStack;
-  return(result);
+  return result;
 
 }
 
@@ -880,8 +880,7 @@ void cleanWrkProof(void) {
       if (type == a_ || type == p_) {
         /* Allocation was only done if: (1) it's not a local label reference
            and (2) it's not a hypothesis.  In this case, deallocate. */
-        nmbrLet((nmbrString **)(&g_WrkProof.mathStringPtrs[step]),
-            NULL_NMBRSTRING);
+        free_nmbrString(*(nmbrString **)(&g_WrkProof.mathStringPtrs[step]));
       }
     }
   }

--- a/src/mmvstr.c
+++ b/src/mmvstr.c
@@ -43,8 +43,7 @@ long g_startTempAllocStack = 0;    /* Where to start freeing temporary allocatio
                                     special nested vstring functions) */
 void *tempAllocStack[MAX_ALLOC_STACK];
 
-static void freeTempAlloc(void)
-{
+void freeTempAlloc(void) {
   /* All memory previously allocated with tempAlloc is deallocated. */
   /* EXCEPT:  When g_startTempAllocStack != 0, the freeing will start at
      g_startTempAllocStack. */
@@ -926,8 +925,8 @@ long entryPosition(long element, const char *list) {
 
 int main(void)
 {
-  vstringdef(s);
-  vstringdef(t);
+  vstring_def(s);
+  vstring_def(t);
 
   printf("Hello\n");
   let(&t,edit(" x y z ",2));

--- a/src/mmvstr.h
+++ b/src/mmvstr.h
@@ -22,7 +22,7 @@ deallocated as needed.  To use the vstring functions within a program,
 all vstrings must be initially set to the null string when declared or
 before first used, for example:
 
-        vstring string1 = "";
+        vstring_def(string1);
         vstring stringArray[] = {"", "", ""};
 
         vstring bigArray[100][10]; /- Must be initialized before using -/
@@ -44,12 +44,12 @@ _not_ be used to initialize a vstring the first time.
 
      Any local vstrings in a function must be deallocated before returning
 from the function, otherwise there will be memory leakage and eventual
-memory overflow.  To deallocate, assign the vstring to "" with 'let(&':
+memory overflow.  To deallocate, assign the vstring to "" with 'free_vstring':
 
         void abc(void) {
-          vstring xyz = "";
+          vstring_def(xyz);
           ...
-          let(&xyz, "");
+          free_vstring(xyz);
         }
 
      The 'cat' function emulates the '+' concatenation operator in BASIC.
@@ -106,14 +106,13 @@ outside of 'let(&' assignments; for example
           print2("%s\n",left(string1,70));
 
 will allocate another 70 bytes or so of memory each pass through the loop.
-If necessary, dummy 'let(&' assignments can be made periodically to clear
+If necessary, 'freeTempAlloc' can be used periodically to clear
 this temporary memory:
 
-        for (i=0; i<10000; i++)
-          {
+        for (i=0; i<10000; i++) {
           print2("%s\n",left(string1,70));
-          let(&dummy,"");
-          }
+          freeTempAlloc();
+        }
 
 It should be noted that the 'linput' function assigns its target string
 with 'let(&' and thus has the same effect as 'let(&'.
@@ -173,7 +172,13 @@ typedef char* vstring;
 */
 typedef vstring temp_vstring;
 
-#define vstringdef(x) vstring x = ""
+#define vstring_def(x) vstring x = ""
+#define free_vstring(x) let(&x, "")
+
+/* Free space allocated for temporaries. This is normally called automatically
+  by let(), but it can also be called directly to avoid buildup of temporary
+  strings. */
+void freeTempAlloc(void);
 
 /* Emulation of BASIC string assignment */
 /* This function must ALWAYS be called to make assignment to

--- a/src/mmword.c
+++ b/src/mmword.c
@@ -44,14 +44,14 @@ FILE *f1_fp_;
 FILE *f2_fp_;
 FILE *f3_fp_;
 char eof1, eof2;
-vstring ctlz_ = "";
-vstring l1_ = "";
-vstring l2_ = "";
-vstring tmp_ = "";
-vstring tmpLine = "";
-vstring addTag_ = "";
-vstring delStartTag_ = "";
-vstring delEndTag_ = "";
+vstring_def(ctlz_);
+vstring_def(l1_);
+vstring_def(l2_);
+vstring_def(tmp_);
+vstring_def(tmpLine);
+vstring_def(addTag_);
+vstring_def(delStartTag_);
+vstring_def(delEndTag_);
 flag printedAtLeastOne;
      /*  Declare input and save buffers */
 #define MAX_LINES 10000
@@ -71,7 +71,7 @@ flag printedAtLeastOne;
 void revise(FILE *f1_fp, FILE *f2_fp, FILE *f3_fp, vstring addTag, long m)
 {
   /******** Figure out the differences (DO LIST subroutine) ******/
-  vstring blanksPrefix = "";
+  vstring_def(blanksPrefix);
   long tmpi;
   long i, j;
 
@@ -126,22 +126,22 @@ l7100:  /*
 
                       /* Deallocate string memory */
                       for (i = 0; i < MAX_LINES; i++) {
-                        let(&(line1_[i]), "");
-                        let(&(line2_[i]), "");
+                        free_vstring(line1_[i]);
+                        free_vstring(line2_[i]);
                       }
                       for (i = 0; i < MAX_BUF; i++) {
-                        let(&(reserve1_[i]), "");
-                        let(&(reserve2_[i]), "");
+                        free_vstring(reserve1_[i]);
+                        free_vstring(reserve2_[i]);
                       }
-                      let(&ctlz_, "");
-                      let(&l1_, "");
-                      let(&l2_, "");
-                      let(&tmp_, "");
-                      let(&tmpLine, "");
-                      let(&addTag_, "");
-                      let(&delStartTag_, "");
-                      let(&delEndTag_, "");
-                      let(&blanksPrefix, "");
+                      free_vstring(ctlz_);
+                      free_vstring(l1_);
+                      free_vstring(l2_);
+                      free_vstring(tmp_);
+                      free_vstring(tmpLine);
+                      free_vstring(addTag_);
+                      free_vstring(delStartTag_);
+                      free_vstring(delEndTag_);
+                      free_vstring(blanksPrefix);
 
                         return;
                 }
@@ -281,18 +281,18 @@ l7240: /* */
              tmpi = 0;
              while (((vstring)(line1_[i]))[tmpi] == ' ') tmpi++;
              let(&blanksPrefix, space(tmpi));
-             let(&tmpLine, "");
+             free_vstring(tmpLine);
              tmpLine = stripAndTag(cat(blanksPrefix, delStartTag_, NULL),
                  addTag_, 0);
              fprintf(f3_fp_, "%s\n", tmpLine);
            }
            fprintf(f3_fp_, "%s\n", line1_[i]);
                                      /* Output original deleted lines */
-           /*let(&tmp_, "");*/ /* Clear vstring stack */
+           /*freeTempAlloc();*/ /* Clear vstring stack */
          }
        }
        if (printedAtLeastOne) {
-         let(&tmpLine, "");
+         free_vstring(tmpLine);
          tmpLine = stripAndTag(cat(blanksPrefix, delEndTag_, NULL), addTag_
              ,0);
          fprintf(f3_fp_, "%s\n", tmpLine);
@@ -300,7 +300,7 @@ l7240: /* */
        for (i=0; i<=i1_-m; i++) {
          if (i<=i2_-m) {
            if (strcmpe(line2_[i],ctlz_)) {
-             let(&tmpLine, "");
+             free_vstring(tmpLine);
              if (i == 0) {
                tmpLine = stripAndTag(line2_[i], addTag_, 0);
              } else {
@@ -309,13 +309,13 @@ l7240: /* */
              }
              fprintf(f3_fp_, "%s\n", tmpLine);
                                      /* Output tagged edited lines */
-             /*let(&tmp_, "");*/ /* Clear vstring stack */
+             /*freeTempAlloc();*/ /* Clear vstring stack */
            }
          }
        }
        for (i=i1_-m+1; i<=i2_-m; i++) {
          if (strcmpe(line2_[i],ctlz_)) {
-           let(&tmpLine, "");
+           free_vstring(tmpLine);
            if (i == 0) {
              tmpLine = stripAndTag(line2_[i], addTag_, 0);
            } else {
@@ -324,7 +324,7 @@ l7240: /* */
            }
            fprintf(f3_fp_, "%s\n", tmpLine);
                                      /* Print remaining edited lines */
-           /*let(&tmp_, "");*/ /* Clear vstring stack */
+           /*freeTempAlloc();*/ /* Clear vstring stack */
          }
        }
        for (i=0; i<=m-1; i++) {
@@ -342,10 +342,9 @@ l7240: /* */
 
 
 
-void gosub_7320()
-{
+void gosub_7320() {
         /* Subroutine:  get next L1_ from original file */
-  vstring tmpLin = "";
+  vstring_def(tmpLin);
   if (r1) {     /*  Get next line from save array */
     let(&l1_,reserve1_[0]);
     r1=r1-1;
@@ -362,7 +361,7 @@ void gosub_7320()
         /* Note that we will discard any blank lines before EOF; this
            should be OK though */
         let(&l1_,ctlz_);
-        let(&tmpLin, ""); /* Deallocate */
+        free_vstring(tmpLin); /* Deallocate */
         return;
       }
       let(&l1_, edit(l1_, 4 + 128 + 2048)); /* Trim garb, trail space; untab */
@@ -373,13 +372,13 @@ void gosub_7320()
     }
   }
   let(&l1_, cat(tmpLin, l1_, NULL)); /* Add any blank lines */
-  let(&tmpLin, ""); /* Deallocate */
+  free_vstring(tmpLin); /* Deallocate */
   return;
 }
 
 void gosub_7330() {
         /*  Subroutine:  get next L2_ from edited file */
-  vstring tmpLin = "";
+  vstring_def(tmpLin);
   vstring tmpStrPtr; /* pointer only */
   flag stripDeletedSectionMode;
   if (r2) {     /*  Get next line from save array */
@@ -399,7 +398,7 @@ void gosub_7330() {
         /* Note that we will discard any blank lines before EOF; this
            should be OK though */
         let(&l2_, ctlz_);
-        let(&tmpLin, ""); /* Deallocate */
+        free_vstring(tmpLin); /* Deallocate */
         return;
       }
       let(&l2_, edit(l2_, 4 + 128 + 2048)); /* Trim garb, trail space; untab */
@@ -426,7 +425,7 @@ void gosub_7330() {
       if (getRevision(l2_) == getRevision(addTag_)) {
         tmpStrPtr = l2_;
         l2_ = stripAndTag(l2_, "", 0);
-        let(&tmpStrPtr, ""); /* deallocate old l2_ */
+        free_vstring(tmpStrPtr); /* deallocate old l2_ */
       }
 
       if (!l2_[0]) { /* Ignore blank lines for comparison */
@@ -436,7 +435,7 @@ void gosub_7330() {
     }
   }
   let(&l2_, cat(tmpLin, l2_, NULL)); /* Add any blank lines */
-  let(&tmpLin, ""); /* Deallocate */
+  free_vstring(tmpLin); /* Deallocate */
   return;
 
 }
@@ -451,8 +450,8 @@ char strcmpe(vstring s1, vstring s2)
   flag ignoreSpaces = 1;
   flag ignoreSameLineComments = 1;
 
-  vstring tmps1 = "";
-  vstring tmps2 = "";
+  vstring_def(tmps1);
+  vstring_def(tmps2);
   long i;
   long i2;
   long i3;
@@ -488,8 +487,8 @@ char strcmpe(vstring s1, vstring s2)
   }
 
   cmpflag = !!strcmp(tmps1, tmps2);
-  let(&tmps1, ""); /* Deallocate string */
-  let(&tmps2, ""); /* Deallocate string */
+  free_vstring(tmps1); /* Deallocate string */
+  free_vstring(tmps2); /* Deallocate string */
   return (cmpflag);
 }
 
@@ -499,7 +498,8 @@ char strcmpe(vstring s1, vstring s2)
 vstring stripAndTag(vstring line, vstring tag, flag tagBlankLines)
 {
   long i, j, k, n;
-  vstring line1 = "", comment = "";
+  vstring_def(line1);
+  vstring_def(comment);
   long lineLength = LINE_LENGTH;
   flag validTag;
   i = 0;
@@ -521,7 +521,7 @@ vstring stripAndTag(vstring line, vstring tag, flag tagBlankLines)
       break;
     }
     if (validTag) let(&line1, edit(left(line1, i - 1), 128));
-    let(&comment, ""); /* deallocate */
+    free_vstring(comment); /* deallocate */
   }
 
   /* Count blank lines concatenated to the beginning of this line */
@@ -561,7 +561,7 @@ vstring stripAndTag(vstring line, vstring tag, flag tagBlankLines)
 /* Used to determine default argument for tag question */
 long highestRevision(vstring fileName)
 {
-  vstring str1 = "";
+  vstring_def(str1);
   long revision;
   long largest = 0;
   FILE *fp;
@@ -572,7 +572,7 @@ long highestRevision(vstring fileName)
     revision = getRevision(str1);
     if (revision > largest) largest = revision;
   }
-  let(&str1, "");
+  free_vstring(str1);
   fclose(fp);
   return largest;
 }
@@ -581,14 +581,14 @@ long highestRevision(vstring fileName)
 /* Tags are assumed to be of format nn or #nn in comment at end of line */
 long getRevision(vstring line)
 {
-  vstring str1 = "";
-  vstring str2 = "";
-  vstring tag = "";
+  vstring_def(str1);
+  vstring_def(str2);
+  vstring_def(tag);
   long revision;
 
   if (instr(1, line, "/*") == 0) return 0; /* Speedup - no comment in line */
   let(&str1, edit(line, 2)); /* This line has the tag not stripped */
-  let(&str2, "");
+  free_vstring(str2);
   str2 = stripAndTag(str1, "", 0); /* Strip old tag & add dummy new one */
   let(&str2, edit(str2, 2)); /* This line has the tag stripped */
   if (!strcmp(str1, str2)) {
@@ -599,9 +599,9 @@ long getRevision(vstring line)
     if (tag[0] == '#') let(&tag, right(tag, 2)); /* Remove any # */
     revision = (long)(val(tag));
   }
-  let(&tag, "");
-  let(&str1, "");
-  let(&str2, "");
+  free_vstring(tag);
+  free_vstring(str1);
+  free_vstring(str2);
   return revision;
 }
 

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -45,9 +45,9 @@ long g_mathboxStmt = 0; /* At this statement and above, use SANDBOX_COLOR
 long g_mathboxes = 0; /* # of mathboxes */
 /* The following 3 strings are 0-based e.g. g_mathboxStart[0] is for
    mathbox #1 */
-nmbrString *g_mathboxStart = NULL_NMBRSTRING; /* Start stmt vs. mathbox # */
-nmbrString *g_mathboxEnd = NULL_NMBRSTRING; /* End stmt vs. mathbox # */
-pntrString *g_mathboxUser = NULL_PNTRSTRING; /* User name vs. mathbox # */
+nmbrString_def(g_mathboxStart); /* Start stmt vs. mathbox # */
+nmbrString_def(g_mathboxEnd); /* End stmt vs. mathbox # */
+pntrString_def(g_mathboxUser); /* User name vs. mathbox # */
 
 /* This is the list of characters causing the space before the opening "`"
    in a math string in a comment to be removed for HTML output. */
@@ -72,39 +72,39 @@ long numSymbs;
 
 /* Variables set by the language in the set.mm etc. $t statement */
 /* Some of these are global; see mmwtex.h */
-vstring g_htmlCSS = ""; /* Set by g_htmlCSS commands */
-vstring g_htmlFont = ""; /* Set by htmlfont commands */
-vstring g_htmlVarColor = ""; /* Set by htmlvarcolor commands */
-vstring htmlExtUrl = ""; /* Set by htmlexturl command */
-vstring htmlTitle = ""; /* Set by htmltitle command */
-  vstring htmlTitleAbbr = ""; /* Extracted from htmlTitle */
-vstring g_htmlHome = ""; /* Set by htmlhome command */
+vstring_def(g_htmlCSS); /* Set by g_htmlCSS commands */
+vstring_def(g_htmlFont); /* Set by htmlfont commands */
+vstring_def(g_htmlVarColor); /* Set by htmlvarcolor commands */
+vstring_def(htmlExtUrl); /* Set by htmlexturl command */
+vstring_def(htmlTitle); /* Set by htmltitle command */
+  vstring_def(htmlTitleAbbr); /* Extracted from htmlTitle */
+vstring_def(g_htmlHome); /* Set by htmlhome command */
   /* Future - assign these in the $t set.mm comment instead of g_htmlHome */
-  vstring g_htmlHomeHREF = ""; /* Extracted from g_htmlHome */
-  vstring g_htmlHomeIMG = ""; /* Extracted from g_htmlHome */
-vstring g_htmlBibliography = ""; /* Optional; set by htmlbibliography command */
-vstring extHtmlLabel = ""; /* Set by exthtmllabel command - where extHtml starts */
-vstring g_extHtmlTitle = ""; /* Set by exthtmltitle command (global!) */
-  vstring g_extHtmlTitleAbbr = ""; /* Extracted from htmlTitle */
-vstring extHtmlHome = ""; /* Set by exthtmlhome command */
+  vstring_def(g_htmlHomeHREF); /* Extracted from g_htmlHome */
+  vstring_def(g_htmlHomeIMG); /* Extracted from g_htmlHome */
+vstring_def(g_htmlBibliography); /* Optional; set by htmlbibliography command */
+vstring_def(extHtmlLabel); /* Set by exthtmllabel command - where extHtml starts */
+vstring_def(g_extHtmlTitle); /* Set by exthtmltitle command (global!) */
+  vstring_def(g_extHtmlTitleAbbr); /* Extracted from htmlTitle */
+vstring_def(extHtmlHome); /* Set by exthtmlhome command */
   /* Future - assign these in the $t set.mm comment instead of g_htmlHome */
-  vstring extHtmlHomeHREF = ""; /* Extracted from extHtmlHome */
-  vstring extHtmlHomeIMG = ""; /* Extracted from extHtmlHome */
-vstring extHtmlBibliography = ""; /* Optional; set by exthtmlbibliography command */
-vstring htmlDir = ""; /* Directory for GIF version, set by htmldir command */
-vstring altHtmlDir = ""; /* Directory for Unicode Font version, set by
+  vstring_def(extHtmlHomeHREF); /* Extracted from extHtmlHome */
+  vstring_def(extHtmlHomeIMG); /* Extracted from extHtmlHome */
+vstring_def(extHtmlBibliography); /* Optional; set by exthtmlbibliography command */
+vstring_def(htmlDir); /* Directory for GIF version, set by htmldir command */
+vstring_def(altHtmlDir); /* Directory for Unicode Font version, set by
                             althtmldir command */
 
 /* Sandbox stuff */
-vstring sandboxHome = "";
-  vstring sandboxHomeHREF = ""; /* Extracted from extHtmlHome */
-  vstring sandboxHomeIMG = ""; /* Extracted from extHtmlHome */
-vstring sandboxTitle = "";
-  vstring sandboxTitleAbbr = "";
+vstring_def(sandboxHome);
+  vstring_def(sandboxHomeHREF); /* Extracted from extHtmlHome */
+  vstring_def(sandboxHomeIMG); /* Extracted from extHtmlHome */
+vstring_def(sandboxTitle);
+  vstring_def(sandboxTitleAbbr);
 
 /* Variables holding all HTML <a name..> tags from bibiography pages  */
-vstring g_htmlBibliographyTags = "";
-vstring extHtmlBibliographyTags = "";
+vstring_def(g_htmlBibliographyTags);
+vstring_def(extHtmlBibliographyTags);
 
 
 void eraseTexDefs(void) {
@@ -114,8 +114,8 @@ void eraseTexDefs(void) {
     g_texDefsRead = 0;
 
     for (i = 0; i < numSymbs; i++) {  /* Deallocate structure member i */
-      let(&(g_TexDefs[i].tokenName), "");
-      let(&(g_TexDefs[i].texEquiv), "");
+      free_vstring(g_TexDefs[i].tokenName);
+      free_vstring(g_TexDefs[i].texEquiv);
     }
     free(g_TexDefs); /* Deallocate the structure */
   }
@@ -130,7 +130,6 @@ flag readTexDefs(
   flag gifCheck   /* 1 = check for missing GIFs */)
 {
 
-  char *fileBuf;
   char *startPtr;
   long lineNumOffset = 0;
   char *fbPtr;
@@ -143,8 +142,8 @@ flag readTexDefs(
   char zapChar;
   long cmd;
   long parsePass;
-  vstring token = "";
-  vstring partialToken = "";
+  vstring_def(token);
+  vstring_def(partialToken);
   FILE *tmpFp;
   static flag saveHtmlFlag = -1; /* -1 to force 1st read */
   static flag saveAltHtmlFlag = 1; /* -1 to force 1st read */
@@ -185,10 +184,10 @@ flag readTexDefs(
   }
 
   /* Find the comment with the $t */
-  fileBuf = ""; /* This used to point to the input file buffer of an external
+  vstring_def(fileBuf); /* This used to point to the input file buffer of an external
                    latex.def file; now it's from the xxx.mm $t comment, so we
                    make it a normal string */
-  let(&fileBuf, "");
+
   /* Note that g_Statement[g_statements + 1] is a special (empty) statement whose
      labelSection holds any comment after the last statement. */
   for (i = 1; i <= g_statements + 1; i++) {
@@ -207,10 +206,9 @@ flag readTexDefs(
       /* (A second one in the labelSection of one statement will trigger
          an error below.) */
       if (fileBuf[0]) {
-        print2(
-  "?Error: There are two comments containing a $t keyword in \"%s\".\n",
+        print2("?Error: There are two comments containing a $t keyword in \"%s\".\n",
             g_input_fn);
-        let(&fileBuf, "");
+        free_vstring(fileBuf);
         return 2;
       }
       let(&fileBuf, tmpPtr);
@@ -264,7 +262,7 @@ flag readTexDefs(
     print2(
 "The file should have exactly one comment of the form $(...$t...$) with\n");
     print2("the LaTeX and HTML definitions between $t and $).\n");
-    let(&fileBuf, "");
+    free_vstring(fileBuf);
     return 2;
   }
   startPtr++; /* Move to 1st char after $t */
@@ -284,7 +282,7 @@ flag readTexDefs(
     print2(
   "?Error: There is no $) comment closure after the $t keyword in \"%s\".\n",
         g_input_fn);
-    let(&fileBuf, "");
+    free_vstring(fileBuf);
     return 2;
   }
 
@@ -296,7 +294,7 @@ flag readTexDefs(
         print2(
   "?Error: There are two comments containing a $t keyword in \"%s\".\n",
             g_input_fn);
-        let(&fileBuf, "");
+        free_vstring(fileBuf);
         return 2;
       }
     }
@@ -348,7 +346,7 @@ flag readTexDefs(
             " \"htmlcss\", \"htmlfont\",",
             " or \"htmlexturl\" here.",
             NULL));
-        let(&fileBuf, "");
+        free_vstring(fileBuf);
         return 2;
       }
       fbPtr = fbPtr + tokenLength;
@@ -376,7 +374,7 @@ flag readTexDefs(
             /*fbPtr*/dollarTStmtPtr + (fbPtr - fileBuf),
               tokenLength,
               "Expected a quoted string here.");
-          let(&fileBuf, "");
+          free_vstring(fileBuf);
           return 2;
         }
         if (parsePass == 2) {
@@ -434,7 +432,7 @@ flag readTexDefs(
             /*fbPtr*/dollarTStmtPtr + (fbPtr - fileBuf),
               tokenLength,
               "Expected the keyword \"as\" here.");
-          let(&fileBuf, "");
+          free_vstring(fileBuf);
           return 2;
         }
         fbPtr[tokenLength] = zapChar;
@@ -465,7 +463,7 @@ flag readTexDefs(
             /*fbPtr*/dollarTStmtPtr + (fbPtr - fileBuf),
               tokenLength,
               "Expected a quoted string here.");
-          let(&fileBuf, "");
+          free_vstring(fileBuf);
           return 2;
         }
         if (parsePass == 2) {
@@ -529,7 +527,7 @@ flag readTexDefs(
             /*fbPtr*/dollarTStmtPtr + (fbPtr - fileBuf),
               tokenLength, /*lineNum, g_input_fn,*/
               "Expected \"+\" or \";\" here.");
-          let(&fileBuf, "");
+          free_vstring(fileBuf);
          return 2;
         }
         fbPtr = fbPtr + tokenLength;
@@ -798,9 +796,9 @@ flag readTexDefs(
   }
 
 
-  let(&token, ""); /* Deallocate */
-  let(&partialToken, ""); /* Deallocate */
-  let(&fileBuf, "");
+  free_vstring(token); /* Deallocate */
+  free_vstring(partialToken); /* Deallocate */
+  free_vstring(fileBuf);
   g_texDefsRead = 1;  /* Set global flag that it's been read in */
   return warningFound; /* Return indicator that parsing passed (0) or
                            had warning(s) (1) */
@@ -913,8 +911,8 @@ int texSrchCmp(const void *key, const void *data)
 vstring asciiToTt(vstring s)
 {
 
-  vstring ttstr = "";
-  vstring tmp = "";
+  vstring_def(ttstr);
+  vstring_def(tmp);
   long i, j, k;
 
   let(&ttstr, s); /* In case the input s is temporarily allocated */
@@ -992,7 +990,7 @@ vstring asciiToTt(vstring s)
     }
   } /* Next i */
 
-  let(&tmp, "");  /* Deallocate */
+  free_vstring(tmp);  /* Deallocate */
   return ttstr;
 } /* asciiToTt */
 
@@ -1002,7 +1000,7 @@ vstring asciiToTt(vstring s)
 /* *** Note: The caller must deallocate the returned string */
 vstring tokenToTex(vstring mtoken, long statemNum /*for error msgs*/)
 {
-  vstring tex = "";
+  vstring_def(tex);
   vstring tmpStr;
   long i, j, k;
   void *texDefsPtr; /* For binary search */
@@ -1063,7 +1061,7 @@ vstring tokenToTex(vstring mtoken, long statemNum /*for error msgs*/)
             cat(left(tex, i), tmpStr, right(tex, i + 2), NULL));
         i = i + k - 1; /* Adjust iteration */
         j = j + k - 1; /* Adjust length */
-        let(&tmpStr, ""); /* Deallocate */
+        free_vstring(tmpStr); /* Deallocate */
       }
     } /* Next i */
 
@@ -1083,17 +1081,17 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
 {
 
   vstring tex;
-  vstring texLine = "";
-  vstring lastTex = "";
-  vstring token = "";
+  vstring_def(texLine);
+  vstring_def(lastTex);
+  vstring_def(token);
   flag alphnew, alphold, unknownnew, unknownold;
   long i;
   vstring srcptr;
 
   srcptr = mathComment;
 
-  let(&texLine, "");
-  let(&lastTex, "");
+  free_vstring(texLine);
+  free_vstring(lastTex);
   while(1) {
     i = whiteSpaceLen(srcptr);
     srcptr = srcptr + i;
@@ -1132,12 +1130,12 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
     } else {
       let(&texLine, cat(texLine, tex, NULL));
     }
-    let(&lastTex, ""); /* Deallocate */
+    free_vstring(lastTex); /* Deallocate */
     lastTex = tex; /* Pass deallocation responsibility for tex to lastTex */
   } /* End while (1) */
 
-  let(&lastTex, ""); /* Deallocate */
-  let(&token, ""); /* Deallocate */
+  free_vstring(lastTex); /* Deallocate */
+  free_vstring(token); /* Deallocate */
 
   return texLine;
 } /* asciiMathToTex */
@@ -1149,7 +1147,7 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
    char. of start of next comment section. */
 vstring getCommentModeSection(vstring *srcptr, char *mode)
 {
-  vstring modeSection = "";
+  vstring_def(modeSection);
   vstring ptr; /* Not allocated */
   flag addMode = 0;
   if (!g_outputToString) bug(2319);
@@ -1227,18 +1225,18 @@ void printTexHeader(flag texHeaderFlag)
 {
 
   long i, j, k;
-  vstring tmpStr = "";
+  vstring_def(tmpStr);
 
   /* "Mathbox for <username>" mod */
-  vstring localSandboxTitle = "";
-  vstring hugeHdr = "";
-  vstring bigHdr = "";
-  vstring smallHdr = "";
-  vstring tinyHdr = "";
-  vstring hugeHdrComment = "";
-  vstring bigHdrComment = "";
-  vstring smallHdrComment = "";
-  vstring tinyHdrComment = "";
+  vstring_def(localSandboxTitle);
+  vstring_def(hugeHdr);
+  vstring_def(bigHdr);
+  vstring_def(smallHdr);
+  vstring_def(tinyHdr);
+  vstring_def(hugeHdrComment);
+  vstring_def(bigHdrComment);
+  vstring_def(smallHdrComment);
+  vstring_def(tinyHdrComment);
 
   if (2/*error*/ == readTexDefs(0/*errorsOnly=0*/, 1 /*gifCheck=1*/)) {
     print2(
@@ -1385,14 +1383,14 @@ void printTexHeader(flag texHeaderFlag)
            formatted right, but use default just in case) */
         let(&localSandboxTitle, sandboxTitle);
       }
-      let(&hugeHdr, "");   /* Deallocate memory */
-      let(&bigHdr, "");   /* Deallocate memory */
-      let(&smallHdr, ""); /* Deallocate memory */
-      let(&tinyHdr, ""); /* Deallocate memory */
-      let(&hugeHdrComment, "");   /* Deallocate memory */
-      let(&bigHdrComment, "");   /* Deallocate memory */
-      let(&smallHdrComment, ""); /* Deallocate memory */
-      let(&tinyHdrComment, ""); /* Deallocate memory */
+      free_vstring(hugeHdr);   /* Deallocate memory */
+      free_vstring(bigHdr);   /* Deallocate memory */
+      free_vstring(smallHdr); /* Deallocate memory */
+      free_vstring(tinyHdr); /* Deallocate memory */
+      free_vstring(hugeHdrComment);   /* Deallocate memory */
+      free_vstring(bigHdrComment);   /* Deallocate memory */
+      free_vstring(smallHdrComment); /* Deallocate memory */
+      free_vstring(tinyHdrComment); /* Deallocate memory */
 
       printLongLine(cat("<TITLE>",
           /* Strip off ".html" */
@@ -1625,10 +1623,10 @@ void printTexHeader(flag texHeaderFlag)
   } /* g_htmlFlag */
   fprintf(g_texFilePtr, "%s", g_printString);
   g_outputToString = 0;
-  let(&g_printString, "");
+  free_vstring(g_printString);
 
   /* Deallocate strings */
-  let(&tmpStr, "");
+  free_vstring(tmpStr);
 
 } /* printTexHeader */
 
@@ -1670,31 +1668,31 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   vstring cmtptr; /* Not allocated */
   vstring srcptr; /* Not allocated */
   vstring lineStart; /* Not allocated */
-  vstring tmpStr = "";
+  vstring_def(tmpStr);
   vstring modeSection; /* Not allocated */
-  vstring sourceLine = "";
-  vstring outputLine = "";
-  vstring tmp = "";
+  vstring_def(sourceLine);
+  vstring_def(outputLine);
+  vstring_def(tmp);
   flag textMode, mode, lastLineFlag, displayMode;
-  vstring tmpComment = "";
+  vstring_def(tmpComment);
   flag preformattedMode = 0; /* HTML <HTML> preformatted mode */
 
   /* For bibliography hyperlinks */
-  vstring bibTag = "";
-  vstring bibFileName = "";
-  vstring bibFileContents = "";
-  vstring bibFileContentsUpper = ""; /* Uppercase version */
-  vstring bibTags = "";
+  vstring_def(bibTag);
+  vstring_def(bibFileName);
+  vstring_def(bibFileContents);
+  vstring_def(bibFileContentsUpper); /* Uppercase version */
+  vstring_def(bibTags);
   long pos1, pos2, htmlpos1, htmlpos2, saveScreenWidth;
   flag tmpMathMode;
 
   /* Variables for converting ` ` and ~ to old $m,$n and $l,$n formats in
      order to re-use the old code */
   /* Note that DOLLAR_SUBST will replace the old $. */
-  vstring cmt = "";
-  vstring cmtMasked = ""; /* cmt with math syms blanked */ /* also mask ~ label */
-  vstring tmpMasked = ""; /* tmp with math syms blanked */
-  vstring tmpStrMasked = ""; /* tmpStr w/ math syms blanked */
+  vstring_def(cmt);
+  vstring_def(cmtMasked); /* cmt with math syms blanked */ /* also mask ~ label */
+  vstring_def(tmpMasked); /* tmp with math syms blanked */
+  vstring_def(tmpStrMasked); /* tmpStr w/ math syms blanked */
   long i, clen;
   flag returnVal = 0; /* 1 means error/warning */
 
@@ -1775,7 +1773,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       }
       if (!pos1) pos1 = (long)strlen(cmt) + 1;
       if (mode == 1 && preformattedMode == 0) {
-        let(&tmpStr, "");
+        free_vstring(tmpStr);
         /* asciiToTt() is where "<" is converted to "&lt;" etc. */
         tmpStr = asciiToTt(left(cmt, pos1));
         let(&tmpStrMasked, tmpStr);
@@ -1799,8 +1797,8 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     }
     let(&cmt, tmp);
     let(&cmtMasked, tmpMasked);
-    let(&tmpStr, ""); /* Deallocate */
-    let(&tmpStrMasked, "");
+    free_vstring(tmpStr); /* Deallocate */
+    free_vstring(tmpStrMasked);
   }
 
 
@@ -1916,7 +1914,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         case '_': cmt[pos1 - 1] = '-'; break;
       }
       if (strchr("%#{}&^|<>_", cmt[pos1 - 1]) != NULL) {
-        let(&tmpStr, "");
+        free_vstring(tmpStr);
         tmpStr = asciiToTt(chr(cmt[pos1 - 1]));
         let(&cmt, cat(left(cmt, pos1 - 1), tmpStr,
             right(cmt, pos1 + 1), NULL));
@@ -2116,7 +2114,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         if (fileCheck) {
           if (!bibTags[0]) {
             /* The bibliography file has not be read in yet. */
-            let(&bibFileContents, "");
+            free_vstring(bibFileContents);
             if (errorsOnly == 0) {
               print2("Reading HTML bibliographic tags from file \"%s\"...\n",
                   bibFileName);
@@ -2272,7 +2270,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
             let(&cmt, cat(left(cmt, i - 2), right(cmt, i), NULL));
             clen = clen - 1;
           }
-          let(&tmp, "");
+          free_vstring(tmp);
         }
         /* If symbol is followed by a space and closing punctuation, take out
            the space so it looks better. */
@@ -2293,7 +2291,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
             let(&cmt, cat(left(cmt, i + 1), right(cmt, i + 3), NULL));
             clen = clen - 1;
           }
-          let(&tmp, "");
+          free_vstring(tmp);
         }
 
       }
@@ -2348,7 +2346,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           let(&cmt, cat(left(cmt, i - 2), right(cmt, i), NULL));
           clen = clen - 1;
         }
-        let(&tmp, "");
+        free_vstring(tmp);
 
       }
     }
@@ -2376,7 +2374,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         let(&cmt, cat(left(cmt, i), right(cmt, i + 2), NULL));
         clen = clen - 1;
       }
-      let(&tmp, "");
+      free_vstring(tmp);
 
     }
     /* clen should always remain comment length - do a sanity check here */
@@ -2471,12 +2469,12 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         NULL))) let(&tmpStr, left(tmpStr, (long)strlen(tmpStr) - 2)); /* Strip $n */
     srcptr = tmpStr;
     modeSection = getCommentModeSection(&srcptr, &mode);
-    let(&modeSection, ""); /* Deallocate */
+    free_vstring(modeSection); /* Deallocate */
     if (mode == 'm') {
       modeSection = getCommentModeSection(&srcptr, &mode);
-      let(&modeSection, ""); /* Deallocate */
+      free_vstring(modeSection); /* Deallocate */
     }
-    let(&tmpStr, ""); /* Deallocate */
+    free_vstring(tmpStr); /* Deallocate */
 
 
     /* Convert all sections of the line to text, math, or labels */
@@ -2499,7 +2497,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
 
           let(&modeSection, edit(modeSection, 8 + 128 + 16));  /* Discard
                       leading and trailing blanks; reduce spaces to one space */
-          let(&tmpStr, "");
+          free_vstring(tmpStr);
           tmpStr = asciiToTt(modeSection);
           if (!tmpStr[0]) {
             /* This can happen if ~ is followed by ` (start of math string) */
@@ -2558,7 +2556,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
               let(&outputLine, cat(outputLine, "{\\tt ", tmpStr,
                  "}", NULL));
             } else {
-              let(&tmp, "");
+              free_vstring(tmp);
               if (addColoredLabelNumber != 0) {
                 /* When the error above occurs, i < 0 will cause pinkHTML()
                    to issue "(future)" for pleasant readability */
@@ -2575,7 +2573,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
               }
             }
           } /* if (!strcmp("http://", left(tmpStr, 7))) ... else */
-          let(&tmpStr, ""); /* Deallocate */
+          free_vstring(tmpStr); /* Deallocate */
           break;
         case 'm': /* Math mode */
 
@@ -2584,7 +2582,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
             bug(2346);
           }
 
-          let(&tmpStr, "");
+          free_vstring(tmpStr);
           tmpStr = asciiMathToTex(modeSection, g_showStatement);
           if (!g_htmlFlag) {
             if (displayMode) {
@@ -2608,10 +2606,10 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                 NULL));
             let(&outputLine, cat(outputLine, tmpStr, NULL)); /* html */
           }
-          let(&tmpStr, ""); /* Deallocate */
+          free_vstring(tmpStr); /* Deallocate */
           break;
       } /* End switch(mode) */
-      let(&modeSection, ""); /* Deallocate */
+      free_vstring(modeSection); /* Deallocate */
     }
     let(&outputLine, edit(outputLine, 128)); /* remove trailing spaces */
 
@@ -2702,7 +2700,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     }
     g_screenWidth = saveScreenWidth;
 
-    let(&tmp, ""); /* Clear temporary allocation stack */
+    freeTempAlloc(); /* Clear temporary allocation stack */
 
     if (lastLineFlag) break; /* Done */
   } /* end while(1) */
@@ -2742,21 +2740,21 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     fprintf(g_texFilePtr, "%s", g_printString);
   }
 
-  let(&g_printString, ""); /* Deallocate strings */
-  let(&sourceLine, "");
-  let(&outputLine, "");
-  let(&cmt, "");
-  let(&cmtMasked, "");
-  let(&tmpComment, "");
-  let(&tmp, "");
-  let(&tmpMasked, "");
-  let(&tmpStr, "");
-  let(&tmpStrMasked, "");
-  let(&bibTag, "");
-  let(&bibFileName, "");
-  let(&bibFileContents, "");
-  let(&bibFileContentsUpper, "");
-  let(&bibTags, "");
+  free_vstring(g_printString); /* Deallocate strings */
+  free_vstring(sourceLine);
+  free_vstring(outputLine);
+  free_vstring(cmt);
+  free_vstring(cmtMasked);
+  free_vstring(tmpComment);
+  free_vstring(tmp);
+  free_vstring(tmpMasked);
+  free_vstring(tmpStr);
+  free_vstring(tmpStrMasked);
+  free_vstring(bibTag);
+  free_vstring(bibFileName);
+  free_vstring(bibFileContents);
+  free_vstring(bibFileContentsUpper);
+  free_vstring(bibTags);
 
   return returnVal; /* 1 if error/warning found */
 
@@ -2779,16 +2777,16 @@ void printTexLongMath(nmbrString *mathString,
 #define INDENTATION_OFFSET 1
   long i;
   long pos;
-  vstring tex = "";
-  vstring texLine = "";
-  vstring sPrefix = "";
-  vstring htmStep = "";
-  vstring htmStepTag = "";
-  vstring htmHyp = "";
-  vstring htmRef = "";
-  vstring htmLocLab = "";
-  vstring tmp = "";
-  vstring descr = "";
+  vstring_def(tex);
+  vstring_def(texLine);
+  vstring_def(sPrefix);
+  vstring_def(htmStep);
+  vstring_def(htmStepTag);
+  vstring_def(htmHyp);
+  vstring_def(htmRef);
+  vstring_def(htmLocLab);
+  vstring_def(tmp);
+  vstring_def(descr);
   char refType = '?'; /* 'e' means $e, etc. */
 
   let(&sPrefix, startPrefix); /* Save it; it may be temp alloc */
@@ -2798,7 +2796,7 @@ void printTexLongMath(nmbrString *mathString,
 
   /* Note that the "tex" assignment below will be used only when !g_htmlFlag
      and g_oldTexFlag, or when g_htmlFlag and len(sPrefix)>0 */
-  let(&tex, "");
+  free_vstring(tex);
   tex = asciiToTt(sPrefix); /* asciiToTt allocates; we must deallocate */
       /* Example: sPrefix = " 4 2,3 ax-mp  $a " */
       /*          tex = "\ 4\ 2,3\ ax-mp\ \ \$a\ " in !g_htmlFlag mode */
@@ -2898,7 +2896,7 @@ void printTexLongMath(nmbrString *mathString,
 
       printLongLine(cat(
           "\\setbox\\startprefix=\\hbox{\\tt ", tex, "}", NULL), "", "\\");
-      let(&tex, ""); /* Deallocate */
+      free_vstring(tex); /* Deallocate */
       tex = asciiToTt(contPrefix);
       printLongLine(cat(
           "\\setbox\\contprefix=\\hbox{\\tt ", tex, "}", NULL), "", "\\");
@@ -2961,11 +2959,11 @@ void printTexLongMath(nmbrString *mathString,
              help the user to recognized "important" (vs. early trivial
              logic) steps.  This prints a small pink statement number
              after the hypothesis statement label. */
-          let(&tmp, "");
+          free_vstring(tmp);
           tmp = pinkHTML(hypStmt);
 
           /* Get description for mod below */
-          let(&descr, ""); /* Deallocate previous description */
+          free_vstring(descr); /* Deallocate previous description */
           descr = getDescription(hypStmt);
           let(&descr, edit(descr, 4 + 16)); /* Discard lf/cr; reduce spaces */
 #define MAX_DESCR_LEN 87
@@ -3005,13 +3003,12 @@ void printTexLongMath(nmbrString *mathString,
           str((double)(indentationLevel + INDENTATION_OFFSET)), "</SPAN>",
           NULL));
       printLongLine(tmp, "", "\"");
-      let(&tmp, "");
+      free_vstring(tmp);
     } /* strlen(sPrefix) */
   } /* g_htmlFlag */
-  let(&tex, ""); /* Deallocate */
-  let(&sPrefix, ""); /* Deallocate */
+  free_vstring(sPrefix); /* Deallocate */
 
-  let(&tex, "");
+  free_vstring(tex);
   tex = getTexLongMath(mathString, hypStmt);
   let(&texLine, cat(texLine, tex, NULL));
 
@@ -3079,17 +3076,17 @@ void printTexLongMath(nmbrString *mathString,
 
   g_outputToString = 0; /* Restore normal output */
   fprintf(g_texFilePtr, "%s", g_printString);
-  let(&g_printString, "");
+  free_vstring(g_printString);
 
-  let(&descr, ""); /*Deallocate */
-  let(&htmStep, ""); /* Deallocate */
-  let(&htmStepTag, ""); /* Deallocate */
-  let(&htmHyp, ""); /* Deallocate */
-  let(&htmRef, ""); /* Deallocate */
-  let(&htmLocLab, ""); /* Deallocate */
-  let(&tmp, ""); /* Deallocate */
-  let(&texLine, ""); /* Deallocate */
-  let(&tex, ""); /* Deallocate */
+  free_vstring(descr); /*Deallocate */
+  free_vstring(htmStep); /* Deallocate */
+  free_vstring(htmStepTag); /* Deallocate */
+  free_vstring(htmHyp); /* Deallocate */
+  free_vstring(htmRef); /* Deallocate */
+  free_vstring(htmLocLab); /* Deallocate */
+  free_vstring(tmp); /* Deallocate */
+  free_vstring(texLine); /* Deallocate */
+  free_vstring(tex); /* Deallocate */
 } /* printTexLongMath */
 
 void printTexTrailer(flag texTrailerFlag) {
@@ -3117,7 +3114,7 @@ void printTexTrailer(flag texTrailerFlag) {
     }
     g_outputToString = 0; /* Restore normal output */
     fprintf(g_texFilePtr, "%s", g_printString);
-    let(&g_printString, "");
+    free_vstring(g_printString);
   }
 
 } /* printTexTrailer */
@@ -3127,41 +3124,41 @@ void printTexTrailer(flag texTrailerFlag) {
    into mmtheorems.html, mmtheorems1.html,... */
 void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
 {
-  nmbrString *nmbrStmtNmbr = NULL_NMBRSTRING;
+  nmbrString_def(nmbrStmtNmbr);
   long pages, page, assertion, assertions, lastAssertion;
   long s, p, i1, i2;
-  vstring str1 = "";
-  vstring str3 = "";
-  vstring str4 = "";
-  vstring prevNextLinks = "";
+  vstring_def(str1);
+  vstring_def(str3);
+  vstring_def(str4);
+  vstring_def(prevNextLinks);
   long partCntr;        /* Counter for hugeHdr */
   long sectionCntr;     /* Counter for bigHdr */
   long subsectionCntr;  /* Counter for smallHdr */
   long subsubsectionCntr;  /* Counter for tinyHdr */
-  vstring outputFileName = "";
+  vstring_def(outputFileName);
   FILE *outputFilePtr;
   long passNumber; /* for summary/detailed table of contents */
 
   /* for table of contents */
-  vstring hugeHdr = "";
-  vstring bigHdr = "";
-  vstring smallHdr = "";
-  vstring tinyHdr = "";
-  vstring hugeHdrComment = "";
-  vstring bigHdrComment = "";
-  vstring smallHdrComment = "";
-  vstring tinyHdrComment = "";
+  vstring_def(hugeHdr);
+  vstring_def(bigHdr);
+  vstring_def(smallHdr);
+  vstring_def(tinyHdr);
+  vstring_def(hugeHdrComment);
+  vstring_def(bigHdrComment);
+  vstring_def(smallHdrComment);
+  vstring_def(tinyHdrComment);
   long stmt, i;
-  pntrString *pntrHugeHdr = NULL_PNTRSTRING;
-  pntrString *pntrBigHdr = NULL_PNTRSTRING;
-  pntrString *pntrSmallHdr = NULL_PNTRSTRING;
-  pntrString *pntrTinyHdr = NULL_PNTRSTRING;
-  pntrString *pntrHugeHdrComment = NULL_PNTRSTRING;
-  pntrString *pntrBigHdrComment = NULL_PNTRSTRING;
-  pntrString *pntrSmallHdrComment = NULL_PNTRSTRING;
-  pntrString *pntrTinyHdrComment = NULL_PNTRSTRING;
-  vstring hdrCommentMarker = "";
-  vstring hdrCommentAnchor = "";
+  pntrString_def(pntrHugeHdr);
+  pntrString_def(pntrBigHdr);
+  pntrString_def(pntrSmallHdr);
+  pntrString_def(pntrTinyHdr);
+  pntrString_def(pntrHugeHdrComment);
+  pntrString_def(pntrBigHdrComment);
+  pntrString_def(pntrSmallHdrComment);
+  pntrString_def(pntrTinyHdrComment);
+  vstring_def(hdrCommentMarker);
+  vstring_def(hdrCommentAnchor);
   flag hdrCommentAnchorDone = 0;
 
   /* Populate the statement map */
@@ -3388,7 +3385,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     /* Write out HTML page so far */
     fprintf(outputFilePtr, "%s", g_printString);
     g_outputToString = 0;
-    let(&g_printString, "");
+    free_vstring(g_printString);
 
     /* Add table of contents to first WRITE THEOREM page */
     if (page == 0) {  /* We're on ToC page */
@@ -3406,16 +3403,16 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
         fprintf(outputFilePtr, "%s", g_printString);
 
         g_outputToString = 0;
-        let(&g_printString, "");
+        free_vstring(g_printString);
 
-        let(&hugeHdr, "");
-        let(&bigHdr, "");
-        let(&smallHdr, "");
-        let(&tinyHdr, "");
-        let(&hugeHdrComment, "");
-        let(&bigHdrComment, "");
-        let(&smallHdrComment, "");
-        let(&tinyHdrComment, "");
+        free_vstring(hugeHdr);
+        free_vstring(bigHdr);
+        free_vstring(smallHdr);
+        free_vstring(tinyHdr);
+        free_vstring(hugeHdrComment);
+        free_vstring(bigHdrComment);
+        free_vstring(smallHdrComment);
+        free_vstring(tinyHdrComment);
         partCntr = 0;    /* Initialize counters */
         sectionCntr = 0;
         subsectionCntr = 0;
@@ -3441,7 +3438,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
                   /* g_Statement[stmt].labelName, NULL)); */
                   "mm", str((double)(g_Statement[stmt].pinkNumber)), NULL));
                      /* Link to page/location - no theorem can be named "mm*" */
-              let(&str4, "");
+              free_vstring(str4);
               str4 = pinkHTML(stmt);
               if (hugeHdr[0]) {
 
@@ -3518,8 +3515,8 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
                   let((vstring *)(&pntrHugeHdr[stmt]), hugeHdr);
                   let((vstring *)(&pntrHugeHdrComment[stmt]), hugeHdrComment);
                 }
-                let(&hugeHdr, "");
-                let(&hugeHdrComment, "");
+                free_vstring(hugeHdr);
+                free_vstring(hugeHdrComment);
               }
               if (bigHdr[0]) {
 
@@ -3600,8 +3597,8 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
                   let((vstring *)(&pntrBigHdr[stmt]), bigHdr);
                   let((vstring *)(&pntrBigHdrComment[stmt]), bigHdrComment);
                 }
-                let(&bigHdr, "");
-                let(&bigHdrComment, "");
+                free_vstring(bigHdr);
+                free_vstring(bigHdrComment);
               }
               if (smallHdr[0]
                   && passNumber == 2) {  /* Skip in pass 1 (summary) */
@@ -3650,9 +3647,9 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
                     "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
                 /* Assign to array for use during theorem output */
                 let((vstring *)(&pntrSmallHdr[stmt]), smallHdr);
-                let(&smallHdr, "");
+                free_vstring(smallHdr);
                 let((vstring *)(&pntrSmallHdrComment[stmt]), smallHdrComment);
-                let(&smallHdrComment, "");
+                free_vstring(smallHdrComment);
               }
 
               if (tinyHdr[0] && passNumber == 2) {  /* Skip in pass 1 (summary) */
@@ -3702,14 +3699,14 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
                     "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
                 /* Assign to array for use during theorem output */
                 let((vstring *)(&pntrTinyHdr[stmt]), tinyHdr);
-                let(&tinyHdr, "");
+                free_vstring(tinyHdr);
                 let((vstring *)(&pntrTinyHdrComment[stmt]), tinyHdrComment);
-                let(&tinyHdrComment, "");
+                free_vstring(tinyHdrComment);
               }
 
               fprintf(outputFilePtr, "%s", g_printString);
               g_outputToString = 0;
-              let(&g_printString, "");
+              free_vstring(g_printString);
             } /* if huge or big or small or tiny header */
           } /* if $a or $p */
         } /* next stmt */
@@ -3740,7 +3737,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
       print2("ALT=\"Metamath Proof Explorer\" HEIGHT=32 WIDTH=32\n");
       print2("ALIGN=MIDDLE> &nbsp;Metamath Proof Explorer</A>\n");
 
-      let(&str3, "");
+      free_vstring(str3);
       if (g_Statement[g_extHtmlStmt].pinkNumber <= 0) bug(2332);
       str3 = pinkRangeHTML(nmbrStmtNmbr[1],
           nmbrStmtNmbr[g_Statement[g_extHtmlStmt].pinkNumber - 1]);
@@ -3760,7 +3757,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
  "BORDER=0 ALT=\"Hilbert Space Explorer\" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE>\n");
       print2("&nbsp;Hilbert Space Explorer</A>\n");
 
-      let(&str3, "");
+      free_vstring(str3);
       if (g_Statement[g_mathboxStmt].pinkNumber <= 0) bug(2333);
       str3 = pinkRangeHTML(g_extHtmlStmt,
          nmbrStmtNmbr[g_Statement[g_mathboxStmt].pinkNumber - 1]);
@@ -3780,7 +3777,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
       print2("BORDER=0 ALT=\"Users' Mathboxes\" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE>\n");
       print2("&nbsp;Users' Mathboxes</A>\n");
 
-      let(&str3, "");
+      free_vstring(str3);
       str3 = pinkRangeHTML(g_mathboxStmt, nmbrStmtNmbr[assertions]);
       printLongLine(cat("<BR>(", str3, ")", NULL),
         " ",  /* Start continuation line with space */
@@ -3808,11 +3805,11 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     print2("<TABLE BORDER CELLSPACING=0 CELLPADDING=3 BGCOLOR=%s\n",
         MINT_BACKGROUND_COLOR);
     print2("SUMMARY=\"Theorem List for %s\">\n", htmlTitle);
-    let(&str3, "");
+    free_vstring(str3);
     if (page < 1) bug(2335); /* Page 0 ToC should have been skipped */
     str3 = pinkHTML(nmbrStmtNmbr[(page - 1) * theoremsPerPage + 1]);
     let(&str3, right(str3, (long)strlen(PINK_NBSP) + 1)); /* Discard "&nbsp;" */
-    let(&str4, "");
+    free_vstring(str4);
     str4 = pinkHTML((page < pages) ?
         nmbrStmtNmbr[page * theoremsPerPage] :
         nmbrStmtNmbr[assertions]);
@@ -3831,7 +3828,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     print2("\n");
     fprintf(outputFilePtr, "%s", g_printString);
     g_outputToString = 0;
-    let(&g_printString, "");
+    free_vstring(g_printString);
 
     /* Find the last assertion that will be printed on the page, so
        we will know when a separator between theorems is not needed */
@@ -3877,13 +3874,13 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
       }
      skip_date:
 
-      let(&str3, "");
+      free_vstring(str3);
       str3 = getDescription(s);
-      let(&str4, "");
+      free_vstring(str4);
       str4 = pinkHTML(s); /* Get little pink number */
       /* Output the description comment */
       /* Break up long lines for text editors with printLongLine */
-      let(&g_printString, "");
+      free_vstring(g_printString);
       g_outputToString = 1;
       print2("\n"); /* Blank line for HTML source human readability */
 
@@ -3973,7 +3970,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
           /* Clear out the g_printString output in prep for printTexComment */
           g_outputToString = 0;
           fprintf(outputFilePtr, "%s", g_printString);
-          let(&g_printString, "");
+          free_vstring(g_printString);
           g_showStatement = s; /* For printTexComment */
           g_texFilePtr = outputFilePtr; /* For printTexComment */
           printTexComment(  /* Sends result to g_texFilePtr */
@@ -4027,7 +4024,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
           /* Clear out the g_printString output in prep for printTexComment */
           g_outputToString = 0;
           fprintf(outputFilePtr, "%s", g_printString);
-          let(&g_printString, "");
+          free_vstring(g_printString);
           g_showStatement = s; /* For printTexComment */
           g_texFilePtr = outputFilePtr; /* For printTexComment */
           printTexComment(  /* Sends result to g_texFilePtr */
@@ -4082,7 +4079,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
           /* Clear out the g_printString output in prep for printTexComment */
           g_outputToString = 0;
           fprintf(outputFilePtr, "%s", g_printString);
-          let(&g_printString, "");
+          free_vstring(g_printString);
           g_showStatement = s; /* For printTexComment */
           g_texFilePtr = outputFilePtr; /* For printTexComment */
           printTexComment(  /* Sends result to g_texFilePtr */
@@ -4142,7 +4139,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
       g_outputToString = 1; /* Restore after printTexComment */
 
       /* Get HTML hypotheses => assertion */
-      let(&str4, "");
+      free_vstring(str4);
       str4 = getTexOrHtmlHypAndAssertion(s); /* In mmwtex.c */
 
       /* Suppress the math content of lemmas, which can
@@ -4166,7 +4163,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
 
       g_outputToString = 0;
       fprintf(outputFilePtr, "%s", g_printString);
-      let(&g_printString, "");
+      free_vstring(g_printString);
 
       if (assertion != lastAssertion) {
         /* Put separator row if not last theorem */
@@ -4177,7 +4174,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
             "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
         g_outputToString = 0;
         fprintf(outputFilePtr, "%s", g_printString);
-        let(&g_printString, "");
+        free_vstring(g_printString);
       }
     } /* next assertion */
 
@@ -4212,7 +4209,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
 
     g_outputToString = 0;
     fprintf(outputFilePtr, "%s", g_printString);
-    let(&g_printString, "");
+    free_vstring(g_printString);
 
 
     fprintf(outputFilePtr, "<A NAME=\"mmpglst\"></A>\n");
@@ -4226,7 +4223,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     for (p = 0; p <= pages; p++) {
 
       /* Construct the pink number range */
-      let(&str3, "");
+      free_vstring(str3);
       if (p > 0) {
         str3 = pinkRangeHTML(
             nmbrStmtNmbr[(p - 1) * theoremsPerPage + 1],
@@ -4280,7 +4277,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     print2("</BODY></HTML>\n");
     g_outputToString = 0;
     fprintf(outputFilePtr, "%s", g_printString);
-    let(&g_printString, "");
+    free_vstring(g_printString);
 
     /* Close file */
     fclose(outputFilePtr);
@@ -4288,24 +4285,24 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
 
  TL_ABORT:
   /* Deallocate memory */
-  let(&str1, "");
-  let(&str3, "");
-  let(&str4, "");
-  let(&prevNextLinks, "");
-  let(&outputFileName, "");
-  let(&hugeHdr, "");
-  let(&bigHdr, "");
-  let(&smallHdr, "");
-  let(&tinyHdr, "");
-  let(&hdrCommentMarker, "");
-  for (i = 0; i <= g_statements; i++) let((vstring *)(&pntrHugeHdr[i]), "");
-  pntrLet(&pntrHugeHdr, NULL_PNTRSTRING);
-  for (i = 0; i <= g_statements; i++) let((vstring *)(&pntrBigHdr[i]), "");
-  pntrLet(&pntrBigHdr, NULL_PNTRSTRING);
-  for (i = 0; i <= g_statements; i++) let((vstring *)(&pntrSmallHdr[i]), "");
-  pntrLet(&pntrSmallHdr, NULL_PNTRSTRING);
-  for (i = 0; i <= g_statements; i++) let((vstring *)(&pntrTinyHdr[i]), "");
-  pntrLet(&pntrTinyHdr, NULL_PNTRSTRING);
+  free_vstring(str1);
+  free_vstring(str3);
+  free_vstring(str4);
+  free_vstring(prevNextLinks);
+  free_vstring(outputFileName);
+  free_vstring(hugeHdr);
+  free_vstring(bigHdr);
+  free_vstring(smallHdr);
+  free_vstring(tinyHdr);
+  free_vstring(hdrCommentMarker);
+  for (i = 0; i <= g_statements; i++) free_vstring(*(vstring *)(&pntrHugeHdr[i]));
+  free_pntrString(pntrHugeHdr);
+  for (i = 0; i <= g_statements; i++) free_vstring(*(vstring *)(&pntrBigHdr[i]));
+  free_pntrString(pntrBigHdr);
+  for (i = 0; i <= g_statements; i++) free_vstring(*(vstring *)(&pntrSmallHdr[i]));
+  free_pntrString(pntrSmallHdr);
+  for (i = 0; i <= g_statements; i++) free_vstring(*(vstring *)(&pntrTinyHdr[i]));
+  free_pntrString(pntrTinyHdr);
 
 } /* writeTheoremList */
 
@@ -4360,7 +4357,7 @@ flag getSectionHeadings(long stmt,
     flag fullComment) {
 
   /* for table of contents */
-  vstring labelStr = "";
+  vstring_def(labelStr);
   long pos, pos1, pos2, pos3, pos4;
   flag errorFound = 0;
   flag saveOutputToString;
@@ -4371,14 +4368,14 @@ flag getSectionHeadings(long stmt,
 
   /* (This initialization seems to be done redundantly by caller elsewhere,
      but for  WRITE SOURCE ... / EXTRACT we need to do it explicitly.) */
-  let(&(*hugeHdrTitle), "");
-  let(&(*bigHdrTitle), "");
-  let(&(*smallHdrTitle), "");
-  let(&(*tinyHdrTitle), "");
-  let(&(*hugeHdrComment), "");
-  let(&(*bigHdrComment), "");
-  let(&(*smallHdrComment), "");
-  let(&(*tinyHdrComment), "");
+  free_vstring(*hugeHdrTitle);
+  free_vstring(*bigHdrTitle);
+  free_vstring(*smallHdrTitle);
+  free_vstring(*tinyHdrTitle);
+  free_vstring(*hugeHdrComment);
+  free_vstring(*bigHdrComment);
+  free_vstring(*smallHdrComment);
+  free_vstring(*tinyHdrComment);
 
   /* We now process only $a or $p statements */
   if (fineResolution == 0) {
@@ -4630,7 +4627,7 @@ flag getSectionHeadings(long stmt,
   /* Restore output stream */
   g_outputToString = saveOutputToString;
 
-  let(&labelStr, "");  /* Deallocate string memory */
+  free_vstring(labelStr);  /* Deallocate string memory */
   return errorFound;
 } /* getSectionHeadings */
 
@@ -4643,8 +4640,8 @@ flag getSectionHeadings(long stmt,
 vstring pinkHTML(long statemNum)
 {
   long statemMap;
-  vstring htmlCode = "";
-  vstring hexValue = "";
+  vstring_def(htmlCode);
+  vstring_def(hexValue);
 
   if (statemNum > 0) {
     statemMap = g_Statement[statemNum].pinkNumber;
@@ -4657,12 +4654,12 @@ vstring pinkHTML(long statemNum)
      was also generated previously) */
 
   /* With style sheet and explicit color */
-  let(&hexValue, "");
+  free_vstring(hexValue);
   hexValue = spectrumToRGB(statemMap, g_Statement[g_statements].pinkNumber);
   let(&htmlCode, cat(PINK_NBSP,
       "<SPAN CLASS=r STYLE=\"color:#", hexValue, "\">",
       (statemMap != -1) ? str((double)statemMap) : "(future)", "</SPAN>", NULL));
-  let(&hexValue, "");
+  free_vstring(hexValue);
 
   return htmlCode;
 } /* pinkHTML */
@@ -4673,20 +4670,20 @@ vstring pinkHTML(long statemNum)
    function cannot be used in let statements but must be assigned to
    a local vstring for local deallocation) */
 vstring pinkRangeHTML(long statemNum1, long statemNum2) {
-  vstring htmlCode = "";
-  vstring str3 = "";
-  vstring str4 = "";
+  vstring_def(htmlCode);
+  vstring_def(str3);
+  vstring_def(str4);
 
   /* Construct the HTML for a pink number range */
-  let(&str3, "");
+  free_vstring(str3);
   str3 = pinkHTML(statemNum1);
   let(&str3, right(str3, (long)strlen(PINK_NBSP) + 1)); /* Discard "&nbsp;" */
-  let(&str4, "");
+  free_vstring(str4);
   str4 = pinkHTML(statemNum2);
   let(&str4, right(str4, (long)strlen(PINK_NBSP) + 1)); /* Discard "&nbsp;" */
   let(&htmlCode, cat(str3, "-", str4, NULL));
-  let(&str3, ""); /* Deallocate */
-  let(&str4, ""); /* Deallocate */
+  free_vstring(str3); /* Deallocate */
+  free_vstring(str4); /* Deallocate */
   return htmlCode;
 } /* pinkRangeHTML */
 
@@ -4696,7 +4693,7 @@ vstring pinkRangeHTML(long statemNum1, long statemNum2) {
    returned vstring to prevent memory leaks.  color = 1 (red) to maxColor
    (violet).  A special case is the color -1, which just returns black. */
 vstring spectrumToRGB(long color, long maxColor) {
-  vstring str1 = "";
+  vstring_def(str1);
   double fraction, fractionInPartition;
   long j, red, green, blue, partition;
 /* Change PARTITIONS whenever the table below has entries added or removed! */
@@ -4825,9 +4822,9 @@ vstring spectrumToRGB(long color, long maxColor) {
 vstring getTexLongMath(nmbrString *mathString, long statemNum)
 {
   long pos;
-  vstring tex = "";
-  vstring texLine = "";
-  vstring lastTex = "";
+  vstring_def(tex);
+  vstring_def(texLine);
+  vstring_def(lastTex);
   flag alphnew, alphold, unknownnew, unknownold;
 
   if (!g_texDefsRead) bug(2322); /* TeX defs were not read */
@@ -4835,7 +4832,7 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
 
   let(&lastTex, "");
   for (pos = 0; pos < nmbrLen(mathString); pos++) {
-    let(&tex, "");
+    free_vstring(tex);
     tex = tokenToTex(g_MathToken[mathString[pos]].tokenName, statemNum);
               /* tokenToTex allocates tex; we must deallocate it */
     if (!g_htmlFlag) {  /* LaTeX */
@@ -4992,8 +4989,8 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
       texLine,
       (g_altHtmlFlag ? "</SPAN>" : ""), NULL));
 
-  let(&tex, "");
-  let(&lastTex, "");
+  free_vstring(tex);
+  free_vstring(lastTex);
   return texLine;
 } /* getTexLongMath */
 
@@ -5007,8 +5004,8 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
 vstring getTexOrHtmlHypAndAssertion(long statemNum) {
   long reqHyps, essHyps, n;
   nmbrString *nmbrTmpPtr; /* Pointer only; not allocated directly */
-  vstring texOrHtmlCode = "";
-  vstring str2 = "";
+  vstring_def(texOrHtmlCode);
+  vstring_def(str2);
   /* Count the number of essential hypotheses essHyps */
   essHyps = 0;
   reqHyps = nmbrLen(g_Statement[statemNum].reqHypList);
@@ -5072,12 +5069,12 @@ vstring getTexOrHtmlHypAndAssertion(long statemNum) {
   }
   /* Construct TeX or HTML assertion */
   nmbrTmpPtr = g_Statement[statemNum].mathString;
-  let(&str2, "");
+  free_vstring(str2);
   str2 = getTexLongMath(nmbrTmpPtr, statemNum);
   let(&texOrHtmlCode, cat(texOrHtmlCode, str2, NULL));
 
   /* Deallocate memory */
-  let(&str2, "");
+  free_vstring(str2);
   return texOrHtmlCode;
 }  /* getTexOrHtmlHypAndAssertion */
 
@@ -5096,8 +5093,13 @@ flag writeBibliography(vstring bibFile,
   FILE *list1_fp = NULL;
   FILE *list2_fp = NULL;
   long lines, p2, i, j, jend, k, l, m, n, p, q, s, pass1refs;
-  vstring str1 = "", str2 = "", str3 = "", str4 = "", newstr = "", oldstr = "";
-  pntrString *pntrTmp = NULL_PNTRSTRING;
+  vstring_def(str1);
+  vstring_def(str2);
+  vstring_def(str3);
+  vstring_def(str4);
+  vstring_def(newstr);
+  vstring_def(oldstr);
+  pntrString_def(pntrTmp);
   flag warnFlag;
 
   n = 0; /* Old gcc 4.6.3 wrongly says may be uninit ln 5506 */
@@ -5319,7 +5321,7 @@ flag writeBibliography(vstring bibFile,
             m = k;
             break;
           }
-          let(&str3, ""); /* Clear tmp alloc stack created by "mid" */
+          freeTempAlloc(); /* Clear tmp alloc stack created by "mid" */
         }
         if (!m) {
           if (p2 == 1) {
@@ -5374,7 +5376,7 @@ flag writeBibliography(vstring bibFile,
           let(&str2, str2);
         }
 
-        let(&newstr, "");
+        free_vstring(newstr);
         newstr = pinkHTML(i); /* Get little pink number */
         let(&oldstr, cat(
             /* Construct the sorting key */
@@ -5472,7 +5474,7 @@ flag writeBibliography(vstring bibFile,
             "\""); /* Don't break inside quotes e.g. "Arial Narrow" */
         g_outputToString = 0;
         fprintf(list2_fp, "%s", g_printString);
-        let(&g_printString, "");
+        free_vstring(g_printString);
       }
     }
   }
@@ -5516,8 +5518,8 @@ flag writeBibliography(vstring bibFile,
 
     print2("%ld table rows were written.\n", n);
     /* Deallocate string array */
-    for (i = 0; i < lines; i++) let((vstring *)(&pntrTmp[i]), "");
-    pntrLet(&pntrTmp,NULL_PNTRSTRING);
+    for (i = 0; i < lines; i++) free_vstring(*(vstring *)(&pntrTmp[i]));
+    free_pntrString(pntrTmp);
   }
 
 
@@ -5608,8 +5610,8 @@ long getMathboxLoc(nmbrString **mathboxStart, nmbrString **mathboxEnd,
     pntrString **mathboxUser) {
   long m, p, q, tagLen, stmt;
   long mathboxes = 0;
-  vstring comment = "";
-  vstring user = "";
+  vstring_def(comment);
+  vstring_def(user);
   assignMathboxInfo(); /* Assign g_mathboxStmt */
   tagLen = (long)strlen(MB_TAG);
   /* Ensure lists are initialized */
@@ -5648,7 +5650,7 @@ long getMathboxLoc(nmbrString **mathboxStart, nmbrString **mathboxEnd,
   }
   (*mathboxEnd)[mathboxes - 1] = g_statements; /* Assumed end of last mathbox */
  RETURN_POINT:
-  let(&comment, "");
-  let(&user, "");
+  free_vstring(comment);
+  free_vstring(user);
   return mathboxes;
 } /* getMathboxLoc */


### PR DESCRIPTION
* This commit adds macros `free_vstring`, `free_nmbrString` and `free_pntrString` for the idiom `let(&x, "")`, in order to make clear when this is being used to deallocate memory (as opposed to actually setting the value to the empty string).
* It also adds macros `vstring_def`, `nmbrString_def` and `pntrString_def` for the idiom `vstring x = ""`, because this is the only safe way to construct a new `vstring`. (The macro `vstringdef` already existed; it has been renamed to `vstring_def` for consistency with the others and used throughout.)
* In a few places, the idiom `let(&dummy, "")` was being used for its side effect of clearing temporary variables, for example when `mid()` is being called in a loop which does not otherwise contain a `let`. Instead of this, the function `freeTempAlloc()` that actually does the work has been made public so it can be called directly.
* Other than whitespace and parenthesization changes, there is nothing else in this commit, despite its large number of touched lines. It is essentially a search and replace job.
