### PR TITLE
Eliminate self-strcpy in writeBibliography

### DIFF
--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -5373,7 +5373,7 @@ flag writeBibliography(vstring bibFile,
             let(&str2, left(str2, k - 1));
             break;
           }
-          let(&str2, str2);
+          freeTempAlloc();
         }
 
         free_vstring(newstr);


### PR DESCRIPTION
With metamath built with `-fsanitize=address`, running `verify markup */file_skip/top_date_skip` triggers this error:
```
Checking bibliographic references...
=================================================================
==29102==ERROR: AddressSanitizer: strcpy-param-overlap: memory ranges [0x6180002cf480,0x6180002cf48b) and [0x6180002cf480, 0x6180002cf48b) overlap
    #0 0x7fe09ac25fff in __interceptor_strcpy.part.0 (/lib64/libasan.so.8+0x61fff)
    #1 0x4dacea in let /home/jamesjer/src/forked/github/metamath-exe/src/mmvstr.c:207
    #2 0x505bcb in writeBibliography /home/jamesjer/src/forked/github/metamath-exe/src/mmwtex.c:5376
    #3 0x44140d in verifyMarkup /home/jamesjer/src/forked/github/metamath-exe/src/mmcmds.c:5327
    #4 0x41f817 in command /home/jamesjer/src/forked/github/metamath-exe/src/metamath.c:6424
    #5 0x4025f8 in main /home/jamesjer/src/forked/github/metamath-exe/src/metamath.c:768
    #6 0x7fe09a9ec54f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #7 0x7fe09a9ec608 in __libc_start_main_impl ../csu/libc-start.c:389
    #8 0x402934 in _start (/home/jamesjer/src/forked/github/metamath-exe/metamath+0x402934)

0x6180002cf480 is located 0 bytes inside of 844-byte region [0x6180002cf480,0x6180002cf7cc)
allocated by thread T0 here:
    #0 0x7fe09ac7e68f in __interceptor_malloc (/lib64/libasan.so.8+0xba68f)
    #1 0x4daccb in let /home/jamesjer/src/forked/github/metamath-exe/src/mmvstr.c:197

0x6180002cf480 is located 0 bytes inside of 844-byte region [0x6180002cf480,0x6180002cf7cc)
allocated by thread T0 here:
    #0 0x7fe09ac7e68f in __interceptor_malloc (/lib64/libasan.so.8+0xba68f)
    #1 0x4daccb in let /home/jamesjer/src/forked/github/metamath-exe/src/mmvstr.c:197

SUMMARY: AddressSanitizer: strcpy-param-overlap (/lib64/libasan.so.8+0x61fff) in __interceptor_strcpy.part.0
==29102==ABORTING
```

The `let(&str2, str);` call was apparently intended to call `freeTempAlloc` by side effect.  However, it also calls `strcpy` with `str2` passed as both parameters.  This is dangerous.  The `strcpy` function is defined with `restrict` on its first parameter, meaning the implementation can assume the second parameter is not equal to the first.

Eliminate the useless and dangerous `strcpy` call and just call `freeTempAlloc` directly.