### PR TITLE
use scrolling mode when used non-interactively

### DIFF
--- a/src/metamath.c
+++ b/src/metamath.c
@@ -923,7 +923,7 @@ void command(int argc, char *argv[]) {
   flag printTime;  /* Set by "/ TIME" in SAVE PROOF and others */
 
   /* Default to prompted mode if run interactively, else continuous mode */
-  flag defaultScrollMode = isatty(STDIN_FILENO);
+  flag defaultScrollMode = isatty(STDIN_FILENO) != 0;
 
   /* Initialization to avoid compiler warning (should not be theoretically
      necessary) */

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -703,6 +703,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include "mmvstr.h"
 #include "mmdata.h"
 #include "mmcmdl.h"
@@ -914,7 +915,8 @@ void command(int argc, char *argv[]) {
   double timeIncr = 0;
   flag printTime;  /* Set by "/ TIME" in SAVE PROOF and others */
 
-  flag defaultScrollMode = 1; /* Default to prompted mode */
+  /* Default to prompted mode if run interactively, else continuous mode */
+  flag defaultScrollMode = isatty(STDIN_FILENO);
 
   /* Initialization to avoid compiler warning (should not be theoretically
      necessary) */

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -703,7 +703,6 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include "mmvstr.h"
 #include "mmdata.h"
 #include "mmcmdl.h"
@@ -717,6 +716,14 @@
 #include "mmunif.h"
 #include "mmword.h"
 #include "mmwtex.h"
+
+// Windows doesn't have the <unistd> header, but it has an isatty equivalent
+#ifdef _WIN32
+#include <io.h>
+#define _isatty isatty
+#else
+#include <unistd.h>
+#endif
 
 void command(int argc, char *argv[]);
 


### PR DESCRIPTION
Use `isatty` to find out whether the user is typing directly in the terminal or if this is a tool-driven run, and set the default scroll mode accordingly. This should help tests to avoid hanging on input.