### PR TITLE
fatal error handling metamath:3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ autom4te.cache/
 stamp-h1
 missing
 metamath
+metamath_test
 Makefile
 Makefile.in
 compile

--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,7 @@ print_help=0
 version_only=0
 version_for_autoconf=0
 unset dest_dir
+unset doc_dir
 top_dir="$(pwd)"
 
 while getopts abcdhm:o:tv flag
@@ -62,6 +63,7 @@ fi
 
 src_dir="$top_dir/src"
 build_dir=${dest_dir:-"$top_dir/build"}
+doc_dir=${dest_dir:-"$top_dir/build"}
 
 # verify we can navigate to the sources
 if [ ! -f "$src_dir/metamath.c" ]
@@ -139,6 +141,8 @@ fi
 
 if [ $do_doc -eq 1 ]
 then
+  rm -rf "$doc_dir/html"
+
   if ! command doxygen -v &> /dev/null; then
     echo >&2 'doxygen not found. Cannot build documentation.'
     exit 1
@@ -160,12 +164,12 @@ then
 
   # ... except for the source/destination directory.  Force this to folders
   # based on this build.
-  echo "OUTPUT_DIRECTORY = \"$build_dir\"" >> Doxyfile.local
+  echo "OUTPUT_DIRECTORY = \"$doc_dir\"" >> Doxyfile.local
   echo "INPUT = \"$src_dir\"" >> Doxyfile.local
 
   # make sure the logo is in the build directory
   cp --force --symbolic-link "$top_dir/doc/Metamath.png" .
 
   doxygen Doxyfile.local
-  echo "Documentation has been generated at $build_dir/html/index.html"
+  echo "Documentation has been generated at $doc_dir/html/index.html"
 fi

--- a/build.sh
+++ b/build.sh
@@ -129,7 +129,7 @@ fi
 if [ $do_make_test -eq 1 ]
 then
   # create an executable running regression tests
-  make "CFLAGS=-DBUILD_REQUESTS_REGRESSION_TEST"
+  make "CFLAGS=-DTEST_ENABLE"
   mv src/metamath "$top_dir"/metamath_test
 else
   # normal executable

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,6 +17,7 @@ noinst_HEADERS = \
 	mminou.h \
 	mmpars.h \
 	mmpfas.h \
+	mmtest.h \
 	mmunif.h \
 	mmveri.h \
 	mmvstr.h \
@@ -35,6 +36,7 @@ metamath_SOURCES = \
 	mminou.c \
 	mmpars.c \
 	mmpfas.c \
+	mmtest.c \
 	mmunif.c \
 	mmveri.c \
 	mmvstr.c \

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -703,8 +703,6 @@
 
 /*----------------------------------------------------------------------*/
 
-#undef RUN_REGRESSION_TEST
-
 #include <string.h>
 #include <stdlib.h>
 #include "mmvstr.h"
@@ -746,7 +744,6 @@ int main(int argc, char *argv[]) {
 #ifdef TEST_ENABLE // enable this in mmtest.h or via './build.sh -t'
 
   RUN_TESTS();
-  exit(EXIT_SUCCESS);
 #endif
 
   /****** If g_listMode is set to 1 here, the startup will be Text Tools

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -703,6 +703,7 @@
 
 /*----------------------------------------------------------------------*/
 
+#undef RUN_REGRESSION_TEST
 
 #include <string.h>
 #include <stdlib.h>
@@ -742,7 +743,6 @@ int main(int argc, char *argv[]) {
 /* argc is the number of arguments; argv points to an array containing them */
 
 # ifdef RUN_REGRESSION_TEST
-
 // activated if at least one unit requests regression tests
 
   bool regressionTestResult = true;

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -742,8 +742,8 @@ int main(int argc, char *argv[]) {
 /* argc is the number of arguments; argv points to an array containing them */
 
 #ifdef TEST_ENABLE // enable this in mmtest.h or via './build.sh -t'
-
   RUN_TESTS();
+  // you never get here
 #endif
 
   /****** If g_listMode is set to 1 here, the startup will be Text Tools

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -743,13 +743,12 @@ int main(int argc, char *argv[]) {
 /* argc is the number of arguments; argv points to an array containing them */
 
 # ifdef RUN_REGRESSION_TEST
-// activated if at least one unit requests regression tests
+// activated if at least one unit requests regression tests.
+// a failing test MUST terminate the program with exit(EXIT_FAILURE).
 
-  bool regressionTestResult = true;
+  test_mmfatl();
 
-  test_mmfatl(&regressionTestResult);
-
-  exit(regressionTestResult? EXIT_SUCCESS : EXIT_FAILURE);
+  exit(EXIT_SUCCESS);
 
 # endif
 

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -721,6 +721,7 @@
 #include "mmword.h"
 #include "mmwtex.h"
 #include "mmfatl.h"
+#include "mmtest.h"
 
 void command(int argc, char *argv[]);
 
@@ -742,15 +743,11 @@ int main(int argc, char *argv[]) {
 
 /* argc is the number of arguments; argv points to an array containing them */
 
-# ifdef RUN_REGRESSION_TEST
-// activated if at least one unit requests regression tests.
-// a failing test MUST terminate the program with exit(EXIT_FAILURE).
+#ifdef TEST_ENABLE // enable this in mmtest.h or via './build.sh -t'
 
-  test_mmfatl();
-
+  RUN_TESTS();
   exit(EXIT_SUCCESS);
-
-# endif
+#endif
 
   /****** If g_listMode is set to 1 here, the startup will be Text Tools
           utilities, and Metamath will be disabled ***************************/

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -72,20 +72,20 @@ static void initBuffer()
 
 /*
  * Use this extension of CHECK_TRUE if file and line number is not
- * sufficient to locate the failing test.  context is a string constant. 
+ * sufficient to locate the failing test.  'context' is a string constant. 
  */
-#define CHECK_TRUE_W_CONTEXT(bool_expr, context)         \
-    if(!(bool_expr)) {                                   \
-        printf(context);                                 \
-        printf("assertion %s failed", #bool_expr);       \
+#define CHECK_TRUE_W_CONTEXT(bool_expr, context)   \
+    if(!(bool_expr)) {                             \
+        printf("%s:\n", context);                  \
+        printf("assertion %s failed", #bool_expr); \
         printf(" at %s:%u\n", __FILE__, __LINE__); \
-        exit(EXIT_FAILURE);                              \
+        exit(EXIT_FAILURE);                        \
     }
 
 /*
  * If bool_expr evaluates to false, print the message and return to caller
  */
-#define CHECK_TRUE(bool_expr) CHECK_TRUE_W_CONTEXT(bool_expr, __func__" ")
+#define CHECK_TRUE(bool_expr) CHECK_TRUE_W_CONTEXT(bool_expr, __func__)
 
 #define REGRESSION_TEST_SUCCESS            \
     printf("Regression tests in " __FILE__ \

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -18,25 +18,11 @@
 
 /*!
  * character constant
- */ 
+ */
 #define NUL '\x00'
 
 //----------
 
-/*
- * During development you may not want to expose preliminary results to the
- * normal compile, as this would trigger 'unused' warnings, for example.  In
- * the regression test environment your code may be referenced by testing code,
- * though.
- *
- * This section should be empty, or even removed, once your development is
- * finished.
- */
-#if TEST_ENABLE
-#   define UNDER_DEVELOPMENT
-#endif
-
-#ifdef UNDER_DEVELOPMENT
 /* the size a fatal error message including the terminating NUL character can
  * assume without truncation.
  */
@@ -54,84 +40,43 @@ static char buffer[BUFFERSIZE + sizeof(ELLIPSIS)];
  * assume the worst case, a corrupted pointer overwrote the buffer.  So we
  * initialize it again immediately before use.
  */
-static void initBuffer()
-{
-    char ellipsis[] = ELLIPSIS;
+static void initBuffer(void) {
+  char ellipsis[] = ELLIPSIS;
 
-    memset(buffer, NUL, BUFFERSIZE);
-    memcpy(buffer + BUFFERSIZE, ellipsis, sizeof(ellipsis));
+  memset(buffer, NUL, BUFFERSIZE);
+  memcpy(buffer + BUFFERSIZE, ellipsis, sizeof(ellipsis));
 }
-
-#endif // UNDER_DEVELOPMENT
 
 //=================   Regression tests   =====================
 
-#if TEST_ENABLE
+#ifdef TEST_ENABLE
 
-/* -----   copy & paste code, the same in all modules -----  */
+bool test_initBuffer(void) {
+  // emulate memory corruption
+  memset(buffer, 'x', sizeof(buffer));
 
-/*
- * If bool_expr evaluates to false, print an error message and die.
- *
- * Use the string constant 'context' to easily identify the error location, in
- * particular if file and line number is not sufficient to locate the failing
- * test. 
- */
-#define CHECK_TRUE_W_CONTEXT(bool_expr, context)   \
-    if(!(bool_expr)) {                             \
-        printf("%s:\n", context);                  \
-        printf("assertion %s failed", #bool_expr); \
-        printf(" at %s:%u\n", __FILE__, __LINE__); \
-        exit(EXIT_FAILURE);                        \
-    }
+  initBuffer();
 
-/*
- * If bool_expr evaluates to false, print an error message and die.
- *
- * File, line and the function this macro is embedded in is sufficient to
- * identify the error position.
- */
-#define CHECK_TRUE(bool_expr) CHECK_TRUE_W_CONTEXT(bool_expr, __func__)
+  unsigned i = 0;
 
-#define REGRESSION_TEST_SUCCESS            \
-    printf("Regression tests in " __FILE__ \
-        " completed with success\n");
+  // check the buffer is filled with NUL...
+  for (;i < BUFFERSIZE; ++i)
+    ASSERT(buffer[i] == NUL);
 
-#define SINGLE_TEST_SUCCESS(name) \
-    if (! TEST_SILENT )           \
-      printf(#name " OK\n");
+  // ...and has the ELLIPSIS string at the end...
+  char ellipsis[] = ELLIPSIS;
+  unsigned j = 0;
+  for (;ellipsis[j] != NUL; ++i, ++j)
+    ASSERT(buffer[i] == ellipsis[j]);
 
-/* -----   end of copy & paste code   ----- */
-
-void test_initBuffer()
-{
-    // emulate memory corruption
-    memset(buffer, 'x', sizeof(buffer));
-
-    initBuffer();
-
-    unsigned i = 0;
-
-    // check the buffer is filled with NUL...
-    for (;i < BUFFERSIZE; ++i)
-        CHECK_TRUE(buffer[i] == NUL)
-
-    // ...and has the ELLIPSIS string at the end...
-    char ellipsis[] = ELLIPSIS;
-    unsigned j = 0;
-    for (;ellipsis[j] != NUL; ++i, ++j)
-        CHECK_TRUE(buffer[i] == ellipsis[j])
-
-    // ... and a terminating NUL character
-    CHECK_TRUE(buffer[i] == NUL)
-
-    SINGLE_TEST_SUCCESS(initBuffer)
+  // ... and a terminating NUL character
+  ASSERT(buffer[i] == NUL);
+  ASSERT(0 == 1);
+  return true;
 }
 
-void test_mmfatl()
-{
-    test_initBuffer();
-    REGRESSION_TEST_SUCCESS
+void test_mmfatl(void) {
+  RUN_TEST(test_initBuffer);
 }
 
 #endif // TEST_ENABLE

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -23,6 +23,21 @@
 
 //----------
 
+/*
+ * During development you may not want to expose preliminary results to the
+ * normal compile, as this would trigger 'unused' warnings, for example.  In
+ * the regression test environment your code may be referenced by testing code,
+ * though.
+ *
+ * This section should be empty, or even removed, once your development is
+ * finished.
+ */
+#if TEST_ENABLE
+#   define UNDER_DEVELOPMENT
+#endif
+
+#ifdef UNDER_DEVELOPMENT
+
 /* the size a fatal error message including the terminating NUL character can
  * assume without truncation.
  */
@@ -46,6 +61,8 @@ static void initBuffer(void) {
   memset(buffer, NUL, BUFFERSIZE);
   memcpy(buffer + BUFFERSIZE, ellipsis, sizeof(ellipsis));
 }
+
+#endif // UNDER_DEVELOPMENT
 
 //=================   Regression tests   =====================
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -119,6 +119,8 @@ void test_initBuffer()
     // ... and a terminating NUL character
     CHECK_TRUE(buffer[i] == NUL)
 
+    CHECK_TRUE(1 == 2)
+
     SINGLE_TEST_SUCCESS(initBuffer)
 }
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -73,7 +73,7 @@ static void initBuffer()
 #define CHECK_TRUE(bool_expr)                      \
     if(!(bool_expr)) {                             \
         printf("assertion %s failed", #bool_expr); \
-        printf(" at %u:%s\n", __LINE__, __FILE__); \
+        printf(" at %u:%s\n", __FILE__, __LINE__); \
         exit(EXIT_FAILURE);                              \
     }
     

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -71,7 +71,6 @@ bool test_initBuffer(void) {
 
   // ... and a terminating NUL character
   ASSERT(buffer[i] == NUL);
-  ASSERT(0 == 1);
   return true;
 }
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -85,7 +85,7 @@ static void initBuffer()
 /*
  * If bool_expr evaluates to false, print the message and return to caller
  */
-#define CHECK_TRUE(bool_expr) CHECK_TRUE_W_CONTEXT(bool_expr, __func__)
+#define CHECK_TRUE(bool_expr) CHECK_TRUE_W_CONTEXT(bool_expr, "")
 
 #define REGRESSION_TEST_SUCCESS            \
     printf("Regression tests in " __FILE__ \

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -117,6 +117,8 @@ bool testSuccessMessage(bool silent)
 {
     if (!silent)
         printf("Regression tests in " __FILE__ " indicate no error\n\n");
+    else
+        printf("Regression tests in " __FILE__ " OK\n");
     return true;
 }
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -65,49 +65,60 @@ static void initBuffer()
 
 #if TEST_ENABLE
 
-/*  automatic testing to prevent regression   */
+/* -----   copy & paste code, the same in all modules -----  */
 
-bool test_initBuffer(bool silent)
+/*
+ * If bool_expr evaluates to false, print the message and return to caller
+ */
+#define CHECK_TRUE(bool_expr)                      \
+    if(!(bool_expr)) {                             \
+        printf("assertion %s failed", #bool_expr); \
+        printf(" at %u:%s\n", __LINE__, __FILE__); \
+        exit(EXIT_FAILURE);                              \
+    }
+    
+#define REGRESSION_TEST_SUCCESS            \
+    printf("Regression tests in " __FILE__ \
+        " completed with success\n");
+
+#define SINGLE_TEST_SUCCESS(name) \
+    if (! TEST_SILENT )                          \
+      printf(#name " OK\n");
+
+/* -----   end of copy & paste code   ----- */
+
+void test_initBuffer()
 {
     // emulate memory corruption
     memset(buffer, 'x', sizeof(buffer));
 
     initBuffer();
 
-    bool ok = true;
     unsigned i = 0;
+
     // check the buffer is filled with NUL...
-    for (; ok && i < BUFFERSIZE; ++i)
-        ok = buffer[i] == NUL;
+    for (;i < BUFFERSIZE; ++i)
+        CHECK_TRUE(buffer[i] == NUL)
+
     // ...and has the ELLIPSIS string at the end...
     char ellipsis[] = ELLIPSIS;
     unsigned j = 0;
-    for (; ok && ellipsis[j] != NUL; ++i, ++j)
-        ok = buffer[i] == ellipsis[j];
-    ok = ok && buffer[i] == NUL;
-    if (!ok)
-        printf("initBuffer: initialization failed\n");
-    else if (!silent)
-        printf("initBuffer OK\n");
-    return ok;
+    for (;ellipsis[j] != NUL; ++i, ++j)
+        CHECK_TRUE(buffer[i] == ellipsis[j])
+
+    // ... and a terminating NUL character
+    CHECK_TRUE(buffer[i] == NUL)
+    
+    CHECK_TRUE(1 == 2)
+
+    SINGLE_TEST_SUCCESS(initBuffer)
 }
 
-bool testSuccessMessage(bool silent)
-{
-    if (!silent)
-        printf("Regression tests in " __FILE__ " indicate no error\n\n");
-    else
-        printf("Regression tests in " __FILE__ " OK\n");
-    return true;
-}
 
-void test_mmfatl(bool* ok)
+void test_mmfatl()
 {
-    bool silent = TEST_SILENT;
-
-    *ok = *ok
-        && test_initBuffer(silent)
-        && testSuccessMessage(silent);
+    test_initBuffer();
+    REGRESSION_TEST_SUCCESS
 }
 
 #endif // TEST_ENABLE

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -71,21 +71,28 @@ static void initBuffer()
 /* -----   copy & paste code, the same in all modules -----  */
 
 /*
- * If bool_expr evaluates to false, print the message and return to caller
+ * Use this extension of CHECK_TRUE if file and line number is not
+ * sufficient to locate the failing test.
  */
-#define CHECK_TRUE(bool_expr)                      \
-    if(!(bool_expr)) {                             \
-        printf("assertion %s failed", #bool_expr); \
-        printf(" at %s:%u\n", __FILE__, __LINE__); \
+#define CHECK_TRUE_W_CONTEXT(bool_expr, context)         \
+    if(!(bool_expr)) {                                   \
+        printf("In %s\n", #context);                     \
+        printf("assertion %s failed", #bool_expr);       \
+        printf(" in %s at %s:%u\n", __FILE__, __LINE__); \
         exit(EXIT_FAILURE);                              \
     }
-    
+
+/*
+ * If bool_expr evaluates to false, print the message and return to caller
+ */
+#define CHECK_TRUE(bool_expr) CHECK_TRUE_W_CONTEXT(bool_expr, __func__)
+
 #define REGRESSION_TEST_SUCCESS            \
     printf("Regression tests in " __FILE__ \
         " completed with success\n");
 
 #define SINGLE_TEST_SUCCESS(name) \
-    if (! TEST_SILENT )                          \
+    if (! TEST_SILENT )           \
       printf(#name " OK\n");
 
 /* -----   end of copy & paste code   ----- */

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -16,6 +16,9 @@
 
 #include "mmfatl.h"
 
+/*!
+ * character constant
+ */ 
 #define NUL '\x00'
 
 //----------
@@ -44,7 +47,7 @@
  */
 #define ELLIPSIS "..."
 
-char buffer[BUFFERSIZE + sizeof(ELLIPSIS)];
+static char buffer[BUFFERSIZE + sizeof(ELLIPSIS)];
 
 /*
  * We do not rely on any initialization during program start.  Instead we

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -71,8 +71,11 @@ static void initBuffer()
 /* -----   copy & paste code, the same in all modules -----  */
 
 /*
- * Use this extension of CHECK_TRUE if file and line number is not
- * sufficient to locate the failing test.  'context' is a string constant. 
+ * If bool_expr evaluates to false, print an error message and die.
+ *
+ * Use the string constant 'context' to easily identify the error location, in
+ * particular if file and line number is not sufficient to locate the failing
+ * test. 
  */
 #define CHECK_TRUE_W_CONTEXT(bool_expr, context)   \
     if(!(bool_expr)) {                             \
@@ -83,7 +86,10 @@ static void initBuffer()
     }
 
 /*
- * If bool_expr evaluates to false, print the message and return to caller
+ * If bool_expr evaluates to false, print an error message and die.
+ *
+ * File, line and the function this macro is embedded is sufficient to identify
+ * the error position.
  */
 #define CHECK_TRUE(bool_expr) CHECK_TRUE_W_CONTEXT(bool_expr, __func__)
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -119,8 +119,6 @@ void test_initBuffer()
     // ... and a terminating NUL character
     CHECK_TRUE(buffer[i] == NUL)
 
-    CHECK_TRUE(1 == 2)
-
     SINGLE_TEST_SUCCESS(initBuffer)
 }
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -73,7 +73,7 @@ static void initBuffer()
 #define CHECK_TRUE(bool_expr)                      \
     if(!(bool_expr)) {                             \
         printf("assertion %s failed", #bool_expr); \
-        printf(" at %u:%s\n", __FILE__, __LINE__); \
+        printf(" at %s:%u\n", __FILE__, __LINE__); \
         exit(EXIT_FAILURE);                              \
     }
     

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -10,17 +10,108 @@
  * conditions (corrupt state, out of memory).
  */
 
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "mmfatl.h"
 
+#define NUL '\x00'
+
+//----------
+
+/*
+ * During development you may not want to expose preliminary results to the
+ * normal compile, as this would trigger 'unused' warnings, for example.  In
+ * the regression test environment your code may be referenced by testing code,
+ * though.
+ *
+ * This section should be empty, or even removed, once your development is
+ * finished.
+ */
+#if TEST_ENABLE
+#   define UNDER_DEVELOPMENT
+#endif
+
+#ifdef UNDER_DEVELOPMENT
+/* the size a fatal error message including the terminating NUL character can
+ * assume without truncation.
+ */
+#define BUFFERSIZE 1024
+
+/* the character sequence appended to a truncated fatal error message, so a
+ * user is aware a displayed message is incomplete.
+ */
+#define ELLIPSIS "..."
+
+char buffer[BUFFERSIZE + sizeof(ELLIPSIS)];
+
+/*
+ * We do not rely on any initialization during program start.  Instead we
+ * assume the worst case, a corrupted pointer overwrote the buffer.  So we
+ * initialize it again immediately before use.
+ */
+static void initBuffer()
+{
+    char ellipsis[] = ELLIPSIS;
+
+    memset(buffer, NUL, BUFFERSIZE);
+    memcpy(buffer + BUFFERSIZE, ellipsis, sizeof(ellipsis));
+}
+
+#endif // UNDER_DEVELOPMENT
+
 //=================   Regression tests   =====================
 
-#ifdef TEST_ENABLE
+#if TEST_ENABLE
 
 /*  automatic testing to prevent regression   */
+
+bool test_initBuffer(bool silent)
+{
+    // emulate memory corruption
+    memset(buffer, 'x', sizeof(buffer));
+
+    initBuffer();
+
+    bool ok = true;
+    unsigned i = 0;
+    // check the buffer is filled with NUL...
+    for (; ok && i < BUFFERSIZE; ++i)
+        ok = buffer[i] == NUL;
+    if (!ok)
+       printf("initBuffer: uninitialized character at offset %u\n", i);
+    else
+    {
+        // ...and has the ELLIPSIS string at the end...
+        char ellipsis[] = ELLIPSIS;
+        unsigned j = 0;
+        unsigned tailStart = i;
+
+        for (; ok && ellipsis[j] != NUL; ++i, ++j)
+            ok = buffer[i] == ellipsis[j];
+        if (!ok)
+        {
+            char bufferTail[sizeof(ELLIPSIS) + 1];
+
+            bufferTail[sizeof(ELLIPSIS)] = NUL;
+            memcpy(bufferTail, buffer + tailStart, sizeof(ELLIPSIS));
+
+            printf("initBuffer: assumed %s at the end, found %s instead\n",
+                   ellipsis, bufferTail);
+        }
+    }
+    if (ok)
+    {
+        ok = buffer[i] == NUL;
+        if (!ok)
+            printf("initBuffer: "
+                "no NUL character following the ellipsis at the end\n");
+    }
+    if (ok && !silent)
+        printf("initBuffer OK\n");
+    return ok;
+}
 
 bool testSuccessMessage(bool silent)
 {
@@ -34,7 +125,8 @@ void test_mmfatl(bool* ok)
     bool silent = TEST_SILENT;
 
     *ok = *ok
+        && test_initBuffer(silent)
         && testSuccessMessage(silent);
 }
 
-#endif
+#endif // TEST_ENABLE

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -85,7 +85,7 @@ static void initBuffer()
 /*
  * If bool_expr evaluates to false, print the message and return to caller
  */
-#define CHECK_TRUE(bool_expr) CHECK_TRUE_W_CONTEXT(bool_expr, "")
+#define CHECK_TRUE(bool_expr) CHECK_TRUE_W_CONTEXT(bool_expr, __func__" ")
 
 #define REGRESSION_TEST_SUCCESS            \
     printf("Regression tests in " __FILE__ \

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -64,6 +64,7 @@ static void initBuffer(void) {
 
 #endif // UNDER_DEVELOPMENT
 
+
 //=================   Regression tests   =====================
 
 #ifdef TEST_ENABLE

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -72,11 +72,11 @@ static void initBuffer()
 
 /*
  * Use this extension of CHECK_TRUE if file and line number is not
- * sufficient to locate the failing test.
+ * sufficient to locate the failing test.  context is a string constant. 
  */
 #define CHECK_TRUE_W_CONTEXT(bool_expr, context)         \
     if(!(bool_expr)) {                                   \
-        printf("In %s\n", #context);                     \
+        printf(context);                                 \
         printf("assertion %s failed", #bool_expr);       \
         printf(" in %s at %s:%u\n", __FILE__, __LINE__); \
         exit(EXIT_FAILURE);                              \

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -79,36 +79,15 @@ bool test_initBuffer(bool silent)
     // check the buffer is filled with NUL...
     for (; ok && i < BUFFERSIZE; ++i)
         ok = buffer[i] == NUL;
+    // ...and has the ELLIPSIS string at the end...
+    char ellipsis[] = ELLIPSIS;
+    unsigned j = 0;
+    for (; ok && ellipsis[j] != NUL; ++i, ++j)
+        ok = buffer[i] == ellipsis[j];
+    ok = ok && buffer[i] == NUL;
     if (!ok)
-       printf("initBuffer: uninitialized character at offset %u\n", i);
-    else
-    {
-        // ...and has the ELLIPSIS string at the end...
-        char ellipsis[] = ELLIPSIS;
-        unsigned j = 0;
-        unsigned tailStart = i;
-
-        for (; ok && ellipsis[j] != NUL; ++i, ++j)
-            ok = buffer[i] == ellipsis[j];
-        if (!ok)
-        {
-            char bufferTail[sizeof(ELLIPSIS) + 1];
-
-            bufferTail[sizeof(ELLIPSIS)] = NUL;
-            memcpy(bufferTail, buffer + tailStart, sizeof(ELLIPSIS));
-
-            printf("initBuffer: assumed %s at the end, found %s instead\n",
-                   ellipsis, bufferTail);
-        }
-    }
-    if (ok)
-    {
-        ok = buffer[i] == NUL;
-        if (!ok)
-            printf("initBuffer: "
-                "no NUL character following the ellipsis at the end\n");
-    }
-    if (ok && !silent)
+        printf("initBuffer: initialization failed\n");
+    else if (!silent)
         printf("initBuffer OK\n");
     return ok;
 }

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -108,12 +108,9 @@ void test_initBuffer()
 
     // ... and a terminating NUL character
     CHECK_TRUE(buffer[i] == NUL)
-    
-    CHECK_TRUE(1 == 2)
 
     SINGLE_TEST_SUCCESS(initBuffer)
 }
-
 
 void test_mmfatl()
 {

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -78,7 +78,7 @@ static void initBuffer()
     if(!(bool_expr)) {                                   \
         printf(context);                                 \
         printf("assertion %s failed", #bool_expr);       \
-        printf(" in %s at %s:%u\n", __FILE__, __LINE__); \
+        printf(" at %s:%u\n", __FILE__, __LINE__); \
         exit(EXIT_FAILURE);                              \
     }
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -88,8 +88,8 @@ static void initBuffer()
 /*
  * If bool_expr evaluates to false, print an error message and die.
  *
- * File, line and the function this macro is embedded is sufficient to identify
- * the error position.
+ * File, line and the function this macro is embedded in is sufficient to
+ * identify the error position.
  */
 #define CHECK_TRUE(bool_expr) CHECK_TRUE_W_CONTEXT(bool_expr, __func__)
 

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -52,7 +52,7 @@
  * ================
  *
  * If the macro **BUILD_REQUESTS_REGRESSION_TEST** is defined (option -t of
- * build.sh) or **TEST_MMFATL** is defined, then regression tests are
+ * build.sh) or **TEST_FORCE_ENABLE** is defined, then regression tests are
  * implemented.  Invoke in addition option -c on build.sh, should you switch
  * between with/out testing, but no intermediate source file change.
  *
@@ -76,6 +76,7 @@
  * Github checks on each push request.
  */
 
+
 // Setting TEST_ENABLE to en/disable regression tests in this module
 //------------------------------------------------------------------
 
@@ -92,15 +93,34 @@
 
 /* -----   copy & paste code, the same in all modules -----  */
 
-/* If BUILD_REQUESTS_REGRESSION_TEST is defined compilation of regression
- * tests is requested from somewhere outside of C files.  This can still be
- * overridden locally by setting TEST_FORCE_ENABLE explicitly before.
+/*!
+ * \def TEST_SILENT
+ * macro, either true or false.
+ *
+ * Controls the verbosity of a regression test.  If true, success messages are
+ * mostly suppressed during a test run.  A failing test always produces output.
  */
 #undef TEST_SILENT
+
+/*!
+ * \def TEST_ENABLE
+ * macro, is either 0 or 1.
+ *
+ * Controls whether the regression tests for a
+ * particular module is in/excluded.
+ */
 #undef TEST_ENABLE
 
+/*!
+ * \def BUILD_REQUESTS_REGRESSION_TEST
+ * If BUILD_REQUESTS_REGRESSION_TEST is defined, compilation of regression
+ * tests is requested from somewhere outside of C files.  This can still be
+ * overridden locally by setting TEST_FORCE_ENABLE explicitly before.
+ * 
+ * BUILD_REQUESTS_REGRESSION_TEST is only set by the build process and must
+ * never be changed by software.
+ */
 #ifdef BUILD_REQUESTS_REGRESSION_TEST
-// optimized for continuous integration, suppresses success messages
 #   define TEST_SILENT false
 #   define TEST_ENABLE 1
 #else
@@ -109,7 +129,12 @@
 #   define TEST_ENABLE 0
 #endif
 
-// we do not assume TEST_FORCE_ENABLE is restricted to 0 or 1
+/*! \def TEST_FORCE_ENABLE
+ * allows overriding the BUILD_REQUESTS_REGRESSION_TEST setting and
+ * unconditionally implement or disable regression tests local to this module.
+ * Set to 1 to enable tests, 0 to disable them locally, or leave it undefined
+ * if you want default behaviour.
+ */
 #ifdef TEST_FORCE_ENABLE
 #   undef TEST_ENABLE
 #   if TEST_FORCE_ENABLE

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -79,6 +79,7 @@
 // Setting TEST_ENABLE to en/disable regression tests in this module
 //------------------------------------------------------------------
 
+// in case an included header has set this to something
 #undef TEST_FORCE_ENABLE
 /* uncomment one of the following to enforce disabling/enabling of regression
  * tests in this file unconditionally
@@ -86,47 +87,50 @@
 // #define TEST_FORCE_ENABLE 0
 // #define TEST_FORCE_ENABLE 1
 
-/* the function running regression tests in this module */
+// the function running regression tests in this module
 #define TEST_FUNCTION(x) test_mmfatl(x)
 
 /* -----   copy & paste code, the same in all modules -----  */
 
-/* in case an included header file of another module has defined it */
-#undef TEST_ENABLE
-
 /* If BUILD_REQUESTS_REGRESSION_TEST is defined compilation of regression
  * tests is requested from somewhere outside of C files.  This can still be
- * overridden locally by setting TEST_ENABLE explicitely below.
+ * overridden locally by setting TEST_FORCE_ENABLE explicitely before.
  */
+#undef TEST_SILENT
+#undef TEST_ENABLE
+
 #ifdef BUILD_REQUESTS_REGRESSION_TEST
-#   define TEST_ENABLE
-/* optimized for continuous integration, suppresses success messages */
+// optimized for continuous integration, suppresses success messages
 #   define TEST_SILENT true
+#   define TEST_ENABLE 1
 #else
-/* each test prints a confirmation on the screen */  
+// each test prints a confirmation on the screen
 #   define TEST_SILENT false
+#   define TEST_ENABLE 0
 #endif
 
+// we do not assume TEST_FORCE_ENABLE is restricted to 0 or 1
 #ifdef TEST_FORCE_ENABLE
+#   undef TEST_ENABLE
 #   if TEST_FORCE_ENABLE
-#       define TEST_ENABLE
+#       define TEST_ENABLE 1
 #   else
-#       undef TEST_ENABLE
+#       define TEST_ENABLE 0
 #   endif
 #endif
 
-#ifdef TEST_ENABLE
+#if TEST_ENABLE
 
-/* enable regression tests in main() in metamath.c */
+// enable regression tests in main() in metamath.c
 #   define RUN_REGRESSION_TEST
-    /* regression tests are implemented and called through this function */
+    // regression tests are implemented and called through this function
     extern void TEST_FUNCTION(bool*);
 #endif
 
 /* -----   end of copy & paste code   ----- */
 
-#ifndef TEST_ENABLE
-    /* still necessary should another module request regression tests */
+#if ! TEST_ENABLE
+    // still necessary should another module request regression tests
 #   define test_mmfatl(x)
 #endif
 

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -8,6 +8,7 @@
 #define METAMATH_MMFATL_H_
 
 #include <stdbool.h>
+#include "mmtest.h"
 
 /*!
  * \file mmfatl.h
@@ -47,116 +48,12 @@
  * For this kind of expansion you still need a buffer where the final message
  * is constructed.  In our context, this buffer is pre-allocated, and fixed in
  * size, truncation of overflowing text enforced.
- *
- * Regression tests
- * ================
- *
- * If the macro **BUILD_REQUESTS_REGRESSION_TEST** is defined (option -t of
- * build.sh) or **TEST_FORCE_ENABLE** is defined, then regression tests are
- * implemented.  Invoke in addition option -c on build.sh, should you switch
- * between with/out testing, but no intermediate source file change.
- *
- * In order to run implemented regression tests properly we suggest to add a
- * \code{.c}
- * test_mmfatl();
- * \endcode
- * line to main() close to its begin and **before** any function declared in
- * this header file is called.
- *
- * If tests are disabled this line evaluates to nothing.  In addition, the
- * compiler skips any test code, so the artifact size will not grow.  All in
- * all, a disabled test suite does not come with a linking or runtime penalty.
- *
- * If enabled, running tests document their progress to stdout.  Testing exits
- * on the first regression found with a diagnostic message further detailing on
- * the context of the failure.
- *
- * We recommend running the tests each time you modify mmfatl.h or mmfatl.c
- * to ensure it still executes as desired.  They are automatically invoked by
- * Github checks on each push request.
  */
 
+#ifdef TEST_ENABLE
 
-// Setting TEST_ENABLE to en/disable regression tests in this module
-//------------------------------------------------------------------
+extern void test_mmfatl(void);
 
-// in case an included header has set this to something
-#undef TEST_FORCE_ENABLE
-/* uncomment one of the following to enforce disabling/enabling of regression
- * tests in this file unconditionally
- */
-// #define TEST_FORCE_ENABLE 0
-// #define TEST_FORCE_ENABLE 1
-
-// the function running regression tests in this module
-#define TEST_FUNCTION(x) test_mmfatl(x)
-
-/* -----   copy & paste code, the same in all modules -----  */
-
-/*!
- * \def TEST_SILENT
- * macro, either true or false.
- *
- * Controls the verbosity of a regression test.  If true, success messages are
- * mostly suppressed during a test run.  A failing test always produces output.
- */
-#undef TEST_SILENT
-
-/*!
- * \def TEST_ENABLE
- * macro, is either 0 or 1.
- *
- * Controls whether the regression tests for a
- * particular module is in/excluded.
- */
-#undef TEST_ENABLE
-
-/*!
- * \def BUILD_REQUESTS_REGRESSION_TEST
- * If BUILD_REQUESTS_REGRESSION_TEST is defined, compilation of regression
- * tests is requested from somewhere outside of C files.  This can still be
- * overridden locally by setting TEST_FORCE_ENABLE explicitly before.
- * 
- * BUILD_REQUESTS_REGRESSION_TEST is only set by the build process and must
- * never be changed by software.
- */
-#ifdef BUILD_REQUESTS_REGRESSION_TEST
-#   define TEST_SILENT false
-#   define TEST_ENABLE 1
-#else
-// each test prints a confirmation on the screen
-#   define TEST_SILENT false
-#   define TEST_ENABLE 0
-#endif
-
-/*! \def TEST_FORCE_ENABLE
- * allows overriding the BUILD_REQUESTS_REGRESSION_TEST setting and
- * unconditionally implement or disable regression tests local to this module.
- * Set to 1 to enable tests, 0 to disable them locally, or leave it undefined
- * if you want default behaviour.
- */
-#ifdef TEST_FORCE_ENABLE
-#   undef TEST_ENABLE
-#   if TEST_FORCE_ENABLE
-#       define TEST_ENABLE 1
-#   else
-#       define TEST_ENABLE 0
-#   endif
-#endif
-
-#if TEST_ENABLE
-
-// enable regression tests in main() in metamath.c
-#   define RUN_REGRESSION_TEST
-    // regression tests are implemented and called through this function
-    extern void TEST_FUNCTION();
-#endif
-
-/* -----   end of copy & paste code   ----- */
-
-#if ! TEST_ENABLE
-    // still necessary should another module request regression tests
-#   define test_mmfatl(x)
 #endif
 
 #endif /* include guard */

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -85,7 +85,7 @@
  * tests in this file unconditionally
  */
 // #define TEST_FORCE_ENABLE 0
- #define TEST_FORCE_ENABLE 1
+// #define TEST_FORCE_ENABLE 1
 
 // the function running regression tests in this module
 #define TEST_FUNCTION(x) test_mmfatl(x)

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -34,11 +34,6 @@
  * be called when heap problems arise, since they use it internally.  GNU tags
  * such functions as 'AS-Unsafe heap' in their documentation (libc.pdf).
  *
- * A corrupt state is often caused by limit violations overwriting adjacent
- * memory.  To specifically guard against this, the pre-allocated memory area,
- * at your option, may include safety borders detaching necessary pre-set
- * administrative data from other memory.
- *
  * Often it is sensible to embed details in a diagnosis message.  Placeholders
  * in the format string mark insertion points for such values, much as in
  * \p printf. The variety and functionality is greatly reduced in our case,

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -101,7 +101,7 @@
 
 #ifdef BUILD_REQUESTS_REGRESSION_TEST
 // optimized for continuous integration, suppresses success messages
-#   define TEST_SILENT true
+#   define TEST_SILENT false
 #   define TEST_ENABLE 1
 #else
 // each test prints a confirmation on the screen

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -94,7 +94,7 @@
 
 /* If BUILD_REQUESTS_REGRESSION_TEST is defined compilation of regression
  * tests is requested from somewhere outside of C files.  This can still be
- * overridden locally by setting TEST_FORCE_ENABLE explicitely before.
+ * overridden locally by setting TEST_FORCE_ENABLE explicitly before.
  */
 #undef TEST_SILENT
 #undef TEST_ENABLE

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -85,7 +85,7 @@
  * tests in this file unconditionally
  */
 // #define TEST_FORCE_ENABLE 0
-// #define TEST_FORCE_ENABLE 1
+ #define TEST_FORCE_ENABLE 1
 
 // the function running regression tests in this module
 #define TEST_FUNCTION(x) test_mmfatl(x)
@@ -124,7 +124,7 @@
 // enable regression tests in main() in metamath.c
 #   define RUN_REGRESSION_TEST
     // regression tests are implemented and called through this function
-    extern void TEST_FUNCTION(bool*);
+    extern void TEST_FUNCTION();
 #endif
 
 /* -----   end of copy & paste code   ----- */

--- a/src/mmtest.c
+++ b/src/mmtest.c
@@ -1,0 +1,35 @@
+/*****************************************************************************/
+/*            Copyright (C) 2022  Mario Carneiro                             */
+/*            License terms:  GNU General Public License                     */
+/*****************************************************************************/
+/*34567890123456 (79-character line to adjust editor window) 2345678901234567*/
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include "mmtest.h"
+#include "mmfatl.h"
+
+/*!
+ * \file mmtest.c an implementation of a simple regression test framework
+ */
+
+#ifdef TEST_ENABLE
+
+bool g_testFailed = false;
+
+void runTest(bool (*test)(), const char* funcName, const char* testName) {
+  if (!TEST_SILENT) printf("running %s:%s...", funcName, testName);
+  if (test()) {
+    if (!TEST_SILENT) printf(" ok\n");
+  } else {
+    printf("\nTEST %s:%s FAILED\n", funcName, testName);
+    g_testFailed = true;
+  }
+}
+
+void runTests(void) {
+  test_mmfatl();
+  exit(g_testFailed ? EXIT_FAILURE : EXIT_SUCCESS);
+}
+
+#endif // TEST_ENABLE

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -62,7 +62,8 @@
 
 #ifdef TEST_ENABLE
 
-  extern void runTest(bool (*test)(), const char* funcName, const char* testName);
+  extern void runTest(
+      bool (*test)(), const char* funcName, const char* testName);
   #define RUN_TEST(testName) runTest(testName, __func__, #testName)
 
   /*
@@ -73,12 +74,12 @@
   * sufficient to locate the failing test.
   * Accepts a format string for the assertion message.
   */
-  #define ASSERTF(bool_expr, ...)                \
-    if (!(bool_expr)) {                          \
-      printf("\n%s: ", __func__);                \
-      printf(__VA_ARGS__);                       \
+  #define ASSERTF(bool_expr, ...)              \
+    if (!(bool_expr)) {                        \
+      printf("\n%s: ", __func__);              \
+      printf(__VA_ARGS__);                     \
       printf(" at %s:%u", __FILE__, __LINE__); \
-      return false;                              \
+      return false;                            \
     }
 
   /*
@@ -88,7 +89,8 @@
   * File, line and the function this macro is embedded in is sufficient to
   * identify the error position.
   */
-  #define ASSERT(bool_expr) ASSERTF(bool_expr, "assertion %s failed", #bool_expr)
+  #define ASSERT(bool_expr) \
+      ASSERTF(bool_expr, "assertion %s failed", #bool_expr)
 
   extern void runTests(void);
   #define RUN_TESTS() runTests()

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -1,0 +1,101 @@
+/*****************************************************************************/
+/*            Copyright (C) 2022  Mario Carneiro                             */
+/*            License terms:  GNU General Public License                     */
+/*****************************************************************************/
+/*34567890123456 (79-character line to adjust editor window) 2345678901234567*/
+
+#ifndef METAMATH_MMTEST_H_
+#define METAMATH_MMTEST_H_
+
+/*!
+ * \file mmtest.h
+ * \brief runs the regression tests
+ *
+ * part of the application's infrastructure
+ *
+ * Regression tests
+ * ================
+ *
+ * If the macro **TEST_ENABLE** is defined (option -t of build.sh), then
+ * regression tests are run. The setting can be overridden in this file.
+ * Invoke in addition option -c (clean) on build.sh, should you switch
+ * between with/out testing, but no intermediate source file change.
+ *
+ * If tests are disabled the \ref runTests line evaluates to nothing.
+ * In addition, the compiler skips any test code, so the artifact size will not
+ * grow.  All in all, a disabled test suite does not come with a linking or
+ * runtime penalty.
+ *
+ * If enabled, running tests document their progress to stdout.  Testing exits
+ * on the first regression found with a diagnostic message further detailing on
+ * the context of the failure.
+ *
+ * We recommend running the tests each time you modify the code to ensure it
+ * still executes as desired.  They are automatically invoked by Github checks
+ * on each push request.
+ */
+
+/*!
+ * \def TEST_ENABLE
+ * macro, is either 0 or 1.
+ *
+ * Controls whether the regression tests for a
+ * particular module is in/excluded.
+ */
+
+// Uncomment this to force-disable tests
+// #undef TEST_ENABLE
+
+// Uncomment this to force-enable tests
+// #define TEST_ENABLE
+
+#include <stdio.h>
+
+/*!
+ * \def TEST_SILENT
+ * macro, either true or false.
+ *
+ * Controls the verbosity of a regression test.  If true, success messages are
+ * mostly suppressed during a test run.  A failing test always produces output.
+ */
+#define TEST_SILENT false
+
+#ifdef TEST_ENABLE
+
+  extern void runTest(bool (*test)(), const char* funcName, const char* testName);
+  #define RUN_TEST(testName) runTest(testName, __func__, #testName)
+
+  /*
+  * If bool_expr evaluates to false, print an error message and return to
+  * caller.
+  *
+  * Use this extension of ASSERT if file and line number is not
+  * sufficient to locate the failing test.
+  * Accepts a format string for the assertion message.
+  */
+  #define ASSERTF(bool_expr, ...)                \
+    if (!(bool_expr)) {                          \
+      printf("\n%s: ", __func__);                \
+      printf(__VA_ARGS__);                       \
+      printf(" at %s:%u", __FILE__, __LINE__); \
+      return false;                              \
+    }
+
+  /*
+  * If bool_expr evaluates to false, print an error message and return to
+  * caller.
+  *
+  * File, line and the function this macro is embedded in is sufficient to
+  * identify the error position.
+  */
+  #define ASSERT(bool_expr) ASSERTF(bool_expr, "assertion %s failed", #bool_expr)
+
+  extern void runTests(void);
+  #define RUN_TESTS() runTests()
+
+#else // TEST_ENABLE
+  #define RUN_TESTS()
+#endif // TEST_ENABLE
+
+
+#endif /* include guard */

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -37,7 +37,7 @@
 
 /*!
  * \def TEST_ENABLE
- * macro, is either 0 or 1.
+ * macro, only defined or not is evaluated.
  *
  * Controls whether the regression tests for a
  * particular module is in/excluded.


### PR DESCRIPTION
The layer printing a final fatal error message must not rely on the memory heap, as it can be exhausted, or even corrupt.  Instead it uses a buffer allocated right at program start for this sole purpose.  It needs this buffer, because it is intended to add simple parsing features to the fatal error message handler.

2 macros control the details of this buffer:
- BUFFERSIZE the capacity of the buffer.  The terminating NUL character must be covered
- ELLIPSIS a string indicating truncation to the user should the parsing overflow the buffer.

This PR allocates a buffer according to the macro settings.  Although C initializes all global variables, we do not rely on this, but assume the buffer might be overwritten in a corrupt environment, and we need to initialize it again.  So far this initialization is very simple: Fill the buffer with NUL and append the ELLIPSIS at the end.

This functionality can undergo a regression test.  So this PR adds the first entry to the test suite.  A few adaptions were made to the macros controlling whether a normal executable, or a test version is to be created.  Boilerplate code for a more concise test code added.
