### PR TITLE
fatal error handling #2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,7 @@ help_text=\
 'Builds all artefacts in the metamath-exe/build subfolder (if not directed
 otherwise).  Change to the metamath-exe top folder first before running
 this script, or issue the -m option.
-
 Possible options are:
-
 -a Used by autotools. Put hyphens in the version string when used with -v
 -b build binary only, no reconfigure. Faster, but should not be used on first run.
 -c Clean the build directory.
@@ -22,6 +20,7 @@ Possible options are:
     Relative paths are relative to the current directory.
 -o followed by a directory: optionally clean directory and build all artefacts there.
     Relative paths are relative to the destination'"'"'s top metamath-exe directory.
+-t run regression tests in the executable
 -v extract the version from metamath sources, print it and exit'
 
 #============   evaluate command line parameters   ==========
@@ -34,8 +33,9 @@ version_only=0
 version_for_autoconf=0
 unset dest_dir
 top_dir="$(pwd)"
+do_tests=0
 
-while getopts abcdhm:o:v flag
+while getopts abcdhm:o:tv flag
 do
   case "${flag}" in
     a) version_for_autoconf=1;;
@@ -45,6 +45,7 @@ do
     h) print_help=1;;
     m) cd "${OPTARG}" && top_dir=$(pwd);;
     o) dest_dir=${OPTARG};;
+    t) test_flag="CFLAGS=-DREGRESSION_TEST";;
     v) version_only=1;;
   esac
 done
@@ -116,7 +117,7 @@ then
   autoreconf -i
 
   cd "$build_dir"
-  "$top_dir/configure" -q
+  "$top_dir/configure" -q $test_flag
 fi
 
 #===========   do the build   =====================

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,9 @@ help_text=\
 'Builds all artefacts in the metamath-exe/build subfolder (if not directed
 otherwise).  Change to the metamath-exe top folder first before running
 this script, or issue the -m option.
+
 Possible options are:
+
 -a Used by autotools. Put hyphens in the version string when used with -v
 -b build binary only, no reconfigure. Faster, but should not be used on first run.
 -c Clean the build directory.

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -10,4 +10,28 @@
  * conditions (corrupt state, out of memory).
  */
 
+#include <stdbool.h>
+#include <stdio.h>
+
 #include "mmfatl.h"
+
+//=================   Regression tests   =====================
+
+#ifdef TEST_MMFATL
+
+/*  automatic testing to prevent regression   */
+
+bool testSuccessMessage()
+{
+    printf("Regression tests in " __FILE__ " indicate no error\n\n");
+    return true;
+}
+
+void mmfatl_test()
+{
+    if (true
+        && testSuccessMessage()
+    ) { }
+}
+
+#endif

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -45,6 +45,60 @@
  * For this kind of expansion you still need a buffer where the final message
  * is constructed.  In our context, this buffer is pre-allocated, and fixed in
  * size, truncation of overflowing text enforced.
+ *
+ * Regression tests
+ * ================
+ *
+ * If the macro **REGRESSION_TEST** is defined (option -t of build.sh) or
+ * **TEST_MMFATL** is defined, then regression tests are implemented.  Invoke
+ * in addition option -c on build.sh, should you switch between with/out
+ * testing, but no intermediate source file change.
+ *
+ * In order to run implemented regression tests properly we suggest to add a
+ * \code{.c}
+ * mmfatl_test();
+ * \endcode
+ * line to main() close to its begin and **before** any function declared in
+ * this header file is called.
+ *
+ * If tests are disabled this line evaluates to nothing.  In addition, the
+ * compiler skips any test code, so the artifact size will not grow.  All in
+ * all, a disabled test suite does not come with a linking or runtime penalty.
+ *
+ * If enabled, running tests document their progress to stdout.  Testing stops
+ * on the first regression found with a diagnostic message further detailing on
+ * the context of the failure.  The tests, if called as described above, do not
+ * interfere with Metamath program behaviour, even not when detecting a
+ * regression, in any way other than generating extra output on program start.
+ *
+ * We recommend running the tests each time you modify mmfatl.h or mmfatl.c
+ * to ensure it still executes as desired.
  */
+
+// Setting TEST_MMFATL to en/disable regression tests in this module
+//------------------------------------------------------------------
+
+/* If REGRESSION_TEST is defined compilation of regression tests is requested
+ * from an outside source.  This can still be overridden locally by setting
+ * TEST_MMFATL explicitely below.
+ */
+#ifdef REGRESSION_TEST
+#   define TEST_MMFATL
+#endif
+
+/* uncomment one of the following to enforce disabling/enabling of regression
+ * tests in this file unconditionally
+ */
+// #undef TEST_MMFATL
+// #define TEST_MMFATL
+
+#ifdef TEST_MMFATL
+    /* regression tests are implemented and called through this function */
+    extern void mmfatl_test(void);
+#else
+    /* an empty macro deletes any call to the regression test suite at
+     * compile time */
+#   define mmfatl_test(x)
+#endif
 
 #endif /* include guard */


### PR DESCRIPTION
Here we add a framework for regression tests.

Two macros control whether regression tests are compiled in:
1. **REGRESSION_TEST** is set from the outside.  There are several ways to set this macro, but the preferred one is calling build.sh with the -t option.  This is not always sufficient, because sources need to change to trigger a compile.  It is safest to use `./build.sh -ct` to enable tests, and `./build.sh -c` to disable them again.
2. In the header mmfatl.h the macro **TEST_MMFATL** can be unconditionally un/defined to override the settings in 1.

After a successful compile invoking the executable ./metamath will run the test suite right on program start.  So far no tests are included, so the run always displays a successful completion.  The inclusion/absence of this message is a visual indication of an execution of regression tests and can be used to verify the expected behavior.