### PR TITLE
Remove g_printHelp flag

### DIFF
--- a/src/mmcmds.c
+++ b/src/mmcmds.c
@@ -24,7 +24,6 @@
 vstring bigAdd(vstring bignum1, vstring bignum2);
 vstring bigSub(vstring bignum1, vstring bignum2);
 
-flag g_printHelp = 0;
 
 /* For HTML output */
 vstring_def(g_printStringForReferencedBy);
@@ -5892,9 +5891,7 @@ long getStatementNum(vstring stmtName, /* Possibly with wildcards */
 /* Called by help() - prints a help line */
 void H(vstring helpLine)
 {
-  if (g_printHelp) {
     print2("%s\n", helpLine);
-  }
 } /* H */
 
 

--- a/src/mmcmds.h
+++ b/src/mmcmds.h
@@ -138,7 +138,6 @@ long getStatementNum(
 );
 
 /*! For HELP processing */
-extern flag g_printHelp;
 void H(vstring helpLine);
 
 /*! For MIDI files */

--- a/src/mmhlpa.c
+++ b/src/mmhlpa.c
@@ -27,7 +27,7 @@ vstring_def(saveHelpCmd);
    for the same reason.)  */
 let(&saveHelpCmd, helpCmd);
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP");
+if (!strcmp(saveHelpCmd, "HELP")) {
 H("This utility assists with some common file manipulations.");
 H("Most commands will perform an identical operation on each line of a file.");
 H("Use HELP ? to see list of help topics.");
@@ -83,15 +83,17 @@ H("to purge them periodically.");
 H("(3) The command B(EEP) will make the terminal beep.  It can be useful to");
 H("type it ahead to let you know when the current command is finished.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP ADD");
+if (!strcmp(saveHelpCmd, "HELP ADD")) {
 H("This command adds a character string prefix and/or suffix to each");
 H("line in a file.  To add only a prefix, set <endstr> to the empty string,");
 H("and set <begstr> to the empty string to add only a suffix.");
 H("Syntax:  ADD <iofile> <begstr> <endstr>");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP TAG");
+if (!strcmp(saveHelpCmd, "HELP TAG")) {
 H("TAG is the same as ADD but has 4 additional arguments that let you");
 H("specify a range of lines.  Syntax:");
 H("  TAG <iofile> <begstr> <endstr> <startmatch> <s#> <endmatch> <e#>");
@@ -111,8 +113,9 @@ H("\"abc\" through the end of its proof:");
 H("  TAG \"set.mm\" \"@@@\" \"\" \"abc $p\" 1 \"$.\" 1");
 H("so that later, SUBSTITUTE can be used to affect only those lines.  You");
 H("can remove the \"@@@\" tags with SUBSTITUTE when done.");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP DELETE");
+if (!strcmp(saveHelpCmd, "HELP DELETE")) {
 H("This command deletes the part of a line between (and including) the first");
 H("occurrence of <startstr> and the first occurrence of <endstr> (when both");
 H("exist) for all lines in a file.  If either string doesn't exist in a line,");
@@ -120,8 +123,9 @@ H("the line will be unchanged.  If <startstr> is blank (''), the deletion");
 H("will start from the beginning of the line.  If <endstr> is blank, the");
 H("deletion will end at the end of the line.");
 H("Syntax:  DELETE <iofile> <startstr> <endstr>");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP CLEAN");
+if (!strcmp(saveHelpCmd, "HELP CLEAN")) {
 H("This command processes spaces and tabs in each line of a file");
 H("according to the following subcommands:");
 H("  D - Delete all spaces and tabs");
@@ -139,9 +143,10 @@ H("  L - Convert to lower case");
 H("  V - Convert VT220 screen print frame graphics to -,|,+ characters");
 H("Subcommands may be joined with commas (but no spaces), e.g., \"B,E,R,Q\"");
 H("Syntax:  CLEAN <iofile> <subcmd,subcmd,...>");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SUBSTITUTE")
-    || !strcmp(helpCmd, "HELP S");
+if (!strcmp(saveHelpCmd, "HELP SUBSTITUTE")
+    || !strcmp(helpCmd, "HELP S")) {
 H("This command performs a simple string substitution in each line of a file.");
 H("If the string to be replaced is \"\\n\", then every other line will");
 H("be joined to the one below it.  If the replacement string is \"\\n\", then");
@@ -152,108 +157,124 @@ H("The <occurrence> is an integer (1 = first occurrence on each line, etc.)");
 H("or A for all occurrences on each line.");
 H("Syntax:  SUBSTITUTE <iofile> <oldstr> <newstr> <occurrence> <matchstr>");
 H("Note: The SUBSTITUTE command may be abbreviated by S.");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SWAP");
+if (!strcmp(saveHelpCmd, "HELP SWAP")) {
 H("This command swaps the parts of each line before and after a");
 H("specified string <middle>.");
 H("Syntax:  SWAP <iofile> <middle>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP INSERT");
+if (!strcmp(saveHelpCmd, "HELP INSERT")) {
 H("This command inserts a string at a specified column in each line");
 H("in a file.  It is intended to aid further processing of column-");
 H("sensitive files.  Note: the index of the first column is 1, not 0.  If a");
 H("line is shorter than <column>, then it is padded with spaces so that");
 H("<string> is still added at <column>.");
 H("Syntax:  INSERT <iofile> <string> <column>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP BREAK");
+if (!strcmp(saveHelpCmd, "HELP BREAK")) {
 H("This command breaks up a file into tokens, one per line, breaking at");
 H("whitespace and any special characters you specify as delimiters.");
 H("Use an explicit (quoted) space as <specchars> to avoid the default");
 H("special characters and break only on whitespace.");
 H("Syntax:  BREAK <iofile> <specchars>");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP BUILD");
+if (!strcmp(saveHelpCmd, "HELP BUILD")) {
 H("This command combines a list of tokens into multiple tokens per line,");
 H("as many as will fit per line, separating them with spaces.");
 H("Syntax:  BUILD <iofile>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP MATCH");
+if (!strcmp(saveHelpCmd, "HELP MATCH")) {
 H("This command extracts from a file those lines containing (Y) or not");
 H("containing (N) a specified string.");
 H("Syntax:  MATCH <iofile> <matchstr> <Y/N>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SORT");
+if (!strcmp(saveHelpCmd, "HELP SORT")) {
 H("This command sorts a file, comparing lines starting at a key string.");
 H("If the key string is blank, the line is compared starting at column 1.");
 H("If a line doesn't contain the key, it is compared starting at column 1.");
 H("Syntax:  SORT <iofile> <key>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP UNDUPLICATE");
+if (!strcmp(saveHelpCmd, "HELP UNDUPLICATE")) {
 H("This command sorts a file then removes any duplicate lines from the output.");
 H("Syntax:  UNDUPLICATE <iofile>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP DUPLICATE");
+if (!strcmp(saveHelpCmd, "HELP DUPLICATE")) {
 H("This command finds all duplicate lines in a file and places them, in");
 H("sorted order, into the output file.");
 H("Syntax:  DUPLICATE <iofile>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP UNIQUE");
+if (!strcmp(saveHelpCmd, "HELP UNIQUE")) {
 H("This command finds all unique lines in a file and places them, in");
 H("sorted order, into the output file.");
 H("Syntax:  UNIQUE <iofile>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP REVERSE");
+if (!strcmp(saveHelpCmd, "HELP REVERSE")) {
 H("This command reverses the order of the lines in a file.");
 H("Syntax:  REVERSE <iofile>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP RIGHT");
+if (!strcmp(saveHelpCmd, "HELP RIGHT")) {
 H("This command right-justifies the lines in a file by putting spaces in");
 H("front of them so that they end in the same column as the longest line");
 H("in the file.");
 H("Syntax:  RIGHT <iofile>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP PARALLEL");
+if (!strcmp(saveHelpCmd, "HELP PARALLEL")) {
 H("This command puts two files side-by-side.");
 H("The two files should have the same number of lines; if not, a warning is");
 H("issued and the longer file paralleled with empty strings at the end.");
 H("Syntax:  PARALLEL <inpfile1> <inpfile2> <outfile> <btwnstr>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP NUMBER");
+if (!strcmp(saveHelpCmd, "HELP NUMBER")) {
 H("This command creates a list of numbers.  Hint:  Use the RIGHT command to");
 H("right-justify the list after creating it.");
 H("Syntax:  NUMBER <outfile> <first> <last> <incr>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP COUNT");
+if (!strcmp(saveHelpCmd, "HELP COUNT")) {
 H("This command counts the occurrences of a string in a file and displays");
 H("some other statistics about the file.  The sum of the lines is obtained");
 H("by extracting digits and is only valid if the file consists of genuine");
 H("numbers.");
 H("Syntax:  COUNT <inpfile> <string>");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP TYPE") || !strcmp(helpCmd, "HELP T");
+if (!strcmp(saveHelpCmd, "HELP TYPE") || !strcmp(helpCmd, "HELP T")) {
 H("This command displays (i.e. types out) the first n lines of a file on the");
 H("terminal screen.  If n is not specified, it will default to 10.  If n is");
 H("the string \"ALL\", then the whole file will be typed.");
 H("Syntax:  TYPE <inpfile> <n>");
 H("Note: The TYPE command may be abbreviated by T.");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP COPY") || !strcmp(helpCmd, "HELP C");
+if (!strcmp(saveHelpCmd, "HELP COPY") || !strcmp(helpCmd, "HELP C")) {
 H("This command copies (concatenates) all input files in a comma-separated");
 H("list (no blanks allowed) to an output file.  The output file may have");
 H("the same name as an input file.  Any previous version of the output");
@@ -263,8 +284,9 @@ H("will result in 1.tmp containing those lines of 2.tmp that didn't");
 H("previously exist in 1.tmp.");
 H("Syntax:  COPY <inpfile,inpfile,...> <outfile>");
 H("Note: The COPY command may be abbreviated by C.");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP UPDATE");
+if (!strcmp(saveHelpCmd, "HELP UPDATE")) {
 H("This command tags edits made to a program source.  The idea is to keep");
 H("all past history of a file in the file itself, in the form of comments.");
 H("UPDATE was written for a proprietary language that allowed nested C-style");
@@ -276,8 +298,9 @@ H("may be easiest just to type UPDATE <return> and answer the questions.");
 H("Try it on an original and edited version of a test file to see if you");
 H("find it useful.");
 H("Syntax:  UPDATE <originfile> <editedinfile> <editedoutfile> <tag> <match>");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP CLI");
+if (!strcmp(saveHelpCmd, "HELP CLI")) {
 H("Each command line is an English-like word followed by arguments separated");
 H("by spaces, as in SUBMIT abc.cmd.  Commands are not case sensitive, and");
 H("only as many letters are needed as are necessary to eliminate ambiguity;");
@@ -316,8 +339,9 @@ H("");
 H("Some other commands you may want to review with HELP are:");
 H("    SUBMIT");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SUBMIT");
+if (!strcmp(saveHelpCmd, "HELP SUBMIT")) {
 H("Syntax:  SUBMIT <filename> [/ SILENT]");
 H("");
 H("This command causes further command lines to be taken from the specified");
@@ -331,9 +355,10 @@ H("        command.");
 H("");
 H("SUBMIT can be called recursively, i.e., SUBMIT commands are allowed");
 H("inside of a command file.");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SYSTEM");
+if (!strcmp(saveHelpCmd, "HELP SYSTEM")) {
 H("A line enclosed in single or double quotes will be executed by your");
 H("computer's operating system, if it has such a feature.  For example, on a");
 H("Unix system,");
@@ -344,6 +369,7 @@ H("");
 H("For your convenience, the trailing quote is optional, for example:");
 H("    Tools> 'ls | more");
 H("");
+}
 
 free_vstring(saveHelpCmd); /* Deallocate memory */
 
@@ -362,7 +388,7 @@ vstring_def(saveHelpCmd);
 let(&saveHelpCmd, helpCmd);
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP CLI");
+if (!strcmp(saveHelpCmd, "HELP CLI")) {
 H("The Metamath program was first developed on a VAX/VMS system, and some");
 H("aspects of its command line behavior reflect this heritage.  Hopefully");
 H(
@@ -426,10 +452,11 @@ H("    HELP SET HEIGHT");
 H("    HELP SUBMIT");
 H("    HELP UNDO (or REDO) - in Proof Assistant only");
 H("");
+}
 
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP LANGUAGE");
+if (!strcmp(saveHelpCmd, "HELP LANGUAGE")) {
 H("The language is best learned by reading the book and studying a few proofs");
 H("with the Metamath program.  This is a brief summary for reference.");
 H("");
@@ -578,9 +605,10 @@ H("");
 H("  $[ <file-name> $] - place contents of file <file-name> here; a second,");
 H("       recursive, or self reference to a file is ignored");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP MARKUP");
+if (!strcmp(saveHelpCmd, "HELP MARKUP")) {
 H("(See HELP VERIFY MARKUP for the markup language used in database");
 H("comments.)");
 H("");
@@ -631,9 +659,10 @@ H("must always be escaped even if / SYMBOLS is omitted, because the");
 H("algorithm will still use \"`...`\" to avoid interpreting special");
 H("characters in math symbols.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP EXPLORE");
+if (!strcmp(saveHelpCmd, "HELP EXPLORE")) {
 H("When you first enter Metamath, you will first want to READ in a Metamath");
 H("source file.  The source file provided for set theory is called set.mm;");
 H("to read it type");
@@ -667,10 +696,11 @@ H("        on various qualifiers you select.");
 H("    SHOW USAGE <label> - Shows what later proofs make use of this");
 H("        statement.");
 H("");
+}
 
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP HTML");
+if (!strcmp(saveHelpCmd, "HELP HTML")) {
 H("(Note: See HELP WRITE SOURCE for the \"<HTML>\" tag in comments.)");
 H("To create an HTML output file for a $a or $p statement, use");
 H("    SHOW STATEMENT <label> / HTML");
@@ -772,12 +802,14 @@ H("a later one, the HTML code assigned to \"exthtmltitle\" and");
 H("\"exthtmlhome\" is used instead of that assigned to \"htmltitle\" and");
 H("\"htmlhome\" respectively.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP LATEX");
+if (!strcmp(saveHelpCmd, "HELP LATEX")) {
 H("See HELP TEX.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP TEX");
+if (!strcmp(saveHelpCmd, "HELP TEX")) {
 H("Metamath will create a \"turn-key\" LaTeX source file which can be");
 H("immediately compiled and printed using a TeX program.  The TeX program");
 H("must have the following minimum requirements:  the LaTeX style option and");
@@ -795,9 +827,10 @@ H("");
 H("The LaTeX symbol definitions should be included in a special comment");
 H("containing a $t token.  See the set.mm file for an example.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP BEEP") || !strcmp(helpCmd, "HELP B");
+if (!strcmp(saveHelpCmd, "HELP BEEP") || !strcmp(helpCmd, "HELP B")) {
 H("Syntax:  BEEP");
 H("");
 H("This command will produce a beep.  By typing it ahead after a long-");
@@ -809,16 +842,18 @@ H("multiple-page display paged with \"Press <return> for more...\" prompts,");
 H("then the B will back up to the previous page rather than perform the BEEP");
 H("command.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP QUIT");
+if (!strcmp(saveHelpCmd, "HELP QUIT")) {
 H("Syntax:  QUIT [/ FORCE]");
 H("");
 H("This command is a synonym for EXIT.  See HELP EXIT.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP EXIT");
+if (!strcmp(saveHelpCmd, "HELP EXIT")) {
 H("Syntax:  EXIT [/ FORCE]");
 H("");
 H("This command exits from Metamath.  If there have been changes to the");
@@ -842,9 +877,10 @@ H("");
 H("**Warning**  Pressing CTRL-C will abort the Metamath program");
 H("unconditionally.  This means any unsaved work will be lost.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP _EXIT_PA");
+if (!strcmp(saveHelpCmd, "HELP _EXIT_PA")) {
 H("Syntax:  _EXIT_PA [/ FORCE]");
 H("");
 H("This command is a synonym for EXIT inside the Proof Assistant but will");
@@ -852,9 +888,10 @@ H("generate an error message (and otherwise have no effect) elsewhere.  It");
 H("can help prevent accidentally exiting Metamath when a script fails to");
 H("enter the Proof Assistant (PROVE command).  See HELP EXIT.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP READ");
+if (!strcmp(saveHelpCmd, "HELP READ")) {
 H("Syntax:  READ <file> [/ VERIFY]");
 H("");
 H("This command will read in a Metamath language source file and any included");
@@ -880,9 +917,10 @@ H("        qualifier will slow down reading in the file.");
 H("");
 H("See also HELP ERASE.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP ERASE");
+if (!strcmp(saveHelpCmd, "HELP ERASE")) {
 H("Syntax:  ERASE");
 H("");
 H("This command will delete the database if one was READ in.  It does not");
@@ -890,9 +928,10 @@ H("affect parameters listed in SHOW SETTINGS that are unrelated to the");
 H("database.  The user will be prompted for confirmation if the database was");
 H("changed but not saved with WRITE SOURCE.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP OPEN LOG");
+if (!strcmp(saveHelpCmd, "HELP OPEN LOG")) {
 H("Syntax:  OPEN LOG <file>");
 H("");
 H("This command will open a log file that will store everything you see on");
@@ -905,17 +944,19 @@ H("");
 H("The log file can be closed with CLOSE LOG.  It will automatically be");
 H("closed upon exiting Metamath.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP CLOSE LOG");
+if (!strcmp(saveHelpCmd, "HELP CLOSE LOG")) {
 H("Syntax:  CLOSE LOG");
 H("");
 H("The CLOSE LOG command closes a log file if one is open.  See also OPEN");
 H("LOG.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP OPEN TEX");
+if (!strcmp(saveHelpCmd, "HELP OPEN TEX")) {
 H("Syntax:  OPEN TEX <file> [/ NO_HEADER] [/ OLD_TEX]");
 H("");
 H("This command opens a file for writing LaTeX source and writes a LaTeX");
@@ -937,9 +978,10 @@ H("        PROOF.  It is obsolete and will be removed eventually.");
 H("");
 H("See also CLOSE TEX.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP CLOSE TEX");
+if (!strcmp(saveHelpCmd, "HELP CLOSE TEX")) {
 H("Syntax:  CLOSE TEX");
 H("");
 H("This command writes a trailer to any LaTeX file that was opened with OPEN");
@@ -947,17 +989,19 @@ H("TEX (unless / NO_HEADER was used with OPEN) and closes the LaTeX file.");
 H("");
 H("See also OPEN TEX.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP TOOLS");
+if (!strcmp(saveHelpCmd, "HELP TOOLS")) {
 H("Syntax:  TOOLS");
 H("");
 H("This command invokes a utility to manipulate ASCII text files.  Type TOOLS");
 H("to enter this utility, which has its own HELP commands.  Once you are");
 H("inside, EXIT will return to Metamath.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP WRITE SOURCE");
+if (!strcmp(saveHelpCmd, "HELP WRITE SOURCE")) {
 H("Syntax:  WRITE SOURCE <filename> [/ FORMAT] [/ REWRAP] [/ SPLIT]");
 H("           [/ KEEP_INCLUDES] [/ NO_VERSIONING]");
 H("");
@@ -1004,8 +1048,9 @@ H("        \"$[...$]\", all commented includes \"$( Begin $[...\" etc.,");
 H("        and all \"$j\" comments will be discarded.  / EXTRACT and / SPLIT");
 H("        may not be used together.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP WRITE THEOREM_LIST");
+if (!strcmp(saveHelpCmd, "HELP WRITE THEOREM_LIST")) {
 H("Syntax:  WRITE THEOREM_LIST [/ THEOREMS_PER_PAGE <number>] [/ SHOW_LEMMAS]");
 H("               [/ HTML] [/ALT_HTML] [/ NO_VERSIONING]");
 H("");
@@ -1054,12 +1099,14 @@ H("");
 H("Note:  To create the files mmdefinitions.html and mmascii.html, use");
 H("SHOW STATEMENT *! / HTML.  See HELP HTML.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP BIBLIOGRAPHY");
+if (!strcmp(saveHelpCmd, "HELP BIBLIOGRAPHY")) {
 H("See HELP WRITE BIBLIOGRAPHY.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP WRITE BIBLIOGRAPHY");
+if (!strcmp(saveHelpCmd, "HELP WRITE BIBLIOGRAPHY")) {
 H("Syntax:  WRITE BIBLIOGRAPHY <filename>");
 H("");
 H("This command reads an HTML bibliographic cross-reference file, normally");
@@ -1114,9 +1161,10 @@ H("will cause a double bracket to be rendered on the web page.");
 H("");
 H("See also");
 H("https://github.com/metamath/set.mm/pull/1761#issuecomment-672433658");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP WRITE RECENT_ADDITIONS");
+if (!strcmp(saveHelpCmd, "HELP WRITE RECENT_ADDITIONS")) {
 H("Syntax:  WRITE RECENT_ADDITIONS <filename>");
 H("");
 H("Optional qualifier:");
@@ -1138,6 +1186,7 @@ H("");
 H("If neither / HTML nor / ALT_HTML is specified, the output will default to");
 H("GIF format unless ALT_HTML was previously set as shown in SHOW SETTINGS.");
 H("");
+}
 
 
 free_vstring(saveHelpCmd); /* Deallocate memory */

--- a/src/mmhlpb.c
+++ b/src/mmhlpb.c
@@ -26,37 +26,39 @@ vstring_def(saveHelpCmd);
    for the same reason.)  */
 let(&saveHelpCmd, helpCmd);
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP");
-H("Welcome to Metamath.  Here are some general guidelines.");
-H("");
-H("To make the most effective use of Metamath, you should become familiar");
-H("with the Metamath book.  In particular, you will need to learn");
-H("the syntax of the Metamath language.");
-H("");
-H("For help using the command line, type HELP CLI.");
-H("For help invoking Metamath, type HELP INVOKE.");
-H("For a summary of the Metamath language, type HELP LANGUAGE.");
-H("For a summary of comment markup, type HELP VERIFY MARKUP.");
-H("For help getting started, type HELP DEMO.");
-H("For help exploring the data base, type HELP EXPLORE.");
-H("For help creating a LaTeX file, type HELP TEX.");
-H("For help creating Web pages, type HELP HTML.");
-H("For help proving new theorems, type HELP PROOF_ASSISTANT.");
-H("For a list of help topics, type HELP ? (to force an error message).");
-H("For current program settings, type SHOW SETTINGS.");
-H("For a simple but general-purpose ASCII file manipulator, type TOOLS.");
-H("To exit Metamath, type EXIT (or its synonym QUIT).");
-H("");
-H("Copyright (C) 2020 Norman Megill  License terms:  GPL 2.0 or later");
-H("");
+if (!strcmp(saveHelpCmd, "HELP")) {
+    H("Welcome to Metamath.  Here are some general guidelines.");
+    H("");
+    H("To make the most effective use of Metamath, you should become familiar");
+    H("with the Metamath book.  In particular, you will need to learn");
+    H("the syntax of the Metamath language.");
+    H("");
+    H("For help using the command line, type HELP CLI.");
+    H("For help invoking Metamath, type HELP INVOKE.");
+    H("For a summary of the Metamath language, type HELP LANGUAGE.");
+    H("For a summary of comment markup, type HELP VERIFY MARKUP.");
+    H("For help getting started, type HELP DEMO.");
+    H("For help exploring the data base, type HELP EXPLORE.");
+    H("For help creating a LaTeX file, type HELP TEX.");
+    H("For help creating Web pages, type HELP HTML.");
+    H("For help proving new theorems, type HELP PROOF_ASSISTANT.");
+    H("For a list of help topics, type HELP ? (to force an error message).");
+    H("For current program settings, type SHOW SETTINGS.");
+    H("For a simple but general-purpose ASCII file manipulator, type TOOLS.");
+    H("To exit Metamath, type EXIT (or its synonym QUIT).");
+    H("");
+    H("Copyright (C) 2020 Norman Megill  License terms:  GPL 2.0 or later");
+    H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP COMMENTS");
-H("Comment markup is described near the end of HELP LANGUAGE.  See also");
-H("HELP HTML for the $t comment and HTML definitions.");
-H("");
+if (!strcmp(saveHelpCmd, "HELP COMMENTS")) {
+    H("Comment markup is described near the end of HELP LANGUAGE.  See also");
+    H("HELP HTML for the $t comment and HTML definitions.");
+    H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP INVOKE");
+if (!strcmp(saveHelpCmd, "HELP INVOKE")) {
 H("To invoke Metamath from a Unix/Linux/MacOSX prompt, assuming that the");
 H("Metamath program is in the current directory, type");
 H("");
@@ -95,31 +97,35 @@ H("  bash$ ./metamath \"read '/tmp/set.mm'\"");
 H("");
 H("are equivalent.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW MEMORY");
+if (!strcmp(saveHelpCmd, "HELP SHOW MEMORY")) {
 H("Syntax:  SHOW MEMORY");
 H("");
 H("This command shows the available memory left.  It is not meaningful");
 H("on modern machines with virtual memory.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW SETTINGS");
+if (!strcmp(saveHelpCmd, "HELP SHOW SETTINGS")) {
 H("Syntax:  SHOW SETTINGS");
 H("");
 H("This command shows the state of various parameters.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW ELAPSED_TIME");
+if (!strcmp(saveHelpCmd, "HELP SHOW ELAPSED_TIME")) {
 H("Syntax:  SHOW ELAPSED_TIME");
 H("");
 H("This command shows the time elapsed in the session and from any");
 H("previous use of SHOW ELAPSED_TIME.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW LABELS");
+if (!strcmp(saveHelpCmd, "HELP SHOW LABELS")) {
 H("Syntax:  SHOW LABELS <label-match> [/ ALL] [/ LINEAR]");
 H("");
 H("This command shows the labels of $a and $p statements that match");
@@ -131,9 +137,10 @@ H("    / ALL - Include matches for $e and $f statement labels.");
 H("    / LINEAR - Display only one label per line.  This can be useful for");
 H("        building scripts in conjunction with the TOOLS utility.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW DISCOURAGED");
+if (!strcmp(saveHelpCmd, "HELP SHOW DISCOURAGED")) {
 H("Syntax:  SHOW DISCOURAGED");
 H("");
 H("This command shows the usage and proof statistics for statements with");
@@ -142,8 +149,9 @@ H("discouraged.)\" markup tags in their description comments.  The output");
 H("is intended to be used by scripts that compare a modified .mm file");
 H("to a previous version.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW SOURCE");
+if (!strcmp(saveHelpCmd, "HELP SHOW SOURCE")) {
 H("Syntax:  SHOW SOURCE <label>");
 H("");
 H("This command shows the ASCII source code associated with a statement.");
@@ -151,9 +159,10 @@ H("Normally you should use SHOW STATEMENT for a more meaningful display,");
 H("but SHOW SOURCE can be used to see statements with multiple comments");
 H("and to see the exact content of the Metamath database.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW STATEMENT");
+if (!strcmp(saveHelpCmd, "HELP SHOW STATEMENT")) {
 H("Syntax:  SHOW STATEMENT <label-match> [/ COMMENT] [/ FULL] [/ TEX]");
 H("             [/ OLD_TEX] [/ HTML] [/ ALT_HTML] [/ BRIEF_HTML]");
 H("             [/ BRIEF_ALT_HTML] [/ NO_VERSIONING] [/ MNEMONICS]");
@@ -194,9 +203,10 @@ H("    / MNEMONICS - Produces the output file mnemosyne.txt for use with");
 H("        Mnemosyne http://www.mnemosyne-proj.org/principles.php.  Should");
 H("        not be used with any other qualifier.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW PROOF");
+if (!strcmp(saveHelpCmd, "HELP SHOW PROOF")) {
 H("Syntax:  SHOW PROOF <label-match> [<qualifiers (see below)>]");
 H("");
 H("This command displays the proof of the specified $p statement various");
@@ -264,9 +274,10 @@ H("        SAVE PROOF except that the proof is displayed on the screen in");
 H("        a format suitable for manual inclusion in a source file.  See");
 H("        HELP SAVE PROOF.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP MIDI");
+if (!strcmp(saveHelpCmd, "HELP MIDI")) {
 H("Syntax:  MIDI <label> [/ PARAMETER \"<parameter string>\"]");
 H("");
 H("This will create a MIDI sound file for the proof of <label>, where <label>");
@@ -307,9 +318,10 @@ H("      song.");
 H("");
 H("Quotes around the parameter string are optional if it has no spaces.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW NEW_PROOF");
+if (!strcmp(saveHelpCmd, "HELP SHOW NEW_PROOF")) {
 H("Syntax:  SHOW NEW_PROOF [<qualifiers (see below)]");
 H("");
 H("This command (available only in Proof Assistant mode) displays the proof");
@@ -331,9 +343,10 @@ H("display.");
 H("");
 H("See also:  SHOW PROOF");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW USAGE");
+if (!strcmp(saveHelpCmd, "HELP SHOW USAGE")) {
 H("Syntax:  SHOW USAGE <label-match> [/ RECURSIVE]");
 H("");
 H("This command lists the statements whose proofs make direct reference to");
@@ -347,6 +360,7 @@ H("    / ALL - Include $e and $f statements.  Without / ALL, $e and $f");
 H("        statements are excluded when <label-match> contains wildcard");
 H("        characters.");
 H("");
+}
 
 free_vstring(saveHelpCmd); /* Deallocate memory */
 
@@ -366,9 +380,7 @@ vstring_def(saveHelpCmd);
 let(&saveHelpCmd, helpCmd);
 
 
-
-
-g_printHelp = !strcmp(saveHelpCmd, "HELP SHOW TRACE_BACK");
+if (!strcmp(saveHelpCmd, "HELP SHOW TRACE_BACK")) {
 H("Syntax:  SHOW TRACE_BACK <label-match> [/ ESSENTIAL] [/ AXIOMS] [/ TREE]");
 H("             [/ DEPTH <number>] [/ COUNT_STEPS] [/MATCH <label-match>]");
 H("             [/TO <label-match>]");
@@ -399,9 +411,10 @@ H("        requiring ax-reg that ac6s depends on.  In case there are");
 H("        multiple paths from ac6s back to ax-reg, all statements involved");
 H("        in all paths are listed.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SEARCH");
+if (!strcmp(saveHelpCmd, "HELP SEARCH")) {
 H("Syntax:  SEARCH <label-match> \"<symbol-match>\" [/ ALL] [/ COMMENTS]");
 H("             [/ JOIN]");
 H("");
@@ -474,9 +487,10 @@ H("");
 H("See the last section of HELP LET for how to handle quotes and special");
 H("characters.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET ECHO");
+if (!strcmp(saveHelpCmd, "HELP SET ECHO")) {
 H("Syntax:  SET ECHO ON or SET ECHO OFF");
 H("");
 H("The SET ECHO ON command will cause command lines to be echoed with any");
@@ -487,9 +501,10 @@ H("files (see HELP SUBMIT) from your log file (see HELP OPEN LOG).  To make");
 H("it easier to extract these lines, \"!\" (which you will discard) is");
 H("prepended to each echoed command line.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET SCROLL");
+if (!strcmp(saveHelpCmd, "HELP SET SCROLL")) {
 H("Syntax:  SET SCROLL PROMPTED or SET SCROLL CONTINUOUS");
 H("");
 H("The Metamath command line interface starts off in the PROMPTED mode,");
@@ -497,9 +512,10 @@ H("which means that you will prompted to continue or quit after each");
 H("screenful of a long listing.  In CONTINUOUS mode, long listings will be");
 H("scrolled without pausing.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET WIDTH");
+if (!strcmp(saveHelpCmd, "HELP SET WIDTH")) {
 H("Syntax:  SET WIDTH <number>");
 H("");
 H("Metamath assumes the width of your screen is 79 characters.  If your");
@@ -515,17 +531,19 @@ H("spurious blank line after an 80-character line (try it!).");
 H("");
 H("Note:  This command was SET SCREEN_WIDTH prior to Version 0.07.9.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET HEIGHT");
+if (!strcmp(saveHelpCmd, "HELP SET HEIGHT")) {
 H("Syntax:  SET HEIGHT <number>");
 H("");
 H("Metamath assumes your screen height is 24 lines of characters.  If your");
 H("screen is taller or shorter, this command lets you to change the number");
 H("of lines at which the display pauses and prompts you to continue.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET DISCOURAGEMENT");
+if (!strcmp(saveHelpCmd, "HELP SET DISCOURAGEMENT")) {
 H("Syntax:  SET DISCOURAGEMENT OFF or SET DISCOURAGEMENT ON");
 H("");
 H("By default this is set to ON, which means that statements whose");
@@ -537,8 +555,9 @@ H("advanced users who are intimately familiar with the database, for use");
 H("when maintaining \"discouraged\" statements.  SHOW SETTINGS will show you");
 H("the current value.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET CONTRIBUTOR");
+if (!strcmp(saveHelpCmd, "HELP SET CONTRIBUTOR")) {
 H("Syntax:  SET CONTRIBUTOR <name>");
 H("");
 H("Specify the contributor name for new \"(Contributed by...\" comment");
@@ -546,8 +565,9 @@ H("markup added by SAVE PROOF or SAVE NEW_PROOF.  Use quotes (' or \")");
 H("around <name> if it contains spaces.  The current contributor is");
 H("displayed by SHOW SETTINGS.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET ROOT_DIRECTORY");
+if (!strcmp(saveHelpCmd, "HELP SET ROOT_DIRECTORY")) {
 H("Syntax:  SET ROOT_DIRECTORY <directory path>");
 H("");
 H("Specify the directory path (relative to the working directory i.e. the");
@@ -559,8 +579,9 @@ H("current directory path is displayed by SHOW SETTINGS.");
 H("");
 H("Use a quoted space (' ' or \" \") for <directory path> if you want to");
 H("reset it to be the working directory.");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET UNIFICATION_TIMEOUT");
+if (!strcmp(saveHelpCmd, "HELP SET UNIFICATION_TIMEOUT")) {
 H("Syntax:  SET UNIFICATION_TIMEOUT <number>");
 H("");
 H("(This command affects the Proof Assistant only.)");
@@ -576,9 +597,10 @@ H("Often, a better solution to resolve a unification timeout is to manually");
 H("assign some or all of the unknowns (see HELP LET) then try to unify");
 H("again.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET EMPTY_SUBSTITUTION");
+if (!strcmp(saveHelpCmd, "HELP SET EMPTY_SUBSTITUTION")) {
 H("Syntax:  SET EMPTY_SUBSTITUTION ON or SET EMPTY_SUBSTITUTION OFF");
 H("");
 H("(This command affects the Proof Assistant only.  It may be issued");
@@ -596,9 +618,10 @@ H("of a system needing empty substitutions; another example would be a");
 H("system that implements a Deduction Rule and in which deductions from");
 H("empty assumption lists would be permissible.)");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET SEARCH_LIMIT");
+if (!strcmp(saveHelpCmd, "HELP SET SEARCH_LIMIT")) {
 H("Syntax:  SET SEARCH_LIMIT <number>");
 H("");
 H("(This command affects the Proof Assistant only.)");
@@ -608,9 +631,10 @@ H("in Proof Assistant mode gives up.  If you want IMPROVE to search harder,");
 H("you may increase it.  The SHOW SETTINGS command tells you its current");
 H("value.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET JEREMY_HENTY_FILTER");
+if (!strcmp(saveHelpCmd, "HELP SET JEREMY_HENTY_FILTER")) {
 H("Syntax:  SET JEREMY_HENTY_FILTER ON or SET JEREMY_HENTY_FILTER OFF");
 H("");
 H("(This command affects the Proof Assistant only.)");
@@ -620,9 +644,10 @@ H("that reduces the number of ambiguous unifications by eliminating");
 H("\"equivalent\" ones in a sense defined by Henty.  Normally this filter");
 H("is ON, and the only reason to turn it off would be for debugging.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP VERIFY PROOF");
+if (!strcmp(saveHelpCmd, "HELP VERIFY PROOF")) {
 H("Syntax:  VERIFY PROOF <label-match> [/ SYNTAX_ONLY]");
 H("");
 H("This command verifies the proofs of the specified statements.");
@@ -641,9 +666,10 @@ H("Note: READ, followed by VERIFY PROOF *, will ensure the database is free");
 H("from errors in Metamath language but will not check the markup language");
 H("in comments.  See HELP VERIFY MARKUP.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP VERIFY MARKUP");
+if (!strcmp(saveHelpCmd, "HELP VERIFY MARKUP")) {
 H("Syntax:  VERIFY MARKUP <label-match> [/ DATE_SKIP] [/ TOP_DATE_CHECK]");
 H("            [/ FILE_CHECK] [/ UNDERSCORE_SKIP] [/ MATHBOX_SKIP] [/VERBOSE]");
 H("");
@@ -689,9 +715,10 @@ H("");
 H("For help with modularization tags such as \"$( Begin $[ set-header.mm $] $)\",");
 H("see the 21-Dec-2017 entry in http://us.metamath.org/mpeuni/mmnotes.txt .");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SUBMIT");
+if (!strcmp(saveHelpCmd, "HELP SUBMIT")) {
 H("Syntax:  SUBMIT <filename> [/ SILENT]");
 H("");
 H("This command causes further command lines to be taken from the specified");
@@ -711,9 +738,10 @@ H("        command.  The output will still be recorded in any log file that");
 H("        has been opened with OPEN LOG (or is opened inside the command");
 H("        file itself).  The screen output of any operating system commands");
 H("        inside the command file (see HELP SYSTEM) is not suppressed.");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SYSTEM");
+if (!strcmp(saveHelpCmd, "HELP SYSTEM")) {
 H("A line enclosed in single or double quotes will be executed by your");
 H("computer's operating system, if it has such a feature.  For example, on a");
 H("GNU/Linux system,");
@@ -724,13 +752,15 @@ H("");
 H("For your convenience, the trailing quote is optional, for example:");
 H("    MM> 'ls | less -EX");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP MM-PA");
+if (!strcmp(saveHelpCmd, "HELP MM-PA")) {
 H("See HELP PROOF_ASSISTANT");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP MORE");
+if (!strcmp(saveHelpCmd, "HELP MORE")) {
 H("Syntax:  MORE <filename>");
 H("");
 H("This command will type (i.e. display) the contents of an ASCII file on");
@@ -738,9 +768,10 @@ H("your screen.  (This command is provided for convenience but is not very");
 H("powerful.  See HELP SYSTEM to invoke your operating system's command to");
 H("do this, such as \"less -EX\" in Linux.)");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP FILE SEARCH");
+if (!strcmp(saveHelpCmd, "HELP FILE SEARCH")) {
 H("Syntax:  FILE SEARCH <filename> \"<search string>\" [/ FROM_LINE");
 H("             <number>] [/ TO_LINE <number>]");
 H("");
@@ -750,9 +781,10 @@ H("on your screen.  The search is case-insensitive.  (This command is");
 H("deprecated.  See HELP SYSTEM to invoke your operating system's");
 H("equivalent command, such as \"grep\" in Linux.)");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP PROVE");
+if (!strcmp(saveHelpCmd, "HELP PROVE")) {
 H("Syntax:  PROVE <label> [/ OVERRIDE]");
 H("");
 H("This command will enter the Proof Assistant, which will allow you to");
@@ -766,9 +798,10 @@ H("        allow the Proof Assistant to be entered.");
 H("");
 H("See also:  HELP PROOF_ASSISTANT and HELP EXIT");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP PROOF_ASSISTANT");
+if (!strcmp(saveHelpCmd, "HELP PROOF_ASSISTANT")) {
 H("Before using the Proof Assistant, you must add a $p to your source file");
 H("(using a text editor) containing the statement you want to prove.  Its");
 H("proof should consist of a single ?, meaning \"unknown step.\"  Example:");
@@ -868,17 +901,19 @@ H("");
 H("Type EXIT to exit the MM-PA> prompt and get back to the MM> prompt.");
 H("Another EXIT will then get you out of Metamath.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP UNDO");
+if (!strcmp(saveHelpCmd, "HELP UNDO")) {
 H("Syntax:  UNDO");
 H("");
 H("This command, available in the Proof Assistant only, allows any command");
 H("(such as ASSIGN, DELETE, IMPROVE) that affects the proof to be reversed.");
 H("See also HELP REDO and HELP SET UNDO.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP REDO");
+if (!strcmp(saveHelpCmd, "HELP REDO")) {
 H("Syntax:  REDO");
 H("");
 H("This command, available in the Proof Assistant only, reverses the");
@@ -887,9 +922,10 @@ H("if no proof-changing commands (such as ASSIGN, DELETE, IMPROVE)");
 H("were issued after the last UNDO.  A sequence of REDOs will reverse as");
 H("many UNDOs as were issued since the last proof-changing command.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SET UNDO");
+if (!strcmp(saveHelpCmd, "HELP SET UNDO")) {
 H("Syntax:  SET UNDO <number>");
 H("");
 H("(This command affects the Proof Assistant only.)");
@@ -901,9 +937,10 @@ H("");
 H("If this command is issued while inside of the Proof Assistant, the");
 H("UNDO stack is reset (i.e. previous possible UNDOs will be lost).");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP ASSIGN");
+if (!strcmp(saveHelpCmd, "HELP ASSIGN")) {
 H("Syntax:  ASSIGN <step> <label> [/ NO_UNIFY] [/ OVERRIDE]");
 H("         ASSIGN FIRST <label> [/ NO_UNIFY] [/ OVERRIDE]");
 H("         ASSIGN LAST <label> [/ NO_UNIFY] [/ OVERRIDE]");
@@ -934,9 +971,10 @@ H("    / OVERRIDE - By default, ASSIGN will refuse to assign a statement");
 H("        if \"(New usage is discouraged.)\" is present in the statement's");
 H("        description comment.  This qualifier will allow the assignment.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP REPLACE");
+if (!strcmp(saveHelpCmd, "HELP REPLACE")) {
 H("Syntax:  REPLACE <step> <label> [/ OVERRIDE]");
 H("Syntax:  REPLACE FIRST <label> [/ OVERRIDE]");
 H("Syntax:  REPLACE LAST <label> [/ OVERRIDE]");
@@ -987,8 +1025,9 @@ H("    / OVERRIDE - By default, REPLACE will refuse to assign a statement");
 H("        if \"(New usage is discouraged.)\" is present in the statement's");
 H("        description comment.  This qualifier will allow the assignment.");
 H("");
+}
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP MATCH");
+if (!strcmp(saveHelpCmd, "HELP MATCH")) {
 H("Syntax:  MATCH STEP <step> [/ MAX_ESSENTIAL_HYP <number>]");
 H("    or:  MATCH ALL [/ ESSENTIAL_ONLY] [/ MAX_ESSENTIAL_HYP <number>]");
 H("");
@@ -1001,9 +1040,10 @@ H("        with more than the specified number of $e hypotheses");
 H("    / ESSENTIAL_ONLY - in the MATCH ALL statement, only the steps that");
 H("        would be listed in SHOW NEW_PROOF display are matched.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP LET");
+if (!strcmp(saveHelpCmd, "HELP LET")) {
 H("Syntax:  LET VARIABLE <variable> = \"<symbol sequence>\"");
 H("         LET STEP <step> = \"<symbol sequence>\"");
 H("         LET STEP FIRST = \"<symbol sequence>\"");
@@ -1071,9 +1111,10 @@ H("implicitly surrounded by white space:");
 H("  MM-PA> LET VARIABLE $17=ph");
 H("  MM-PA> SHOW NEW_PROOF/UNKNOWN");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP UNIFY");
+if (!strcmp(saveHelpCmd, "HELP UNIFY")) {
 H("HELP UNIFY");
 H("Syntax:  UNIFY STEP <step>");
 H("         UNIFY ALL [/ INTERACTIVE]");
@@ -1093,9 +1134,10 @@ H("See also SET UNIFICATION_TIMEOUT.  The default is 100000, but increasing");
 H("it to 1000000 can help difficult cases.  The LET VARIABLE command to");
 H("manually assign unknown variables also helps difficult cases.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP INITIALIZE");
+if (!strcmp(saveHelpCmd, "HELP INITIALIZE")) {
 H("Syntax:  INITIALIZE ALL");
 H("         INITIALIZE USER");
 H("         INITIALIZE STEP <step>");
@@ -1119,9 +1161,10 @@ H("de-unify these, use DELETE FLOATING_HYPOTHESES then INITIALIZE ALL.");
 H("");
 H("See also:  UNIFY and DELETE");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP DELETE");
+if (!strcmp(saveHelpCmd, "HELP DELETE")) {
 H("Syntax:  DELETE STEP <step>");
 H("         DELETE ALL");
 H("         DELETE FLOATING_HYPOTHESES");
@@ -1138,9 +1181,10 @@ H("an INITIALIZE command to recover from an error.  Note that once a proof");
 H("step with a $f hypothesis as the target is completely known, the IMPROVE");
 H("command can usually fill in the proof for that step.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP IMPROVE");
+if (!strcmp(saveHelpCmd, "HELP IMPROVE")) {
 H("Syntax:  IMPROVE <step> [/ DEPTH <number>] [/ NO_DISTINCT] [/ 2] [/ 3]");
 H("                       [/ SUBPROOFS] [/ INCLUDE_MATHBOXES] [/ OVERRIDE]");
 H("         IMPROVE FIRST [/ DEPTH <number>] [/ NO_DISTINCT] [/ 2] [/ 3]");
@@ -1225,9 +1269,10 @@ H("in case the default is changed in the future).");
 H("");
 H("See also:  HELP SET SEARCH_LIMIT");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP MINIMIZE_WITH");
+if (!strcmp(saveHelpCmd, "HELP MINIMIZE_WITH")) {
 H("Syntax:  MINIMIZE_WITH <label-match> [/ VERBOSE] [/ MAY_GROW]");
 H("              [/ EXCEPT <label-match>] [/ INCLUDE_MATHBOXES]");
 H("              [/ ALLOW_NEW_AXIOMS <label-match>]");
@@ -1296,10 +1341,11 @@ H("        \"(New usage is discouraged.)\" in their description comment.");
 H("        With this qualifier it will try to use them anyway.");
 H("    / TIME - prints out the run time used by the MINIMIZE_WITH run.");
 H("");
+}
 
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP EXPAND");
+if (!strcmp(saveHelpCmd, "HELP EXPAND")) {
 H("Syntax:  EXPAND <label-match>");
 H("");
 H("This command, available in the Proof Assistant only, replaces any");
@@ -1313,9 +1359,10 @@ H("Except for early theorems close to the axioms, it is best to use specific");
 H("labels rather than EXPAND * because the proof size grows exponentially as");
 H("each layer is eliminated.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SAVE PROOF");
+if (!strcmp(saveHelpCmd, "HELP SAVE PROOF")) {
 H("Syntax:  SAVE PROOF <label-match> [/ <qualifier>] [/ <qualifier>]...");
 H("");
 H("The SAVE PROOF command will reformat a proof in one of two formats and");
@@ -1353,9 +1400,10 @@ H("    SAVE PROOF * / EXPLICIT / PACKED / FAST");
 H("will allow the order of $e and $f hypotheses to be changed without");
 H("affecting any proofs.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP SAVE NEW_PROOF");
+if (!strcmp(saveHelpCmd, "HELP SAVE NEW_PROOF")) {
 H("Syntax:  SAVE NEW_PROOF <label-match> [/ <qualifier>] [/ <qualifier>]...");
 H("");
 H("The SAVE NEW_PROOF command is available in the Proof Assistant only. It");
@@ -1381,9 +1429,10 @@ H("        allow the proof to be saved.");
 H("");
 H("Note that if no qualifier is specified, / NORMAL is assumed.");
 H("");
+}
 
 
-g_printHelp = !strcmp(saveHelpCmd, "HELP DEMO");
+if (!strcmp(saveHelpCmd, "HELP DEMO")) {
 H("For a quick demo that enables you to see Metamath do something, type");
 H("the following:");
 H("    READ set.mm");
@@ -1396,6 +1445,7 @@ H("will show all the distributive laws in the database.");
 H("    SEARCH * \"C_ $* u.\"");
 H("will show all statements with subset then union in them.");
 H("");
+}
 
 if (strcmp(helpCmd, saveHelpCmd)) bug(1401); /* helpCmd got corrupted */
 free_vstring(saveHelpCmd); /* Deallocate memory */


### PR DESCRIPTION
The help functions were previously setting a flag g_printHelp
for each block of help commands to print based on the string input from
the user to the help command. The H() function was then internally
checking that g_printHelp flag to determine whether to print
its argument, or do nothing.

It's clearer to have the help-printing functions check the input string,
and then just print the appropriate block then and there. This allows
for the removal of the g_printHelp global flag altogether, and makes the
underlying logic easier to understand.