### PR TITLE
fix color codes on windows

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -48,11 +48,12 @@ if ! [ -x "$(command -v "$cmd")" ]; then
 fi
 
 # color codes
-red='\033[0;31m'
-green='\033[0;32m'
-cyan='\033[0;36m'
-white='\033[0;37m'
-off='\033[0m'
+escape=$(printf '\033')
+red="$escape[0;31m"
+green="$escape[0;32m"
+cyan="$escape[0;36m"
+white="$escape[0;97m"
+off="$escape[0m"
 
 # set to 1 if any test fails
 exit_code=0


### PR DESCRIPTION
The escapes here are in single quotes, meaning that they are left uninterpreted and any interpretation of the escapes is being done by `echo`. I tried `echo -e` but that doesn't work in `bash --posix`, but `printf` seems to work to produce the escape character, which can then be interpolated directly into the other variables.

Also swaps out the "white" character for "bright white", which looks the same on linux but also works on windows.