### PR TITLE
Add some of the tests from metamath-test

### DIFF
--- a/tests/anatomy-bad1.expected
+++ b/tests/anatomy-bad1.expected
@@ -1,0 +1,16 @@
+MM> READ "anatomy-bad1.mm"
+Reading source file "anatomy-bad1.mm"... 699 bytes
+699 bytes were read into the source buffer.
+The source has 8 statements; 1 are $a and 1 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+?Error on line 29 of file "anatomy-bad1.mm" at statement 8, label "wnew", type
+"$p":
+wnew $p wff ( s -> ( r -> p ) ) $= ws wr wp w2 ws $.
+                                               ^^
+After proof step 5 (the last step), the RPN stack contains 3 entries: "ws"
+(step 1), "w2" (step 4), and  "ws" (step 5).  It should contain exactly one
+entry.
+

--- a/tests/anatomy-bad1.in
+++ b/tests/anatomy-bad1.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/anatomy-bad1.mm
+++ b/tests/anatomy-bad1.mm
@@ -1,0 +1,30 @@
+$( anatomy.mm $)
+
+$(
+                      PUBLIC DOMAIN DEDICATION
+
+This file is placed in the public domain per the Creative Commons Public
+Domain Dedication. http://creativecommons.org/licenses/publicdomain/
+
+Norman Megill - email: nm at alum.mit.edu
+
+$)
+
+
+$( This file is the introductory formal system example described
+   in Chapter 4 of the Metamath book, "Anatomy of a proof". $)
+
+$( Declare the constant symbols we will use $)
+$c ( ) -> wff $.
+$( Declare the metavariables we will use $)
+$v p q r s $.
+$( Declare wffs $)
+wp $f wff p $.
+wq $f wff q $.
+wr $f wff r $.
+ws $f wff s $.
+w2 $a wff ( p -> q ) $.
+
+$( Prove a simple theorem. $)
+wnew $p wff ( s -> ( r -> p ) ) $= ws wr wp w2 ws $.
+

--- a/tests/anatomy-bad2.expected
+++ b/tests/anatomy-bad2.expected
@@ -1,0 +1,15 @@
+MM> READ "anatomy-bad2.mm"
+Reading source file "anatomy-bad2.mm"... 696 bytes
+696 bytes were read into the source buffer.
+The source has 8 statements; 1 are $a and 1 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+?Error on line 29 of file "anatomy-bad2.mm" at statement 8, label "wnew", type
+"$p":
+wnew $p wff ( s -> ( r -> p ) ) $= ws wr wp w2 $.
+                                            ^^
+After proof step 4 (the last step), the RPN stack contains 2 entries: "ws"
+(step 1) and  "w2" (step 4).  It should contain exactly one entry.
+

--- a/tests/anatomy-bad2.in
+++ b/tests/anatomy-bad2.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/anatomy-bad2.mm
+++ b/tests/anatomy-bad2.mm
@@ -1,0 +1,30 @@
+$( anatomy.mm $)
+
+$(
+                      PUBLIC DOMAIN DEDICATION
+
+This file is placed in the public domain per the Creative Commons Public
+Domain Dedication. http://creativecommons.org/licenses/publicdomain/
+
+Norman Megill - email: nm at alum.mit.edu
+
+$)
+
+
+$( This file is the introductory formal system example described
+   in Chapter 4 of the Metamath book, "Anatomy of a proof". $)
+
+$( Declare the constant symbols we will use $)
+$c ( ) -> wff $.
+$( Declare the metavariables we will use $)
+$v p q r s $.
+$( Declare wffs $)
+wp $f wff p $.
+wq $f wff q $.
+wr $f wff r $.
+ws $f wff s $.
+w2 $a wff ( p -> q ) $.
+
+$( Prove a simple theorem. $)
+wnew $p wff ( s -> ( r -> p ) ) $= ws wr wp w2 $.
+

--- a/tests/anatomy-bad3.expected
+++ b/tests/anatomy-bad3.expected
@@ -1,0 +1,15 @@
+MM> READ "anatomy-bad3.mm"
+Reading source file "anatomy-bad3.mm"... 696 bytes
+696 bytes were read into the source buffer.
+The source has 8 statements; 1 are $a and 1 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+?Error on line 29 of file "anatomy-bad3.mm" at statement 8, label "wnew", type
+"$p":
+wnew $p wff ( s -> ( r -> p ) ) $= wr wp w2 w2 $.
+                                            ^^
+At proof step 4, statement "w2" requires 2 hypotheses but the RPN stack
+contains only one entry, "w2" (step 3).
+

--- a/tests/anatomy-bad3.in
+++ b/tests/anatomy-bad3.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/anatomy-bad3.mm
+++ b/tests/anatomy-bad3.mm
@@ -1,0 +1,30 @@
+$( anatomy.mm $)
+
+$(
+                      PUBLIC DOMAIN DEDICATION
+
+This file is placed in the public domain per the Creative Commons Public
+Domain Dedication. http://creativecommons.org/licenses/publicdomain/
+
+Norman Megill - email: nm at alum.mit.edu
+
+$)
+
+
+$( This file is the introductory formal system example described
+   in Chapter 4 of the Metamath book, "Anatomy of a proof". $)
+
+$( Declare the constant symbols we will use $)
+$c ( ) -> wff $.
+$( Declare the metavariables we will use $)
+$v p q r s $.
+$( Declare wffs $)
+wp $f wff p $.
+wq $f wff q $.
+wr $f wff r $.
+ws $f wff s $.
+w2 $a wff ( p -> q ) $.
+
+$( Prove a simple theorem. $)
+wnew $p wff ( s -> ( r -> p ) ) $= wr wp w2 w2 $.
+

--- a/tests/anatomy.expected
+++ b/tests/anatomy.expected
@@ -1,0 +1,9 @@
+MM> READ "anatomy.mm"
+Reading source file "anatomy.mm"... 699 bytes
+699 bytes were read into the source buffer.
+The source has 8 statements; 1 are $a and 1 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+All proofs in the database were verified.

--- a/tests/anatomy.in
+++ b/tests/anatomy.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/anatomy.mm
+++ b/tests/anatomy.mm
@@ -1,0 +1,30 @@
+$( anatomy.mm $)
+
+$(
+                      PUBLIC DOMAIN DEDICATION
+
+This file is placed in the public domain per the Creative Commons Public
+Domain Dedication. http://creativecommons.org/licenses/publicdomain/
+
+Norman Megill - email: nm at alum.mit.edu
+
+$)
+
+
+$( This file is the introductory formal system example described
+   in Chapter 4 of the Metamath book, "Anatomy of a proof". $)
+
+$( Declare the constant symbols we will use $)
+$c ( ) -> wff $.
+$( Declare the metavariables we will use $)
+$v p q r s $.
+$( Declare wffs $)
+wp $f wff p $.
+wq $f wff q $.
+wr $f wff r $.
+ws $f wff s $.
+w2 $a wff ( p -> q ) $.
+
+$( Prove a simple theorem. $)
+wnew $p wff ( s -> ( r -> p ) ) $= ws wr wp w2 w2 $.
+

--- a/tests/big-unifier-bad2.expected
+++ b/tests/big-unifier-bad2.expected
@@ -1,0 +1,18 @@
+MM> READ "big-unifier-bad2.mm"
+Reading source file "big-unifier-bad2.mm"... 3366 bytes
+3366 bytes were read into the source buffer.
+The source has 28 statements; 4 are $a and 1 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+?Error on line 68 of file "big-unifier-bad2.mm" at statement 28, label
+"theorem1", type "$p":
+   FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOAR $.
+                                                ^
+After proof step 80 (the last step), the RPN stack contains 14 entries: "F"
+(step 55), "L" (step 56), "G" (step 69), "P" (step 70), "M" (step 71), "K"
+(step 72), "B" (step 73), "A" (step 74), "D" (step 75), "C" (step 76), "E"
+(step 77), "O" (step 78), "A" (step 79), and  "R" (step 80).  It should contain
+exactly one entry.
+

--- a/tests/big-unifier-bad2.in
+++ b/tests/big-unifier-bad2.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/big-unifier-bad2.mm
+++ b/tests/big-unifier-bad2.mm
@@ -1,0 +1,100 @@
+$( big-unifier.mm - Version of 30-Aug-2008
+
+                             PUBLIC DOMAIN
+
+This file (specifically, the version of this file with the above date)
+has been placed in the Public Domain per the Creative Commons Public
+Domain Dedication.  http://creativecommons.org/licenses/publicdomain/
+
+The public domain release applies worldwide.  In case this is not
+legally possible, the right is granted to use the work for any purpose,
+without any conditions, unless such conditions are required by law.
+
+Norman Megill - http://metamath.org $)
+
+$(
+
+This file (big-unifier.mm) is a unification and substitution test for
+Metamath verifiers, where small input expressions blow up to thousands
+of symbols.  It is a translation of William McCune's "big-unifier.in"
+for the OTTER theorem prover:
+
+    http://www-unix.mcs.anl.gov/AR/award-2003/big-unifier.in
+    http://www-unix.mcs.anl.gov/AR/award-2003/big-unifier.out
+
+    Description:  "Examples of complicated substitutions in condensed
+        detachment.  These occur in Larry Wos's proofs that XCB is a single
+        axiom for EC."
+$)
+
+
+ $c wff |- e ( , ) $.
+ $v x y z w v u v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 $.
+
+  wx $f wff x $. wy $f wff y $. wz $f wff z $. ww $f wff w $.
+  wv $f wff v $. wu $f wff u $. wv1 $f wff v1 $. wv2 $f wff v2 $.
+  wv3 $f wff v3 $. wv4 $f wff v4 $. wv5 $f wff v5 $. wv6 $f wff v6 $.
+  wv7 $f wff v7 $. wv8 $f wff v8 $. wv9 $f wff v9 $. wv10 $f wff v10 $.
+  wv11 $f wff v11 $.
+
+ $( The binary connective of the language "EC". $)
+ wi $a wff e ( x , y ) $.
+
+ ${
+   ax-mp.1 $e |- x $.
+   ax-mp.2 $e |- e ( x , y ) $.
+   $( The inference rule. $)
+   ax-mp $a |- y $.
+ $}
+
+ $( The first axiom. $)
+ ax-maj $a |- e ( e ( e ( e ( e ( x , e ( y , e ( e ( e ( e ( e ( z , e (
+   e ( e ( z , u ) , e ( v , u ) ) , v ) ) , e ( e ( w , e ( e ( e ( w , v6
+   ) , e ( v7 , v6 ) ) , v7 ) ) , y ) ) , v8 ) , e ( v9 , v8 ) ) , v9 ) ) )
+   , x ) , v10 ) , e ( v11 , v10 ) ) , v11 ) $.
+
+ $( The second axiom. $)
+ ax-min $a |- e ( e ( e ( e ( e ( e ( x , e ( e ( y , e ( e ( e ( y , z )
+   , e ( u , z ) ) , u ) ) , x ) ) , e ( v , e ( e ( e ( v , w ) , e ( v6 ,
+   w ) ) , v6 ) ) ) , v7 ) , v8 ) , e ( v7 , v8 ) ) , e ( v9 , e ( e ( e (
+   v9 , v10 ) , e ( v11 , v10 ) ) , v11 ) ) ) $.
+
+ $( A 3-step proof that applies ~ ax-mp to the two axioms.  The proof was
+    saved in compressed format with "save proof theorem1 /compressed" in
+    the metamath program. $)
+ theorem1 $p |- e ( e ( e ( x , e ( y , e ( e ( e ( y , z ) , e ( u , z ) )
+   , u ) ) ) , v ) , e ( x , v ) ) $=
+   ( wi ax-min ax-maj ax-mp ) ABBCFECFFEFFZFZKDFADFFZAFZFJMFFZKNJFFNFZFAO
+   FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOAR $.
+
+$(
+
+This comment holds a simple typesetting definition file so that HTML
+pages can be created with "show statement theorem1/html" in the
+metamath program.
+
+$t
+htmldef "(" as " ( ";
+htmldef ")" as " ) ";
+htmldef "e" as " e ";
+htmldef "wff" as " wff ";
+htmldef "|-" as " |- ";
+htmldef "," as " , ";
+htmldef "x" as " x ";
+htmldef "y" as " y ";
+htmldef "z" as " z ";
+htmldef "w" as " w ";
+htmldef "v" as " v ";
+htmldef "u" as " u ";
+htmldef "v1" as " v1 ";
+htmldef "v2" as " v2 ";
+htmldef "v3" as " v3 ";
+htmldef "v4" as " v4 ";
+htmldef "v5" as " v5 ";
+htmldef "v6" as " v6 ";
+htmldef "v7" as " v7 ";
+htmldef "v8" as " v8 ";
+htmldef "v9" as " v9 ";
+htmldef "v10" as " v10 ";
+htmldef "v11" as " v11 ";
+$)

--- a/tests/big-unifier-bad3.expected
+++ b/tests/big-unifier-bad3.expected
@@ -1,0 +1,18 @@
+MM> READ "big-unifier-bad3.mm"
+Reading source file "big-unifier-bad3.mm"... 3369 bytes
+3369 bytes were read into the source buffer.
+The source has 28 statements; 4 are $a and 1 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+?Error on line 68 of file "big-unifier-bad3.mm" at statement 28, label
+"theorem1", type "$p":
+   FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOARLAI $.
+                                                   ^
+After proof step 83 (the last step), the RPN stack contains 13 entries: "F"
+(step 55), "L" (step 56), "G" (step 69), "P" (step 70), "M" (step 71), "K"
+(step 72), "B" (step 73), "A" (step 74), "D" (step 75), "C" (step 76), "E"
+(step 77), "O" (step 78), and  "I" (step 83).  It should contain exactly one
+entry.
+

--- a/tests/big-unifier-bad3.in
+++ b/tests/big-unifier-bad3.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/big-unifier-bad3.mm
+++ b/tests/big-unifier-bad3.mm
@@ -1,0 +1,100 @@
+$( big-unifier.mm - Version of 30-Aug-2008
+
+                             PUBLIC DOMAIN
+
+This file (specifically, the version of this file with the above date)
+has been placed in the Public Domain per the Creative Commons Public
+Domain Dedication.  http://creativecommons.org/licenses/publicdomain/
+
+The public domain release applies worldwide.  In case this is not
+legally possible, the right is granted to use the work for any purpose,
+without any conditions, unless such conditions are required by law.
+
+Norman Megill - http://metamath.org $)
+
+$(
+
+This file (big-unifier.mm) is a unification and substitution test for
+Metamath verifiers, where small input expressions blow up to thousands
+of symbols.  It is a translation of William McCune's "big-unifier.in"
+for the OTTER theorem prover:
+
+    http://www-unix.mcs.anl.gov/AR/award-2003/big-unifier.in
+    http://www-unix.mcs.anl.gov/AR/award-2003/big-unifier.out
+
+    Description:  "Examples of complicated substitutions in condensed
+        detachment.  These occur in Larry Wos's proofs that XCB is a single
+        axiom for EC."
+$)
+
+
+ $c wff |- e ( , ) $.
+ $v x y z w v u v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 $.
+
+  wx $f wff x $. wy $f wff y $. wz $f wff z $. ww $f wff w $.
+  wv $f wff v $. wu $f wff u $. wv1 $f wff v1 $. wv2 $f wff v2 $.
+  wv3 $f wff v3 $. wv4 $f wff v4 $. wv5 $f wff v5 $. wv6 $f wff v6 $.
+  wv7 $f wff v7 $. wv8 $f wff v8 $. wv9 $f wff v9 $. wv10 $f wff v10 $.
+  wv11 $f wff v11 $.
+
+ $( The binary connective of the language "EC". $)
+ wi $a wff e ( x , y ) $.
+
+ ${
+   ax-mp.1 $e |- x $.
+   ax-mp.2 $e |- e ( x , y ) $.
+   $( The inference rule. $)
+   ax-mp $a |- y $.
+ $}
+
+ $( The first axiom. $)
+ ax-maj $a |- e ( e ( e ( e ( e ( x , e ( y , e ( e ( e ( e ( e ( z , e (
+   e ( e ( z , u ) , e ( v , u ) ) , v ) ) , e ( e ( w , e ( e ( e ( w , v6
+   ) , e ( v7 , v6 ) ) , v7 ) ) , y ) ) , v8 ) , e ( v9 , v8 ) ) , v9 ) ) )
+   , x ) , v10 ) , e ( v11 , v10 ) ) , v11 ) $.
+
+ $( The second axiom. $)
+ ax-min $a |- e ( e ( e ( e ( e ( e ( x , e ( e ( y , e ( e ( e ( y , z )
+   , e ( u , z ) ) , u ) ) , x ) ) , e ( v , e ( e ( e ( v , w ) , e ( v6 ,
+   w ) ) , v6 ) ) ) , v7 ) , v8 ) , e ( v7 , v8 ) ) , e ( v9 , e ( e ( e (
+   v9 , v10 ) , e ( v11 , v10 ) ) , v11 ) ) ) $.
+
+ $( A 3-step proof that applies ~ ax-mp to the two axioms.  The proof was
+    saved in compressed format with "save proof theorem1 /compressed" in
+    the metamath program. $)
+ theorem1 $p |- e ( e ( e ( x , e ( y , e ( e ( e ( y , z ) , e ( u , z ) )
+   , u ) ) ) , v ) , e ( x , v ) ) $=
+   ( wi ax-min ax-maj ax-mp ) ABBCFECFFEFFZFZKDFADFFZAFZFJMFFZKNJFFNFZFAO
+   FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOARLAI $.
+
+$(
+
+This comment holds a simple typesetting definition file so that HTML
+pages can be created with "show statement theorem1/html" in the
+metamath program.
+
+$t
+htmldef "(" as " ( ";
+htmldef ")" as " ) ";
+htmldef "e" as " e ";
+htmldef "wff" as " wff ";
+htmldef "|-" as " |- ";
+htmldef "," as " , ";
+htmldef "x" as " x ";
+htmldef "y" as " y ";
+htmldef "z" as " z ";
+htmldef "w" as " w ";
+htmldef "v" as " v ";
+htmldef "u" as " u ";
+htmldef "v1" as " v1 ";
+htmldef "v2" as " v2 ";
+htmldef "v3" as " v3 ";
+htmldef "v4" as " v4 ";
+htmldef "v5" as " v5 ";
+htmldef "v6" as " v6 ";
+htmldef "v7" as " v7 ";
+htmldef "v8" as " v8 ";
+htmldef "v9" as " v9 ";
+htmldef "v10" as " v10 ";
+htmldef "v11" as " v11 ";
+$)

--- a/tests/big-unifier.expected
+++ b/tests/big-unifier.expected
@@ -1,0 +1,9 @@
+MM> READ "big-unifier.mm"
+Reading source file "big-unifier.mm"... 21981 bytes
+21981 bytes were read into the source buffer.
+The source has 29 statements; 4 are $a and 2 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+All proofs in the database were verified.

--- a/tests/big-unifier.in
+++ b/tests/big-unifier.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/big-unifier.mm
+++ b/tests/big-unifier.mm
@@ -1,0 +1,342 @@
+$( big-unifier.mm - Version of 30-Aug-2008
+
+                             PUBLIC DOMAIN
+
+This file (specifically, the version of this file with the above date)
+has been placed in the Public Domain per the Creative Commons Public
+Domain Dedication.  http://creativecommons.org/licenses/publicdomain/
+
+The public domain release applies worldwide.  In case this is not
+legally possible, the right is granted to use the work for any purpose,
+without any conditions, unless such conditions are required by law.
+
+Norman Megill - http://metamath.org $)
+
+$(
+
+This file (big-unifier.mm) is a unification and substitution test for
+Metamath verifiers, where small input expressions blow up to thousands
+of symbols.  It is a translation of William McCune's "big-unifier.in"
+for the OTTER theorem prover:
+
+    http://www-unix.mcs.anl.gov/AR/award-2003/big-unifier.in
+    http://www-unix.mcs.anl.gov/AR/award-2003/big-unifier.out
+
+    Description:  "Examples of complicated substitutions in condensed
+        detachment.  These occur in Larry Wos's proofs that XCB is a single
+        axiom for EC."
+$)
+
+
+ $c wff |- e ( , ) $.
+ $v x y z w v u v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 $.
+
+  wx $f wff x $. wy $f wff y $. wz $f wff z $. ww $f wff w $.
+  wv $f wff v $. wu $f wff u $. wv1 $f wff v1 $. wv2 $f wff v2 $.
+  wv3 $f wff v3 $. wv4 $f wff v4 $. wv5 $f wff v5 $. wv6 $f wff v6 $.
+  wv7 $f wff v7 $. wv8 $f wff v8 $. wv9 $f wff v9 $. wv10 $f wff v10 $.
+  wv11 $f wff v11 $.
+
+ $( The binary connective of the language "EC". $)
+ wi $a wff e ( x , y ) $.
+
+ ${
+   ax-mp.1 $e |- x $.
+   ax-mp.2 $e |- e ( x , y ) $.
+   $( The inference rule. $)
+   ax-mp $a |- y $.
+ $}
+
+ $( The first axiom. $)
+ ax-maj $a |- e ( e ( e ( e ( e ( x , e ( y , e ( e ( e ( e ( e ( z , e (
+   e ( e ( z , u ) , e ( v , u ) ) , v ) ) , e ( e ( w , e ( e ( e ( w , v6
+   ) , e ( v7 , v6 ) ) , v7 ) ) , y ) ) , v8 ) , e ( v9 , v8 ) ) , v9 ) ) )
+   , x ) , v10 ) , e ( v11 , v10 ) ) , v11 ) $.
+
+ $( The second axiom. $)
+ ax-min $a |- e ( e ( e ( e ( e ( e ( x , e ( e ( y , e ( e ( e ( y , z )
+   , e ( u , z ) ) , u ) ) , x ) ) , e ( v , e ( e ( e ( v , w ) , e ( v6 ,
+   w ) ) , v6 ) ) ) , v7 ) , v8 ) , e ( v7 , v8 ) ) , e ( v9 , e ( e ( e (
+   v9 , v10 ) , e ( v11 , v10 ) ) , v11 ) ) ) $.
+
+ $( A 3-step proof that applies ~ ax-mp to the two axioms.  The proof was
+    saved in compressed format with "save proof theorem1 /compressed" in
+    the metamath program. $)
+ theorem1 $p |- e ( e ( e ( x , e ( y , e ( e ( e ( y , z ) , e ( u , z ) )
+   , u ) ) ) , v ) , e ( x , v ) ) $=
+   ( wi ax-min ax-maj ax-mp ) ABBCFECFFEFFZFZKDFADFFZAFZFJMFFZKNJFFNFZFAO
+   FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOARLHI $.
+
+ $( This is the same as ~ theorem1 , except that the proof is saved in
+    uncompressed format with "save proof theorem1u /normal" in the metamath
+    program.  Note the size difference in the compressed vs. uncompressed
+    proofs. $)
+ theorem1u $p |- e ( e ( e ( x , e ( y , e ( e ( e ( y , z ) , e ( u , z ) )
+   , u ) ) ) , v ) , e ( x , v ) ) $=
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz
+   wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi
+   wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi
+   wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy
+   wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi
+   wx wv wi wi wx wi wi wi wi wi wx wx wy wy wz wi wu wz wi wi wu wi wi wi wx
+   wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi
+   wi wu wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi
+   wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wx
+   wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wx wy wy wz wi wu wz
+   wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi
+   wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy
+   wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx
+   wv wi wi wx wi wi wi wi wi wx wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy
+   wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv
+   wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi
+   wu wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz
+   wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi
+   wi wi wx wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy
+   wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx
+   wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv
+   wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi
+   wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi wx wx wy wy wz wi wu wz wi
+   wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz
+   wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wy
+   wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz
+   wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv
+   wi wi wx wi wi wi wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi
+   wx wv wi wi wx wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy
+   wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx
+   wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv
+   wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi
+   wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi wx wx wy wy wz wi wu wz wi
+   wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz
+   wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wy
+   wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz
+   wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv
+   wi wi wx wi wi wi wi wi wi wx wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz
+   wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv
+   wi wi wx wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi
+   wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu
+   wi wi wi wv wi wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi
+   wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy
+   wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi wx wx wy
+   wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx
+   wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi
+   wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi
+   wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu wz
+   wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi
+   wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi
+   wi wi wv wi wx wv wi wi wx wi wi wi wi wi wi wi wi wx wy wy wz wi wu wz wi
+   wi wu wi wi wi wv wi wx wv wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv
+   wi wx wv wi wi wx wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi
+   wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy
+   wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi
+   wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz
+   wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx
+   wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi
+   wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi wx wx wy wy wz wi wu wz
+   wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi
+   wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy
+   wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx
+   wv wi wi wx wi wi wi wi wi wi wx wi wi wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy
+   wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx
+   wv wi wi wx wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv
+   wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi
+   wu wi wi wi wv wi wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu
+   wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy
+   wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi wx wx
+   wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz
+   wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv
+   wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi
+   wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu
+   wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi wi wi wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wv wi wx wv wi wi wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy
+   wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx
+   wv wi wi wx wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wy wy wz wi wu wz wi wi wu
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy
+   wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi
+   wx wv wi wi wx wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv
+   wi wi wx wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi
+   wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wx wy
+   wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx
+   wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi
+   wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi
+   wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu wz
+   wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi
+   wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi
+   wi wi wv wi wx wv wi wi wx wi wi wi wi wi wx wx wy wy wz wi wu wz wi wi wu
+   wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi
+   wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx
+   wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wy wy wz
+   wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy
+   wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu
+   wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi
+   wx wi wi wi wi wi wi wx wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy
+   wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu
+   wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi
+   wx wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi
+   wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx
+   wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wv wi wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx
+   wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi wx wx wy wy wz
+   wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy
+   wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz
+   wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx
+   wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu wz wi wi
+   wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi
+   wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wv wi wx wv wi wi wx wi wi wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wv wi wx wv wi wi wx wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz
+   wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi
+   wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu
+   wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi
+   wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv
+   wi wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy
+   wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi
+   wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz
+   wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi wx wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi
+   wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi
+   wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy
+   wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi
+   wx wv wi wi wx wi wi wi wi wi wi ax-min wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy
+   wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx
+   wv wi wi wx wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv
+   wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi
+   wu wi wi wi wv wi wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu
+   wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy
+   wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi wx wx
+   wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz
+   wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv
+   wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi
+   wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu
+   wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi wi wx wy wy wz wi wu wz wi wi
+   wu wi wi wi wv wi wx wv wi wi wx wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wy wx wv wz wu wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz
+   wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi
+   wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi
+   wi wi wv wi wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz
+   wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi wx wx wy wy wz
+   wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wx wy wy wz wi wu wz wi
+   wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx
+   wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi
+   wi wv wi wx wv wi wi wx wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx
+   wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi
+   wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi
+   wi wu wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi
+   wi wi wx wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi
+   wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi
+   wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wv wi wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu wi wi wi wi wx wy
+   wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv
+   wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi wi wx wi wi wx wy
+   wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv
+   wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu
+   wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wx wy wy wz wi wu wz wi
+   wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz
+   wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi
+   wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wy
+   wy wz wi wu wz wi wi wu wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz
+   wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv
+   wi wi wx wi wi wi wi wi wx wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy
+   wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi
+   wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi wx wy wy wz wi wu wz
+   wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wy wy wz wi wu wz wi wi wu
+   wi wi wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wx wy wy wz wi wu wz wi
+   wi wu wi wi wi wv wi wx wv wi wi wx wi wi wy wy wz wi wu wz wi wi wu wi wi
+   wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi wx wi wi wi wi wi
+   wi wi wx wy wy wz wi wu wz wi wi wu wi wi wi wv wi wx wv wi wi ax-maj ax-mp
+   $.
+
+$(
+
+This comment holds a simple typesetting definition file so that HTML
+pages can be created with "show statement theorem1/html" in the
+metamath program.
+
+$t
+htmldef "(" as " ( ";
+htmldef ")" as " ) ";
+htmldef "e" as " e ";
+htmldef "wff" as " wff ";
+htmldef "|-" as " |- ";
+htmldef "," as " , ";
+htmldef "x" as " x ";
+htmldef "y" as " y ";
+htmldef "z" as " z ";
+htmldef "w" as " w ";
+htmldef "v" as " v ";
+htmldef "u" as " u ";
+htmldef "v1" as " v1 ";
+htmldef "v2" as " v2 ";
+htmldef "v3" as " v3 ";
+htmldef "v4" as " v4 ";
+htmldef "v5" as " v5 ";
+htmldef "v6" as " v6 ";
+htmldef "v7" as " v7 ";
+htmldef "v8" as " v8 ";
+htmldef "v9" as " v9 ";
+htmldef "v10" as " v10 ";
+htmldef "v11" as " v11 ";
+$)

--- a/tests/demo0-bad1.expected
+++ b/tests/demo0-bad1.expected
@@ -1,0 +1,22 @@
+MM> READ "demo0-bad1.mm"
+Reading source file "demo0-bad1.mm"... 1353 bytes
+1353 bytes were read into the source buffer.
+The source has 19 statements; 7 are $a and 1 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+?Error on line 50 of file "demo0-bad1.mm" at statement 19, label "th1", type
+"$p":
+       tt tze tpl tt tt a1 mp mp
+                              ^^
+The hypotheses of statement "mp" at proof step 34 cannot be unified.
+  Hypothesis 1:  wff P
+  Step 5:  wff t = ( 0 + t )
+  Hypothesis 2:  wff Q
+  Step 8:  wff t = t
+  Hypothesis 3:  |- P
+  Step 10:  |- ( t + 0 ) = t
+  Hypothesis 4:  |- ( P -> Q )
+  Step 33:  |- ( ( t + 0 ) = t -> t = t )
+

--- a/tests/demo0-bad1.in
+++ b/tests/demo0-bad1.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/demo0-bad1.mm
+++ b/tests/demo0-bad1.mm
@@ -1,0 +1,52 @@
+$( demo0.mm  1-Jan-04 $)
+
+$(
+                      PUBLIC DOMAIN DEDICATION
+
+This file is placed in the public domain per the Creative Commons Public
+Domain Dedication. http://creativecommons.org/licenses/publicdomain/
+
+Norman Megill - email: nm at alum.mit.edu
+
+$)
+
+
+$( This file is the introductory formal system example described
+   in Chapter 2 of the Meamath book. $)
+
+$( Declare the constant symbols we will use $)
+    $c 0 + = -> ( ) term wff |- $.
+$( Declare the metavariables we will use $)
+    $v t r s P Q $.
+$( Specify properties of the metavariables $)
+    tt $f term t $.
+    tr $f term r $.
+    ts $f term s $.
+    wp $f wff P $.
+    wq $f wff Q $.
+$( Define "term" (part 1) $)
+    tze $a term 0 $.
+$( Define "term" (part 2) $)
+    tpl $a term ( t + r ) $.
+$( Define "wff" (part 1) $)
+    weq $a wff t = r $.
+$( Define "wff" (part 2) $)
+    wim $a wff ( P -> Q ) $.
+$( State axiom a1 $)
+    a1 $a |- ( t = r -> ( t = s -> r = s ) ) $.
+$( State axiom a2 $)
+    a2 $a |- ( t + 0 ) = t $.
+    ${
+       min $e |- P $.
+       maj $e |- ( P -> Q ) $.
+$( Define the modus ponens inference rule $)
+       mp  $a |- Q $.
+    $}
+$( Prove a theorem $)
+    th1 $p |- t = t $=
+  $( Here is its proof: $)
+       tt tze tt tpl weq tt tt weq tt a2 tt tze tpl
+       tt weq tt tze tpl tt weq tt tt weq wim tt a2
+       tt tze tpl tt tt a1 mp mp
+     $.
+

--- a/tests/demo0-includee.mm
+++ b/tests/demo0-includee.mm
@@ -1,0 +1,45 @@
+$( demo0-includee.mm  1-Jan-04 $)
+
+$(
+                      PUBLIC DOMAIN DEDICATION
+
+This file is placed in the public domain per the Creative Commons Public
+Domain Dedication. http://creativecommons.org/licenses/publicdomain/
+
+Norman Megill - email: nm at alum.mit.edu
+
+$)
+
+
+$( This file is the introductory formal system example described
+   in Chapter 2 of the Meamath book. $)
+
+$( Declare the constant symbols we will use $)
+    $c 0 + = -> ( ) term wff |- $.
+$( Declare the metavariables we will use $)
+    $v t r s P Q $.
+$( Specify properties of the metavariables $)
+    tt $f term t $.
+    tr $f term r $.
+    ts $f term s $.
+    wp $f wff P $.
+    wq $f wff Q $.
+$( Define "term" (part 1) $)
+    tze $a term 0 $.
+$( Define "term" (part 2) $)
+    tpl $a term ( t + r ) $.
+$( Define "wff" (part 1) $)
+    weq $a wff t = r $.
+$( Define "wff" (part 2) $)
+    wim $a wff ( P -> Q ) $.
+$( State axiom a1 $)
+    a1 $a |- ( t = r -> ( t = s -> r = s ) ) $.
+$( State axiom a2 $)
+    a2 $a |- ( t + 0 ) = t $.
+    ${
+       min $e |- P $.
+       maj $e |- ( P -> Q ) $.
+$( Define the modus ponens inference rule $)
+       mp  $a |- Q $.
+    $}
+

--- a/tests/demo0-includer.expected
+++ b/tests/demo0-includer.expected
@@ -1,0 +1,10 @@
+MM> READ "demo0-includer.mm"
+Reading source file "demo0-includer.mm"... 520 bytes
+Reading included file "demo0-includee.mm"... 1145 bytes
+1711 bytes were read into the source buffer.
+The source has 19 statements; 7 are $a and 1 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+All proofs in the database were verified.

--- a/tests/demo0-includer.in
+++ b/tests/demo0-includer.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/demo0-includer.mm
+++ b/tests/demo0-includer.mm
@@ -1,0 +1,23 @@
+$( demo0-includer.mm  1-Jan-04 $)
+
+$(
+                      PUBLIC DOMAIN DEDICATION
+
+This file is placed in the public domain per the Creative Commons Public
+Domain Dedication. http://creativecommons.org/licenses/publicdomain/
+
+Norman Megill - email: nm at alum.mit.edu
+
+$)
+
+
+$[ demo0-includee.mm $]
+
+$( Prove a theorem $)
+    th1 $p |- t = t $=
+  $( Here is its proof: $)
+       tt tze tpl tt weq tt tt weq tt a2 tt tze tpl
+       tt weq tt tze tpl tt weq tt tt weq wim tt a2
+       tt tze tpl tt tt a1 mp mp
+     $.
+

--- a/tests/demo0.expected
+++ b/tests/demo0.expected
@@ -1,0 +1,9 @@
+MM> READ "demo0.mm"
+Reading source file "demo0.mm"... 1353 bytes
+1353 bytes were read into the source buffer.
+The source has 19 statements; 7 are $a and 1 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+All proofs in the database were verified.

--- a/tests/demo0.in
+++ b/tests/demo0.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/demo0.mm
+++ b/tests/demo0.mm
@@ -1,0 +1,52 @@
+$( demo0.mm  1-Jan-04 $)
+
+$(
+                      PUBLIC DOMAIN DEDICATION
+
+This file is placed in the public domain per the Creative Commons Public
+Domain Dedication. http://creativecommons.org/licenses/publicdomain/
+
+Norman Megill - email: nm at alum.mit.edu
+
+$)
+
+
+$( This file is the introductory formal system example described
+   in Chapter 2 of the Meamath book. $)
+
+$( Declare the constant symbols we will use $)
+    $c 0 + = -> ( ) term wff |- $.
+$( Declare the metavariables we will use $)
+    $v t r s P Q $.
+$( Specify properties of the metavariables $)
+    tt $f term t $.
+    tr $f term r $.
+    ts $f term s $.
+    wp $f wff P $.
+    wq $f wff Q $.
+$( Define "term" (part 1) $)
+    tze $a term 0 $.
+$( Define "term" (part 2) $)
+    tpl $a term ( t + r ) $.
+$( Define "wff" (part 1) $)
+    weq $a wff t = r $.
+$( Define "wff" (part 2) $)
+    wim $a wff ( P -> Q ) $.
+$( State axiom a1 $)
+    a1 $a |- ( t = r -> ( t = s -> r = s ) ) $.
+$( State axiom a2 $)
+    a2 $a |- ( t + 0 ) = t $.
+    ${
+       min $e |- P $.
+       maj $e |- ( P -> Q ) $.
+$( Define the modus ponens inference rule $)
+       mp  $a |- Q $.
+    $}
+$( Prove a theorem $)
+    th1 $p |- t = t $=
+  $( Here is its proof: $)
+       tt tze tpl tt weq tt tt weq tt a2 tt tze tpl
+       tt weq tt tze tpl tt weq tt tt weq wim tt a2
+       tt tze tpl tt tt a1 mp mp
+     $.
+


### PR DESCRIPTION
- Does not include anything which took a long time to run
- Does not include versions of set.mm and the like - we check those
elsewhere
- Emphasis is on failure tests

Why copy them here rather than come up with some test rig to pull them from the https://github.com/david-a-wheeler/metamath-test repository? Well (1) as noted above not every test is included, (2) we very much want to be asserting on how the test fails - that a test produces a specific error message is a much better check that the code is still working than that it produces some kind of failure (perhaps unrelated), and (3) complexity in test scripts will .... well just isn't worth it here especially since metamath-test is fairly small and was last modified 6 years ago.