### PR TITLE
Test disjoint

### DIFF
--- a/tests/disjoint1.expected
+++ b/tests/disjoint1.expected
@@ -1,0 +1,19 @@
+MM> READ "disjoint1.mm"
+Reading source file "disjoint1.mm"... 140 bytes
+140 bytes were read into the source buffer.
+The source has 9 statements; 1 are $a and 1 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> Continuous scrolling is now in effect.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+?Error on line 10 of file "disjoint1.mm" at statement 9, label "bad", type
+"$p":
+  xf xf ax-1 $.
+        ^^^^
+There is a disjoint variable ($d) violation at proof step 3.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"x" and "y" was substituted with "x".  These substitutions have variable "x" in
+common.
+
+All proofs in the database were verified.

--- a/tests/disjoint1.in
+++ b/tests/disjoint1.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/disjoint1.mm
+++ b/tests/disjoint1.mm
@@ -1,0 +1,10 @@
+$c var formula |- $.
+$v x y $.
+xf $f formula x $.
+yf $f formula y $.
+${
+  $d x y $.
+  ax-1 $a |- x y $.
+$}
+bad $p |- x x $=
+  xf xf ax-1 $.

--- a/tests/disjoint2.expected
+++ b/tests/disjoint2.expected
@@ -1,0 +1,138 @@
+MM> READ "disjoint2.mm"
+Reading source file "disjoint2.mm"... 628 bytes
+628 bytes were read into the source buffer.
+The source has 26 statements; 2 are $a and 5 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> Continuous scrolling is now in effect.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+.......................
+?Error on line 15 of file "disjoint2.mm" at statement 12, label "verybad", type
+"$p":
+  xf yf combo zf xf combo ax-1 $.
+                          ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z x )".
+Variables "x" and "z" do not have a disjoint variable requirement in the
+assertion being proved, "verybad".
+
+?Error on line 15 of file "disjoint2.mm" at statement 12, label "verybad", type
+"$p":
+  xf yf combo zf xf combo ax-1 $.
+                          ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z x )".  These substitutions have
+variable "x" in common.
+
+?Error on line 15 of file "disjoint2.mm" at statement 12, label "verybad", type
+"$p":
+  xf yf combo zf xf combo ax-1 $.
+                          ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z x )".
+Variables "y" and "z" do not have a disjoint variable requirement in the
+assertion being proved, "verybad".
+
+?Error on line 15 of file "disjoint2.mm" at statement 12, label "verybad", type
+"$p":
+  xf yf combo zf xf combo ax-1 $.
+                          ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z x )".
+Variables "x" and "y" do not have a disjoint variable requirement in the
+assertion being proved, "verybad".
+.....
+?Error on line 20 of file "disjoint2.mm" at statement 15, label "stillbad",
+type "$p":
+    xf yf combo zf xf combo ax-1 $.
+                            ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z x )".  These substitutions have
+variable "x" in common.
+....
+?Error on line 24 of file "disjoint2.mm" at statement 17, label "semigood",
+type "$p":
+  xf yf combo zf wf combo ax-1 $.
+                          ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z w )".
+Variables "x" and "z" do not have a disjoint variable requirement in the
+assertion being proved, "semigood".
+
+?Error on line 24 of file "disjoint2.mm" at statement 17, label "semigood",
+type "$p":
+  xf yf combo zf wf combo ax-1 $.
+                          ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z w )".
+Variables "w" and "x" do not have a disjoint variable requirement in the
+assertion being proved, "semigood".
+
+?Error on line 24 of file "disjoint2.mm" at statement 17, label "semigood",
+type "$p":
+  xf yf combo zf wf combo ax-1 $.
+                          ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z w )".
+Variables "y" and "z" do not have a disjoint variable requirement in the
+assertion being proved, "semigood".
+
+?Error on line 24 of file "disjoint2.mm" at statement 17, label "semigood",
+type "$p":
+  xf yf combo zf wf combo ax-1 $.
+                          ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z w )".
+Variables "w" and "y" do not have a disjoint variable requirement in the
+assertion being proved, "semigood".
+........
+?Error on line 30 of file "disjoint2.mm" at statement 21, label "almostgood",
+type "$p":
+    xf yf combo zf wf combo ax-1 $.
+                            ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z w )".
+Variables "x" and "z" do not have a disjoint variable requirement in the
+assertion being proved, "almostgood".
+
+?Error on line 30 of file "disjoint2.mm" at statement 21, label "almostgood",
+type "$p":
+    xf yf combo zf wf combo ax-1 $.
+                            ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z w )".
+Variables "w" and "x" do not have a disjoint variable requirement in the
+assertion being proved, "almostgood".
+
+?Error on line 30 of file "disjoint2.mm" at statement 21, label "almostgood",
+type "$p":
+    xf yf combo zf wf combo ax-1 $.
+                            ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z w )".
+Variables "y" and "z" do not have a disjoint variable requirement in the
+assertion being proved, "almostgood".
+
+?Error on line 30 of file "disjoint2.mm" at statement 21, label "almostgood",
+type "$p":
+    xf yf combo zf wf combo ax-1 $.
+                            ^^^^
+There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"( x y )" and "y" was substituted with "( z w )".
+Variables "w" and "y" do not have a disjoint variable requirement in the
+assertion being proved, "almostgood".
+..........
+All proofs in the database were verified.

--- a/tests/disjoint2.expected
+++ b/tests/disjoint2.expected
@@ -1,12 +1,12 @@
 MM> READ "disjoint2.mm"
-Reading source file "disjoint2.mm"... 628 bytes
-628 bytes were read into the source buffer.
-The source has 26 statements; 2 are $a and 5 are $p.
+Reading source file "disjoint2.mm"... 754 bytes
+754 bytes were read into the source buffer.
+The source has 33 statements; 2 are $a and 6 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.
 MM> Continuous scrolling is now in effect.
 MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
-.......................
+..................
 ?Error on line 15 of file "disjoint2.mm" at statement 12, label "verybad", type
 "$p":
   xf yf combo zf xf combo ax-1 $.
@@ -45,7 +45,7 @@ requires that variables "x" and "y" be disjoint.  But "x" was substituted with
 "( x y )" and "y" was substituted with "( z x )".
 Variables "x" and "y" do not have a disjoint variable requirement in the
 assertion being proved, "verybad".
-.....
+....
 ?Error on line 20 of file "disjoint2.mm" at statement 15, label "stillbad",
 type "$p":
     xf yf combo zf xf combo ax-1 $.
@@ -54,7 +54,7 @@ There is a disjoint variable ($d) violation at proof step 7.  Assertion "ax-1"
 requires that variables "x" and "y" be disjoint.  But "x" was substituted with
 "( x y )" and "y" was substituted with "( z x )".  These substitutions have
 variable "x" in common.
-....
+...
 ?Error on line 24 of file "disjoint2.mm" at statement 17, label "semigood",
 type "$p":
   xf yf combo zf wf combo ax-1 $.
@@ -94,7 +94,7 @@ requires that variables "x" and "y" be disjoint.  But "x" was substituted with
 "( x y )" and "y" was substituted with "( z w )".
 Variables "w" and "y" do not have a disjoint variable requirement in the
 assertion being proved, "semigood".
-........
+......
 ?Error on line 30 of file "disjoint2.mm" at statement 21, label "almostgood",
 type "$p":
     xf yf combo zf wf combo ax-1 $.
@@ -134,5 +134,5 @@ requires that variables "x" and "y" be disjoint.  But "x" was substituted with
 "( x y )" and "y" was substituted with "( z w )".
 Variables "w" and "y" do not have a disjoint variable requirement in the
 assertion being proved, "almostgood".
-..........
+...................
 All proofs in the database were verified.

--- a/tests/disjoint2.in
+++ b/tests/disjoint2.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/disjoint2.mm
+++ b/tests/disjoint2.mm
@@ -35,3 +35,9 @@ ${
   good $p |- ( ( x y ) ( z w ) ) $=
     xf yf combo zf wf combo ax-1 $.
 $}
+
+${
+  $d x z $. $d x w $. $d y z $. $d y w $.
+  stillgood $p |- ( ( x y ) ( z w ) ) $=
+    xf yf combo zf wf combo ax-1 $.
+$}

--- a/tests/disjoint2.mm
+++ b/tests/disjoint2.mm
@@ -1,0 +1,37 @@
+$c formula |- ( ) $.
+
+$v x y z w $.
+xf $f formula x $.
+yf $f formula y $.
+zf $f formula z $.
+wf $f formula w $.
+combo $a formula ( x y ) $.
+${
+  $d x y $.
+  ax-1 $a |- ( x y ) $.
+$}
+
+verybad $p |- ( ( x y ) ( z x ) ) $=
+  xf yf combo zf xf combo ax-1 $.
+
+${
+  $d x y z $.
+  stillbad $p |- ( ( x y ) ( z x ) ) $=
+    xf yf combo zf xf combo ax-1 $.
+$}
+
+semigood $p |- ( ( x y ) ( z w ) ) $=
+  xf yf combo zf wf combo ax-1 $.
+
+${
+  $d x y $.
+  $d z w $.
+  almostgood $p |- ( ( x y ) ( z w ) ) $=
+    xf yf combo zf wf combo ax-1 $.
+$}
+
+${
+  $d x y z w $.
+  good $p |- ( ( x y ) ( z w ) ) $=
+    xf yf combo zf wf combo ax-1 $.
+$}

--- a/tests/disjoint3.expected
+++ b/tests/disjoint3.expected
@@ -1,0 +1,20 @@
+MM> READ "disjoint3.mm"
+Reading source file "disjoint3.mm"... 140 bytes
+140 bytes were read into the source buffer.
+The source has 9 statements; 1 are $a and 1 are $p.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> Continuous scrolling is now in effect.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+?Error on line 10 of file "disjoint3.mm" at statement 9, label "bad", type
+"$p":
+  xf yf ax-1 $.
+        ^^^^
+There is a disjoint variable ($d) violation at proof step 3.  Assertion "ax-1"
+requires that variables "x" and "y" be disjoint.  But "x" was substituted with
+"x" and "y" was substituted with "y".
+Variables "x" and "y" do not have a disjoint variable requirement in the
+assertion being proved, "bad".
+
+All proofs in the database were verified.

--- a/tests/disjoint3.in
+++ b/tests/disjoint3.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/disjoint3.mm
+++ b/tests/disjoint3.mm
@@ -1,0 +1,10 @@
+$c var formula |- $.
+$v x y $.
+xf $f formula x $.
+yf $f formula y $.
+${
+  $d x y $.
+  ax-1 $a |- x y $.
+$}
+bad $p |- x y $=
+  xf yf ax-1 $.


### PR DESCRIPTION
As long as I've been saying "we should make a testsuite" I've been thinking in terms of making sure that all flavors of disjoint variable constraint violations are detected. It is one of the quickest way for a verifier to let invalid proofs slip through, or so has been my thought process (certainly when I'm writing proofs it is one of the most common places where the verifier catches me doing something which actually won't work).

Here's a start. My intended technique was to comment out the distinct variable checker (the lines in mmveri.c from `/***** Check for $d violations *****/` to `/***** (End of $d violation check) *****/`), writing a test, and then uncommenting out enough of the checker to get the test to now behave the same way as an unmodified metamath-exe. Well, I got as far as two passes (one for each of the two error messages - which turned into disjoint1.mm and disjoint3.mm in this pull request). No doubt it would be possible to poke at this more (either using this technique, or another one), but this is a start.

Along the way I made a somewhat surprising discovery which was that, without trying to do so, I found a test case which put the disjoint variable checker into an (apparently) infinite loop. I added this to the pull request as disjoint2.mm but the loopy bits (that is the portion which triggers the infinite loop) are commented out and so the .expected file just reflects the not-so-interesting parts of that file. The reason I say that it is the disjoint variable checker at fault is that I didn't see the infinite loop when I was working with a version of metamath with the disjoint variable checker commented out (as described in the previous paragraph).