### PR TITLE
bugfix doxygen not scanning source files

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -133,7 +133,7 @@ then
     exit 1
   fi
 
-  cd "$build_dir/src"
+  cd "$build_dir"
 
   # create a Doxyfile.local and use it for creation of documentation locally
 
@@ -149,8 +149,10 @@ then
     cat "$top_dir/Doxyfile" >> Doxyfile.local
   fi
 
-  # ... except for the destination directory.  Force this to the build folder.
+  # ... except for the source/destination directory.  Force this to folders
+  # based on this build.
   echo "OUTPUT_DIRECTORY = \"$build_dir\"" >> Doxyfile.local
+  echo "INPUT = \"$src_dir\"" >> Doxyfile.local
 
   # make sure the logo is in the build directory
   cp --force --symbolic-link "$top_dir/doc/Metamath.png" .

--- a/build.sh
+++ b/build.sh
@@ -133,8 +133,6 @@ then
     exit 1
   fi
 
-  cd "$build_dir"
-
   # create a Doxyfile.local and use it for creation of documentation locally
 
   # start with the settings given by the distribution


### PR DESCRIPTION
enrich documentation with information about *.c and *.h files.