### PR TITLE
Plug 2 vstring leaks

### DIFF
--- a/src/mmcmdl.c
+++ b/src/mmcmdl.c
@@ -1771,11 +1771,11 @@ static flag getFullArg(long arg, const char *cmdList1) {
       if (!tmpFp) {
         let(&tmpStr, cat("?Sorry, couldn't open the file \"", tmpStr, "\".", NULL));
         printCommandError(errorLine, arg, tmpStr);
-        free_vstring(tmpStr);
         ret = 0;
       } else {
         fclose(tmpFp);
       }
+      free_vstring(tmpStr);
     }
     goto getFullArg_ret;
   }

--- a/src/mmpars.c
+++ b/src/mmpars.c
@@ -6054,6 +6054,7 @@ vstring readSourceAndIncludes(const char *inputFn /*input*/, long *size /*output
          getNextInclusion() call. */
   }
   print2("Reading source file \"%s\"... %ld bytes\n", fullInputFn, *size);
+  free_vstring(fullInputFn);
 
   /* Create a fictitious initial include for the main file (at least 2
      g_IncludeCall structure array entries have been already been allocated


### PR DESCRIPTION
Valgrind found both of these.  In the mmcmdl.c case, tmpStr can point to the allocated memory in the else branch of the if, as well as the then branch, so move free_vstring after the if.  In the mmpars.c case, there was no free_vstring invocation at all.