### PR TITLE
Improve minimize performance

### DIFF
--- a/src/metamath.c
+++ b/src/metamath.c
@@ -5150,6 +5150,92 @@ void command(int argc, char *argv[]) {
       print2("Bytes refer to compressed proof size, "
         "steps to uncompressed length.\n");
 
+      /* Clear tmp for all math tokens */
+      for (k = 0; k < g_mathTokens; k++)
+        g_MathToken[k].tmp = 0;
+
+      long step, mlen;
+      nmbrString *mString;
+
+      /* Set tmp to 1 for math tokens present in the proof */
+      m = nmbrLen(g_ProofInProgress.proof);
+      for (step = 0; step < m; step++) {
+        mString = (g_ProofInProgress.target)[step];
+        mlen = nmbrLen(mString);
+
+        for (i = 0; i < mlen; i++) {
+          g_MathToken[mString[i]].tmp = 1;
+        }
+      }
+
+      /* usefulStatements is a boolean array, where usefulStatements[k] == 1
+         iff statement k might be useful in minimization */
+      char *usefulStatements;
+      usefulStatements = poolMalloc(g_proveStatement*sizeof(char));
+      long usefulCount = 0;
+
+      /* Fill the usefulStatements array */
+      for (k = 1; k < g_proveStatement; k++) {
+        usefulStatements[k] = 1;
+
+        if (!mathboxFlag && k >= g_mathboxStmt && k < thisMathboxStartStmt) {
+          usefulStatements[k] = 0;
+          continue;
+        }
+
+        if (g_Statement[k].type != (char)p_ && g_Statement[k].type != (char)a_) {
+          usefulStatements[k] = 0;
+          continue;
+        }
+        if (!matchesList(g_Statement[k].labelName, g_fullArg[1], '*', '?')) {
+          usefulStatements[k] = 0;
+          continue;
+        }
+
+        if (exceptPos != 0) {
+          /* Skip any match to the EXCEPT argument */
+          if (matchesList(g_Statement[k].labelName, g_fullArg[exceptPos + 1],
+                '*', '?')) {
+            usefulStatements[k] = 0;
+            continue;
+          }
+        }
+
+        if (forbidMatchList[0]) { /* User provided a /FORBID list */
+          /* First, we check to make sure we're not trying a statement
+             in the forbidMatchList directly (traceProof() won't find
+             this) */
+          if (matchesList(g_Statement[k].labelName, forbidMatchList, '*', '?')) {
+            usefulStatements[k] = 0;
+            continue;
+          }
+        }
+
+        /* Check to see if statement comment specified a usage
+           restriction */
+        if (!overrideFlag) {
+          if (getMarkupFlag(k, USAGE_DISCOURAGED)) {
+            usefulStatements[k] = 0;
+            continue;
+          }
+        }
+
+        /* Check if all math constants used in statement k are present
+           in the minimized proof. Hypotheses are not checked. */
+        mString = g_Statement[k].mathString;
+        mlen = nmbrLen(mString);
+
+        for (i = 0; i < mlen; i++) {
+          if (g_MathToken[mString[i]].tokenType == (char)con_) {
+            if (!g_MathToken[mString[i]].tmp)
+              usefulStatements[k] = 0;
+          }
+        }
+        usefulCount += usefulStatements[k];
+      }
+      if (verboseMode)
+        print2("Found %ld potentially useful theorems.\n", usefulCount);
+
       /* Scan forward, then reverse, then pick best result */
       for (forwRevPass = 1; forwRevPass <= 2; forwRevPass++) {
 
@@ -5182,37 +5268,8 @@ void command(int argc, char *argv[]) {
         for (k = forwFlag ? 1 : (g_proveStatement - 1);
              k * (forwFlag ? 1 : -1) < (forwFlag ? g_proveStatement : 0);
              k = k + (forwFlag ? 1 : -1)) {
-          if (!mathboxFlag && k >= g_mathboxStmt && k < thisMathboxStartStmt) {
+          if(!usefulStatements[k])
             continue;
-          }
-
-          if (g_Statement[k].type != (char)p_ && g_Statement[k].type != (char)a_)
-            continue;
-          if (!matchesList(g_Statement[k].labelName, g_fullArg[1], '*', '?'))
-            continue;
-
-          if (exceptPos != 0) {
-            /* Skip any match to the EXCEPT argument */
-            if (matchesList(g_Statement[k].labelName, g_fullArg[exceptPos + 1],
-                '*', '?'))
-              continue;
-          }
-
-          if (forbidMatchList[0]) { /* User provided a /FORBID list */
-            /* First, we check to make sure we're not trying a statement
-               in the forbidMatchList directly (traceProof() won't find
-               this) */
-            if (matchesList(g_Statement[k].labelName, forbidMatchList, '*', '?'))
-              continue;
-          }
-
-          /* Check to see if statement comment specified a usage
-             restriction */
-          if (!overrideFlag) {
-            if (getMarkupFlag(k, USAGE_DISCOURAGED)) {
-              continue;
-            }
-          }
 
           /* Print individual labels */
           if (prntStatus == 0) prntStatus = 1; /* Matched at least one */
@@ -5564,6 +5621,8 @@ void command(int argc, char *argv[]) {
         print2("MINIMIZE_WITH run time = %7.2f sec for \"%s\"\n", timeIncr,
             g_Statement[g_proveStatement].labelName);
       }
+
+      poolFree(usefulStatements); /* Deallocate memory */
 
       free_vstring(str1); /* Deallocate memory */
       free_nmbrString(nmbrSaveProof); /* Deallocate memory */


### PR DESCRIPTION
This is an implementation of the idea presented in #10 . One precomputes the set of math constants used in the proof of the minimized statement (it is stored in .tmp field of g_MathToken in the code), and for each statement we check if all its constants lie in this set. Statements which pass this validation step are marked with 1 in the boolean array usefulStatements. Then the usual back-and-forth minimize_with loop is run, but now it checks only "useful statements".

If minimize_with is supplied with the /VERBOSE option, it will output the number of potentially useful theorems at the beginning.

This optimization reduces the minimization time twofold. For example, on my computer `smfsupmpt` requires 94s to minimize with the vanilla version, and 42s with this optimization; `ssmapsn`` requires 32s without and 13s with the optimization.

One downside of my code is the allocation of the usefulStatements array, I would prefer it to be an expandable vector (not a boolean array), but as far as I understand metamath codebase doesn't have a vector implementation.