### PR TITLE
fatal error handling part 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Makefile
 Makefile.in
 compile
 configure
+configure~
 config.*
 depcomp
 install-sh

--- a/src/mmcmdl.c
+++ b/src/mmcmdl.c
@@ -2240,7 +2240,7 @@ void printCommandError(vstring line1, long arg, vstring errorMsg)
   free_vstring(line);
 } /* printCommandError */
 
-void freeCommandLine() {
+void freeCommandLine(void) {
   long i, j;
   j = pntrLen(g_rawArgPntr);
   for (i = 0; i < j; i++) free_vstring(*(vstring *)(&g_rawArgPntr[i]));

--- a/src/mmdata.c
+++ b/src/mmdata.c
@@ -120,7 +120,7 @@ vstring g_qsortKey; /* Used by qsortStringCmp; pointer only, do not deallocate *
  * administrative header, followed by elements reserved for application data.
  * The header is assigned elements -3 to -1 in the formal array, so that
  * application data starts with element 0.  A **pointer to the block** always
- * refers to element 0, so the header appears somewhat hidden.  Its **size** 
+ * refers to element 0, so the header appears somewhat hidden.  Its **size**
  * is given by the bytes reserved for application data, not including the
  * administrative header.
  *
@@ -216,7 +216,7 @@ vstring g_qsortKey; /* Used by qsortStringCmp; pointer only, do not deallocate *
 
 /*!
  * \page doc-todo Improvements in documentation
- * 
+ *
  * - Revisit the \ref pgBlock "block", \ref pgStack "stack" references to check
  *   the inserted wording.
  * - The formatting of __p__ tags seem insufficient.  Figure out whether and
@@ -3971,7 +3971,7 @@ int qsortStringCmp(const void *p1, const void *p2)
   }
 }
 
-void freeData() {
+void freeData(void) {
   /* 15-Aug-2020 nm TODO: are some of these called twice? (in eraseSource) */
   free(g_IncludeCall);
   free(g_Statement);

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -37,7 +37,7 @@
  * This section should be empty, or even removed, once your development is
  * finished.
  */
-#if TEST_ENABLE
+#ifdef TEST_ENABLE
 #   define UNDER_DEVELOPMENT
 #endif
 
@@ -120,8 +120,7 @@ static void initBuffer(void) {
  * used to indicate whether \ref PLACEHOLDER_CHAR is a normal character, or
  * is an escape character in a format string.
  */
-enum TextType
-{
+enum TextType {
   STRING, //<! NUL terminated text
   FORMAT  //<! NUL terminated format containing placeholders
 };
@@ -135,12 +134,10 @@ enum TextType
  *   insertion point of other data, and stops the copy process.
  * \return a pointer to the character following the last one copied.
  */
-static char const* appendText(char const* source, enum TextType type)
-{
+static char const* appendText(char const* source, enum TextType type) {
   char escape = type == FORMAT ? PLACEHOLDER_CHAR : NUL;
-  while (buffer.begin != buffer.end
-      && *source != NUL && *source != escape)
-        *buffer.begin++ = *source++;
+  while (buffer.begin != buffer.end && *source != NUL && *source != escape)
+    *buffer.begin++ = *source++;
   return source;
 }
 
@@ -161,15 +158,15 @@ bool test_initBuffer(void) {
   unsigned i = 0;
 
   // check the buffer is filled with NUL...
-  for (;i < BUFFERSIZE; ++i)
+  for (; i < BUFFERSIZE; ++i)
     ASSERT(buffer.text[i] == NUL);
 
-  ASSERT(buffer.end == buffer.text + i)
+  ASSERT(buffer.end == buffer.text + i);
 
   // ...and has the ELLIPSIS string at the end...
   char ellipsis[] = ELLIPSIS;
   unsigned j = 0;
-  for (;ellipsis[j] != NUL; ++i, ++j)
+  for (; ellipsis[j] != NUL; ++i, ++j)
     ASSERT(buffer.text[i] == ellipsis[j]);
 
   // ... and a terminating NUL character
@@ -178,7 +175,7 @@ bool test_initBuffer(void) {
 }
 
 char const* bufferCompare(char const* match, int from, unsigned lg,
-                        unsigned begin)
+    unsigned begin)
 {
   if (memcmp(buffer.begin + from, match, lg) != 0)
     return "unexpected buffer contents";
@@ -198,22 +195,21 @@ char const* bufferCompare(char const* match, int from, unsigned lg,
  * \return NULL on success, otherwise a message describing a failure
  */
 char const* testcase_appendText(char const* text, unsigned adv,
-        char const* match, int from, int lg, unsigned begin)
+    char const* match, int from, int lg, unsigned begin)
 {
-    enum TextType type = *text == PLACEHOLDER_CHAR ? FORMAT : STRING;
-    return appendText(text + 1, type) == text + adv + 1 ?
-                bufferCompare(match, from, lg, begin)
-                : "format pointer not properly advanced";
+  enum TextType type = *text == PLACEHOLDER_CHAR ? FORMAT : STRING;
+  return appendText(text + 1, type) == text + adv + 1 ?
+    bufferCompare(match, from, lg, begin) :
+    "format pointer not properly advanced";
 }
 
 // wrapper macro to get the function, line number right, and prevent
 // further test cases on error
-#define TESTCASE_appendText(format, adv, match, from, lg, begin)  \
-  {                                                               \
-    char const* errmsg =                                          \
-        testcase_appendText(format, adv, match, from, lg, begin); \
-    ASSERTF(errmsg == NULL, "%s\n", errmsg);                      \
-  }
+#define TESTCASE_appendText(format, adv, match, from, lg, begin) { \
+  char const* errmsg =                                             \
+    testcase_appendText(format, adv, match, from, lg, begin);      \
+  ASSERTF(errmsg == NULL, "%s\n", errmsg);                         \
+}
 
 bool test_appendText(void) {
   initBuffer();

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -207,7 +207,7 @@ char const* testcase_appendText(char const* text, unsigned adv,
 }
 
 // wrapper macro to get the function, line number right, and prevent
-// further test cases
+// further test cases on error
 #define TESTCASE_appendText(format, adv, match, from, lg, begin)  \
   {                                                               \
     char const* errmsg =                                          \

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -227,7 +227,6 @@ bool test_appendText()
   // _ STRING, % FORMAT
   // corner case 1: insertion at the very beginning of the buffer
   TESTCASE_appendText("_$", 1, "$", -1, 2, 1);
-
   // corner case 2: empty text, placeholder handling
   TESTCASE_appendText("%", 0, "$", -1, 2, 1)
   TESTCASE_appendText("%%", 0, "$", -1, 2, 1);
@@ -235,7 +234,7 @@ bool test_appendText()
   TESTCASE_appendText("%abc", 3, "$abc", -4, 5, 4);
   TESTCASE_appendText("%def%", 3, "$abcdef", -7, 8, 7);
   TESTCASE_appendText("_gh%i", 4, "$abcdefgh%i", -11, 12, 11);
-  // corner case 3: checking for buffer overflow
+  // corner case 3: no space left
   buffer.begin = buffer.end;
   *(buffer.end - 1) = '$';
   *(buffer.end) = '$';

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -215,8 +215,7 @@ char const* testcase_appendText(char const* text, unsigned adv,
     ASSERTF(errmsg == NULL, "%s\n", errmsg);                      \
   }
 
-bool test_appendText()
-{
+bool test_appendText(void) {
   initBuffer();
 
   // uncomment to deliberately trigger an error message

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -17,9 +17,14 @@
 #include "mmfatl.h"
 
 /*!
- * character constant
+ * string terminating character
  */
 #define NUL '\x00'
+
+/*!
+ * format placeholder character
+ */
+#define PLACEHOLDER_CHAR '%'
 
 //----------
 
@@ -48,7 +53,54 @@
  */
 #define ELLIPSIS "..."
 
-static char buffer[BUFFERSIZE + sizeof(ELLIPSIS)];
+/*!
+ * \brief declares a buffer used to generate a text message through a
+ * formatting procedure.
+ *
+ * This buffer type is used to send a final diagnostic message to the user,
+ * before the program dies because of insufficient, or even corrupt memory.
+ * Under such severe conditions support from the C library is limited.  In
+ * particular the memory heap is not available, thus forbidding dynamic program
+ * features.  That is why a buffer of this type is usally preallocated.
+ *
+ * The main buffer operation is appending to already available contents, much
+ * in the way of a stream.  Occasionally we want to tentatively append
+ * characters, so the semantics of this buffer does not match exactly that of a
+ * stream.
+ *
+ * Apart from the writeable portion of the buffer, a fixed text \ref ELLIPSIS
+ * is padded to the right, so in case of a buffer overflow both concatenated
+ * portions automatically indicate truncated text.
+ *
+ * The available unallocated buffer space is delimited by member *end*  on the
+ * right.  Write operations must never write to its address, or even trespass
+ * it.  The current implementation sees its value as constant once it got
+ * initialized.
+ *
+ * The buffer is filled by a formatting procedure, that usually appends to
+ * previously generated text.  The current insertion point on the left is
+ * marked by the member *begin* pointer.  Each insertion forwards it in
+ * the direction of *end*.
+ */
+
+struct Buffer {
+  char* begin; /*!< points to first unallocated character */
+  /*!
+   * marks the end of the writeable portion, where the \ref ELLIPSIS begins.
+   * Logically constant once it got initialized.  Never overwrite this value.
+   */
+  char* end;
+  /*!
+   * the writeable buffer, followed by fixed text indicating truncation if
+   * necessary.
+   */
+  char text[BUFFERSIZE + sizeof(ELLIPSIS)];
+};
+
+/*!
+ * a preallocated buffer supporting formatting.
+ */
+static struct Buffer buffer;
 
 /*
  * We do not rely on any initialization during program start.  Instead we
@@ -58,8 +110,38 @@ static char buffer[BUFFERSIZE + sizeof(ELLIPSIS)];
 static void initBuffer(void) {
   char ellipsis[] = ELLIPSIS;
 
-  memset(buffer, NUL, BUFFERSIZE);
-  memcpy(buffer + BUFFERSIZE, ellipsis, sizeof(ellipsis));
+  buffer.begin = buffer.text;
+  buffer.end = buffer.text + BUFFERSIZE;
+  memset(buffer.begin, NUL, BUFFERSIZE);
+  memcpy(buffer.end, ellipsis, sizeof(ellipsis));
+}
+
+/*!
+ * used to indicate whether \ref PLACEHOLDER_CHAR is a normal character, or
+ * is an escape character in a format string.
+ */
+enum TextType
+{
+  STRING, //<! NUL terminated text
+  FORMAT  //<! NUL terminated format containing placeholders
+};
+
+/*!
+ * append characters to the current end of the buffer from a format string
+ * until a terminating NUL or PLACEHOLDER_CHAR is encountered, or the buffer
+ * overflows.  A terminating character is not copied.
+ * \param source [not null] the source from which bytes are copied.
+ * \param type if \ref FORMAT, a PLACEHOLDER_CHAR is interpreted as a possible
+ *   insertion point of other data, and stops the copy process.
+ * \return a pointer to the character following the last one copied.
+ */
+static char const* appendText(char const* source, enum TextType type)
+{
+  char escape = type == FORMAT? PLACEHOLDER_CHAR : NUL;
+  while (buffer.begin != buffer.end
+      && *source != NUL && *source != escape)
+        *buffer.begin++ = *source++;
+  return source;
 }
 
 #endif // UNDER_DEVELOPMENT
@@ -71,29 +153,110 @@ static void initBuffer(void) {
 
 bool test_initBuffer(void) {
   // emulate memory corruption
-  memset(buffer, 'x', sizeof(buffer));
+  memset(&buffer, 'x', sizeof(buffer));
 
   initBuffer();
 
+  ASSERT(buffer.begin == buffer.text)
   unsigned i = 0;
 
   // check the buffer is filled with NUL...
   for (;i < BUFFERSIZE; ++i)
-    ASSERT(buffer[i] == NUL);
+    ASSERT(buffer.text[i] == NUL);
+
+  ASSERT(buffer.end == buffer.text + i)
 
   // ...and has the ELLIPSIS string at the end...
   char ellipsis[] = ELLIPSIS;
   unsigned j = 0;
   for (;ellipsis[j] != NUL; ++i, ++j)
-    ASSERT(buffer[i] == ellipsis[j]);
+    ASSERT(buffer.text[i] == ellipsis[j]);
 
   // ... and a terminating NUL character
-  ASSERT(buffer[i] == NUL);
+  ASSERT(buffer.text[i] == NUL);
+  return true;
+}
+
+char const* bufferCompare(char const* match, int from, unsigned lg,
+                        unsigned begin)
+{
+  if (memcmp(buffer.begin + from, match, lg) != 0)
+    return "unexpected buffer contents";
+  return buffer.begin == buffer.text + begin?
+    (char const*)0 : "unexpected buffer begin";
+}
+
+/*
+ * \param text source text, first character is skipped and indicates its type:
+ *   % a format string with special treatment of the PLACEHOLDER_CHAR, else
+ *   normal NUL terminated string
+ * \param adv that many characters are expected to be copied
+ * \param match memory dump of buffer after copy...
+ * \param from ... counting from this offset from buffer.begin after copy...
+ * \param lg ...and this many characters.
+ * \param begin offset of buffer.begin from buffer.text after copy.
+ * \return NULL on success, otherwise a message describing a failure
+ */
+char const* testcase_appendText(char const* text, unsigned adv,
+        char const* match, int from, int lg, unsigned begin)
+{
+    enum TextType type = *text == PLACEHOLDER_CHAR? FORMAT : STRING;
+    return appendText(text + 1, type) == text + adv + 1?
+                bufferCompare(match, from, lg, begin)
+                : "format pointer not properly advanced";
+}
+
+// wrapper macro to get the function, line number right, and prevent
+// further test cases
+#define TESTCASE_appendText(format, adv, match, from, lg, begin)  \
+  {                                                               \
+    char const* errmsg =                                          \
+        testcase_appendText(format, adv, match, from, lg, begin); \
+    ASSERTF(errmsg == NULL, "%s\n", errmsg)                       \
+  }
+
+bool test_appendText()
+{
+  initBuffer();
+
+  // uncomment to deliberately trigger an error message
+  // TESTCASE_appendText("_$", 1, "x$", -1, 2, 1);
+
+
+  // The first character of the source is a type character and skipped:
+  // _ STRING, % FORMAT
+  // corner case 1: insertion at the very beginning of the buffer
+  TESTCASE_appendText("_$", 1, "$", -1, 2, 1);
+
+  // corner case 2: empty text, placeholder handling
+  TESTCASE_appendText("%", 0, "$", -1, 2, 1)
+  TESTCASE_appendText("%%", 0, "$", -1, 2, 1);
+  // non-empty text, placeholder handling
+  TESTCASE_appendText("%abc", 3, "$abc", -4, 5, 4);
+  TESTCASE_appendText("%def%", 3, "$abcdef", -7, 8, 7);
+  TESTCASE_appendText("_gh%i", 4, "$abcdefgh%i", -11, 12, 11);
+  // corner case 3: checking for buffer overflow
+  buffer.begin = buffer.end;
+  *(buffer.end - 1) = '$';
+  *(buffer.end) = '$';
+  TESTCASE_appendText("%", 0, "$$", -1, 2, BUFFERSIZE);
+  TESTCASE_appendText("%%", 0, "$$", -1, 2, BUFFERSIZE);
+  TESTCASE_appendText("%abc", 0, "$$", -1, 2, BUFFERSIZE);
+  // corner case 4: truncation in the middle of the text due to overflow
+  *(buffer.end - 2) = '$';
+  buffer.begin = buffer.end - 1;
+  TESTCASE_appendText("_a", 1, "$a$", -2, 3, BUFFERSIZE);
+  buffer.begin = buffer.end - 1;
+  TESTCASE_appendText("%def", 1, "$d$", -2, 3, BUFFERSIZE);
+  buffer.begin = buffer.end - 1;
+  TESTCASE_appendText("%g%", 1, "$g$", -2, 3, BUFFERSIZE);
+
   return true;
 }
 
 void test_mmfatl(void) {
   RUN_TEST(test_initBuffer);
+  RUN_TEST(test_appendText);
 }
 
 #endif // TEST_ENABLE

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -137,7 +137,7 @@ enum TextType
  */
 static char const* appendText(char const* source, enum TextType type)
 {
-  char escape = type == FORMAT? PLACEHOLDER_CHAR : NUL;
+  char escape = type == FORMAT ? PLACEHOLDER_CHAR : NUL;
   while (buffer.begin != buffer.end
       && *source != NUL && *source != escape)
         *buffer.begin++ = *source++;
@@ -157,7 +157,7 @@ bool test_initBuffer(void) {
 
   initBuffer();
 
-  ASSERT(buffer.begin == buffer.text)
+  ASSERT(buffer.begin == buffer.text);
   unsigned i = 0;
 
   // check the buffer is filled with NUL...
@@ -182,8 +182,8 @@ char const* bufferCompare(char const* match, int from, unsigned lg,
 {
   if (memcmp(buffer.begin + from, match, lg) != 0)
     return "unexpected buffer contents";
-  return buffer.begin == buffer.text + begin?
-    (char const*)0 : "unexpected buffer begin";
+  return buffer.begin == buffer.text + begin ?
+    NULL : "unexpected buffer begin";
 }
 
 /*
@@ -200,8 +200,8 @@ char const* bufferCompare(char const* match, int from, unsigned lg,
 char const* testcase_appendText(char const* text, unsigned adv,
         char const* match, int from, int lg, unsigned begin)
 {
-    enum TextType type = *text == PLACEHOLDER_CHAR? FORMAT : STRING;
-    return appendText(text + 1, type) == text + adv + 1?
+    enum TextType type = *text == PLACEHOLDER_CHAR ? FORMAT : STRING;
+    return appendText(text + 1, type) == text + adv + 1 ?
                 bufferCompare(match, from, lg, begin)
                 : "format pointer not properly advanced";
 }
@@ -212,7 +212,7 @@ char const* testcase_appendText(char const* text, unsigned adv,
   {                                                               \
     char const* errmsg =                                          \
         testcase_appendText(format, adv, match, from, lg, begin); \
-    ASSERTF(errmsg == NULL, "%s\n", errmsg)                       \
+    ASSERTF(errmsg == NULL, "%s\n", errmsg);                      \
   }
 
 bool test_appendText()

--- a/src/mminou.c
+++ b/src/mminou.c
@@ -1516,7 +1516,7 @@ double getRunTime(double *timeSinceLastCall) {
 }
 
 
-void freeInOu() {
+void freeInOu(void) {
   long i, j;
   j = pntrLen(backBuffer);
   for (i = 0; i < j; i++) free_vstring(*(vstring *)(&backBuffer[i]));

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -37,7 +37,7 @@
 
 /*!
  * \def TEST_ENABLE
- * macro, only defined or not is evaluated.
+ * macro, no value, just defined or not.
  *
  * Controls whether the regression tests for a
  * particular module is in/excluded.

--- a/src/mmvstr.c
+++ b/src/mmvstr.c
@@ -758,7 +758,7 @@ double val(const char *s) {
 
 
 /* Returns current date as an ASCII string */
-temp_vstring date() {
+temp_vstring date(void) {
   struct tm *time_structure;
   time_t time_val;
   char *month[12];
@@ -792,7 +792,7 @@ temp_vstring date() {
 
 
 /* Return current time as an ASCII string */
-temp_vstring time_() {
+temp_vstring time_(void) {
   struct tm *time_structure;
   time_t time_val;
   int i;

--- a/src/mmword.c
+++ b/src/mmword.c
@@ -348,7 +348,7 @@ l7240: /* */
 
 
 
-void gosub_7320() {
+void gosub_7320(void) {
         /* Subroutine:  get next L1_ from original file */
   vstring_def(tmpLin);
   if (r1) {     /*  Get next line from save array */
@@ -382,7 +382,7 @@ void gosub_7320() {
   return;
 }
 
-void gosub_7330() {
+void gosub_7330(void) {
         /*  Subroutine:  get next L2_ from edited file */
   vstring_def(tmpLin);
   vstring tmpStrPtr; /* pointer only */


### PR DESCRIPTION
Adding stream semantics to the buffer.

The parsing algorithm will scan through the format string and continuously add pieces of text to the output buffer.  It will use appendText() to perform this.  This function is meant to copy chunks of text from a source verbatim to the buffer.  It will stop only at a terminating NUL, a placeholder character %, or when the buffer overflows.  The source could either be the format string itself, or a parameter substituting a %s.  Both cases differ slightly:  In case of a parameter the % is just an ordinary character.  Which semantics to select is given by an argument TextType submitted to appendText.