### PR TITLE
fatal error handling, part 5

### DIFF
--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -92,7 +92,7 @@ static char const* unsignedToString(unsigned long value) {
    * in an unsigned long.  Two extra bytes compensate the truncation error in the
    * division and allow for a terminating NUL character.
    */
-  static char [(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
+  static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
 
   unsigned ofs = sizeof(digits) - 1;
   digits[ofs] = NUL;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -370,9 +370,9 @@ bool test_unsignedToString(void)
   ASSERT(strtoul(unsignedToString(~0u), NULL, 10) == ~0u);
 }
 
-bool test_handleSubstitution1(int dummy, ...) {
-  char const* format = state.format;
-  va_start(state.args, dummy);
+bool test_handleSubstitution1(char const* format, ...) {
+  state.format = format;
+  va_start(state.args, format);
   
   // without initializing the buffer each test appends
   // to the result of the former test.
@@ -456,8 +456,8 @@ bool test_handleSubstitution1(int dummy, ...) {
 }
 
 bool test_handleSubstitution(void) {
-  state.format = "%s%s%s%s%u%u%u%s%%%;%";
-  bool result = test_handleSubstitution1(0,
+  bool result = test_handleSubstitution1(
+    "%s%s%s%s%u%u%u%s%%%;%",
     NULL, "", "abc", "%s", 0, 123, ~0u, "overflow");
   return result;
 }

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -30,7 +30,7 @@
  * format placeholder character, not NUL
  */
 #define PLACEHOLDER_CHAR '%'
-#define PLACEHOLDER_STRING  "%"
+#define PLACEHOLDER_STRING "%"
 /*!
  * marks a string type in a placeholder substitution
  */
@@ -71,8 +71,8 @@
 
 /*!
  * converts an unsigned long to a sequence of decimal digits representing its
- * value.  The value range is known to be at least 2^32 by the C Standard 99
- * .  We support unsigned long in formatted error output to allow for macros like
+ * value.  The value range is known to be at least 2**32 by the C 99 Standard.
+ * We support unsigned long in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
  *
  * There exist no utoa in the C99 standard library, that could be used instead,
@@ -215,7 +215,7 @@ struct ParserInput {
 static struct ParserInput state;
 
 /*!
- * a format specifier is a two character combination, where a PLACEHOLDER_CHAR
+ * A format specifier is a two character combination, where a PLACEHOLDER_CHAR
  * is followed by an alphabetic character designating a type.  A placeholder
  * is substituted by the next argument in member *args* of \ref state.  This
  * function handles this substitution when member *format* of \ref state points

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -88,8 +88,8 @@ static char const* unsignedToString(unsigned value) {
    * sizeof(value) * CHAR_BIT are the bits encodable in value, the factor 146/485,
    * derived from a chained fraction, is about 0.3010309, slightly greater than
    * log 2.  So the number within the brackets is the count of decimal digits
-   * encodable in an unsigned long.  Two extra bytes compensate for the
-   * truncation error of the division and allow for a terminating NUL.
+   * encodable in value.  Two extra bytes compensate for the truncation error of
+   * the division and allow for a terminating NUL.
    */
   static char digits[(sizeof(value) * CHAR_BIT * 146) / 485 + 2];
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -451,6 +451,7 @@ bool test_handleSubstitution1(int dummy, ...) {
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "%%%") == 0);
 
+  va_end(state.args);
   return true;
 }
 
@@ -458,7 +459,6 @@ bool test_handleSubstitution(void) {
   state.format = "%s%s%s%s%u%u%u%s%%%;%";
   bool result = test_handleSubstitution1(0,
     NULL, "", "abc", "%s", 0, 123, ~0u, "overflow");
-  va_end(state.args);
   return result;
 }
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -246,7 +246,7 @@ static void handleSubstitution(void) {
     case PLACEHOLDER_CHAR:
       // %%
       break;
-    default:;
+    default:
       // stray %
       advFormatPtr = 1;
   }

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -18,7 +18,7 @@
 
 #include "mmfatl.h"
 
-#if CHAR_BIT > 8
+#if CHAR_BIT != 8
 /* C99 does not mandate a byte to be an octet, but such systems have become
  * exotic nowadays.  If you really want to run Metamath, say, on a
  * CDC 3600 (wide spread in 1965), then you are a bit on your own here.
@@ -28,7 +28,7 @@
  * limits roughly to required memory space.  We could alternatively evaluate
  * CHAR_BIT in the start-up phase of the program, and dynamically pre-allocate
  * memory accordingly to resolve such compatibility issues.  Or introduce boost
- * libraries to the same effect.  We think it is not worth the effort.
+ * preprocessor libraries to the same effect.  We think it is not worth the effort.
  */
 #   error "machine type not supported, expect a byte to be an octet."
 #endif

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -384,6 +384,9 @@ bool test_unsignedToString(void)
 bool test_handleSubstitution1(int dummy, ...) {
   char const* format = state.format;
   va_start(state.args, dummy);
+  
+  // without initializing the buffer each test appends
+  // to the result of the former test.
 
   // %s NULL
   initBuffer();

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -18,22 +18,6 @@
 
 #include "mmfatl.h"
 
-#if CHAR_BIT != 8
-/* C99 (see https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf) does
- * not mandate a byte to be an octet, but such systems have become exotic
- * nowadays.  If you really want to run Metamath, say, on a CDC 3600 (wide
- * spread in 1965), then you are a bit on your own here.  We recommend
- * contemporary hardware to achieve reasonable results.
- * 
- * Our assumption is CHAR_BIT == 8 from now on.  This allows us to map integer
- * limits roughly to required memory space.  We could alternatively evaluate
- * CHAR_BIT in the start-up phase of the program, and dynamically pre-allocate
- * memory accordingly to resolve such compatibility issues.  Or introduce Boost
- * preprocessor libraries to the same effect.  We think it is not worth the effort.
- */
-# error "machine type not supported, expect a byte to be an octet."
-#endif
-
 /*!
  * string terminating character
  */
@@ -42,8 +26,8 @@
 /*!
  * format placeholder character, not NUL
  */
-#define PLACEHOLDER_CHAR '%'
-#define PLACEHOLDER_STRING  "%"
+#define PLACEHOLDER_CHAR   '%'
+#define PLACEHOLDER_STRING "%"
 /*!
  * marks a string type in a placeholder substitution
  */
@@ -99,12 +83,13 @@
  */
 static char const* unsignedToString(unsigned long value) {
   /*
-   * CHAR_BIT == 8 is assumed here, so a byte's capacity is that of an octet,
-   * amounting to slightly less than 2.5 decimal digits per byte.  The two
-   * extra bytes compensate a truncation error, and allow for a terminating
-   * NUL character.
+   * sizeof(unsigned long) * CHAR_BIT are the bits available in an unsigned long,
+   * the factor 146/485, derived from a chained fraction, is about 0.3010309 or log 2.
+   * So the number within the bracket is the number of decimal digits encodable
+   * in an unsigned long.  Two extra bytes compensate the truncation error and
+   * leave space for a terminal NUL character.
    */
-  static char digits[(5 * sizeof(unsigned long)) / 2 + 2];
+  static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
 
   unsigned ofs = sizeof(digits) - 1;
   digits[ofs] = NUL;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -456,10 +456,9 @@ bool test_handleSubstitution1(char const* format, ...) {
 }
 
 bool test_handleSubstitution(void) {
-  bool result = test_handleSubstitution1(
+  return test_handleSubstitution1(
     "%s%s%s%s%u%u%u%s%%%;%",
     NULL, "", "abc", "%s", 0, 123, ~0u, "overflow");
-  return result;
 }
 
 void test_mmfatl(void) {

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -78,13 +78,12 @@
  * There exist no utoa in the C99 standard library, that could be used instead,
  * and sprintf must not be used in a memory-tight situation (AS Unsafe heap,
  * https://www.gnu.org/software/libc/manual/html_node/Formatted-Output-Functions.html).
- * \param value an unsigned long value to be converted to a string of decimal
- *   digits.
+ * \param value an unsigned value to convert.
  * \returns a pointer to a string converted from \p value.  Except for zero,
  *   the result has a leading non-zero digit.
  * \attention  The result is stable only until the next call to this function.
  */
-static char const* unsignedToString(unsigned long value) {
+static char const* unsignedToString(unsigned value) {
   /*
    * sizeof(unsigned long) * CHAR_BIT are the bits encodable in an unsigned long,
    * the factor 146/485, derived from a chained fraction, is about 0.3010309,
@@ -93,7 +92,7 @@ static char const* unsignedToString(unsigned long value) {
    * compensate for the truncation error of the division and allow for a
    * terminating NUL.
    */
-  static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
+  static char digits[(sizeof(value) * CHAR_BIT * 146) / 485 + 2];
 
   unsigned ofs = sizeof(digits) - 1;
   digits[ofs] = NUL;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -8,6 +8,9 @@
  * \file mmfatl.c a self-contained set of text printing routines using
  * dedicated pre-allocated memory, designed to likely run even under difficult
  * conditions (corrupt state, out of memory).
+ *
+ * C99 (https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf)
+ * compatible.
  */
 
 #include <limits.h>
@@ -26,8 +29,8 @@
 /*!
  * format placeholder character, not NUL
  */
-#define PLACEHOLDER_CHAR   '%'
-#define PLACEHOLDER_STRING "%"
+#define PLACEHOLDER_CHAR '%'
+#define PLACEHOLDER_STRING  "%"
 /*!
  * marks a string type in a placeholder substitution
  */
@@ -83,13 +86,13 @@
  */
 static char const* unsignedToString(unsigned long value) {
   /*
-   * sizeof(unsigned long) * CHAR_BIT are the bits available in an unsigned long,
+   * sizeof(unsigned long) * CHAR_BIT are the bits encodable in an unsigned long,
    * the factor 146/485, derived from a chained fraction, is about 0.3010309 or log 2.
-   * So the number within the brackets is the number of decimal digits encodable
-   * in an unsigned long.  Two extra bytes compensate the truncation error and
-   * allow for a terminating NUL character.
+   * So the number within the bracket is the number of decimal digits encodable
+   * in an unsigned long.  Two extra bytes compensate the truncation error in the
+   * division and allow for a terminating NUL character.
    */
-  static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
+  static char [(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
 
   unsigned ofs = sizeof(digits) - 1;
   digits[ofs] = NUL;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -19,15 +19,15 @@
 
 #if CHAR_BIT > 8
 /* C99 does not mandate a byte to be an octet, but such systems have become
- * really exotic nowadays.  If you really want to run Metamath, say, on a
+ * exotic nowadays.  If you really want to run Metamath, say, on a
  * CDC 3600 (wide spread in 1965), then you are a bit on your own here.
  * We recommend a contemporary machine type to achieve reasonable results.
  * 
  * Our assumption is CHAR_BIT == 8 from now on.  This allows us to map integer
  * limits roughly to required memory space.  We could alternatively evaluate
  * CHAR_BIT in the start-up phase of the program, and dynamically pre-allocate
- * memory accordingly to resolve these compatibility issues.  We think it is not
- * worth the effort.
+ * memory accordingly to resolve such compatibility issues.  Or introduce boost
+ * libraries to the same effect.  We think it is not worth the effort.
  */
 #   error "machine type not supported, expect a byte to be an octet."
 #endif

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -71,7 +71,7 @@
 
 /*!
  * converts an unsigned long to a sequence of decimal digits representing its
- * value.  The value range is known to be at least 2**32 by the C 99 Standard.
+ * value.  The value range is known to be at least 2**32 by the C99 standard.
  * We support unsigned long in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
  *

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -104,20 +104,17 @@ static char const* unsignedToString(unsigned long value) {
    */
   static char digits[(5 * sizeof(unsigned long)) / 2 + 2];
 
-  if (value == 0) {
-    digits[0] = '0';
-    digits[1] = NUL;
-  } else {
-    int ofs = sizeof(digits) - 1;
-    digits[ofs] = NUL;
+  unsigned ofs = sizeof(digits) - 1;
+  digits[ofs] = NUL;
+  if (value == 0)
+    digits[--ofs] = '0';
+  else {
     while (value) {
       digits[--ofs] = (value % 10) + '0';
       value /= 10;
     }
-    if (ofs > 0)
-      memmove(digits, digits + ofs, sizeof(digits) - ofs);
   }
-  return digits;
+  return digits + ofs;
 }
 
 /*!

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -27,7 +27,7 @@
  * Our assumption is CHAR_BIT == 8 from now on.  This allows us to map integer
  * limits roughly to required memory space.  We could alternatively evaluate
  * CHAR_BIT in the start-up phase of the program, and dynamically pre-allocate
- * memory accordingly to resolve such compatibility issues.  Or introduce boost
+ * memory accordingly to resolve such compatibility issues.  Or introduce Boost
  * preprocessor libraries to the same effect.  We think it is not worth the effort.
  */
 #   error "machine type not supported, expect a byte to be an octet."

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -71,9 +71,9 @@
 
 /*!
  * converts an unsigned to a sequence of decimal digits representing its value.
- * The value range is known to be at least 2**32 on contemporary hardware.
- * We support unsigned in formatted error output to allow for macros like
- * __LINE__ denoting error positions in text files.
+ * The value range is known to be at least 2**32 on contemporary hardware, but
+ * C99 guarantees just 2**16.  We support unsigned in formatted error output
+ * to allow for macros like __LINE__ denoting error positions in text files.
  *
  * There exist no utoa in the C99 standard library, that could be used instead,
  * and sprintf must not be used in a memory-tight situation (AS Unsafe heap,

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -387,25 +387,25 @@ bool test_handleSubstitution1(int dummy, ...) {
 
   // %s NULL
   initBuffer();
-  handleSubstitution(PLACEHOLDER_TYPE_STRING);
+  handleSubstitution();
   format += 2;
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "") == 0);
 
   // %s ""
-  handleSubstitution(PLACEHOLDER_TYPE_STRING);
+  handleSubstitution();
   format += 2;
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "") == 0);
 
   // %s "abc"
-  handleSubstitution(PLACEHOLDER_TYPE_STRING);
+  handleSubstitution();
   format += 2;
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "abc") == 0);
 
   // %s "%s"
-  handleSubstitution(PLACEHOLDER_TYPE_STRING);
+  handleSubstitution();
   format += 2;
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "abc%s") == 0);

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -70,9 +70,9 @@
 #define ELLIPSIS "..."
 
 /*!
- * converts an unsigned long to a sequence of decimal digits representing its
- * value.  The value range is known to be at least 2**32 by the C99 standard.
- * We support unsigned long in formatted error output to allow for macros like
+ * converts an unsigned to a sequence of decimal digits representing its value.
+ * The value range is known to be at least 2**32 on contemporary hardware.
+ * We support unsigned in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
  *
  * There exist no utoa in the C99 standard library, that could be used instead,
@@ -85,12 +85,11 @@
  */
 static char const* unsignedToString(unsigned value) {
   /*
-   * sizeof(unsigned long) * CHAR_BIT are the bits encodable in an unsigned long,
-   * the factor 146/485, derived from a chained fraction, is about 0.3010309,
-   * slightly greater than log 2.  So the number within the brackets is the
-   * count of decimal digits encodable in an unsigned long.  Two extra bytes
-   * compensate for the truncation error of the division and allow for a
-   * terminating NUL.
+   * sizeof(value) * CHAR_BIT are the bits encodable in value, the factor 146/485,
+   * derived from a chained fraction, is about 0.3010309, slightly greater than
+   * log 2.  So the number within the brackets is the count of decimal digits
+   * encodable in an unsigned long.  Two extra bytes compensate for the
+   * truncation error of the division and allow for a terminating NUL.
    */
   static char digits[(sizeof(value) * CHAR_BIT * 146) / 485 + 2];
 
@@ -415,7 +414,7 @@ bool test_handleSubstitution1(int dummy, ...) {
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "abc%s0123") == 0);
 
-  // %u ~0
+  // %u ~0u
   initBuffer();
   handleSubstitution();
   format += 2;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -85,7 +85,7 @@ static char const* unsignedToString(unsigned long value) {
   /*
    * sizeof(unsigned long) * CHAR_BIT are the bits available in an unsigned long,
    * the factor 146/485, derived from a chained fraction, is about 0.3010309 or log 2.
-   * So the number within the bracket is the number of decimal digits encodable
+   * So the number within the brackets is the number of decimal digits encodable
    * in an unsigned long.  Two extra bytes compensate the truncation error and
    * leave space for a terminal NUL character.
    */

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -85,8 +85,7 @@
 /*!
  * converts an unsigned long to a sequence of decimal digits representing its
  * value.  The value range is known to be at least 2^32 by the C Standard 99
- * .  We
- * support unsigned long in formatted error output to allow for macros like
+ * .  We support unsigned long in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
  *
  * There exist no utoa in the C99 standard library, that could be used instead,

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -243,25 +243,20 @@ static struct ParserInput state;
  * \post the substituted value is written to \ref buffer.
  * \post the format member in \ref state is skipped
  */
-static void handleSubstitution()
-{
+static void handleSubstitution(void) {
   char const* arg = PLACEHOLDER_STRING;  // default: no substitution case
   int advFormatPtr = 2; // advance by this many characters
-  switch (*(state.format + 1))
-  {
+  switch (*(state.format + 1)) {
     case PLACEHOLDER_TYPE_STRING:
       arg = va_arg(state.args, char const*);
       break;
-
     case PLACEHOLDER_TYPE_UNSIGNED:
       // a %u format specifier is recognized. 
       arg = unsignedToString(va_arg(state.args, unsigned));
       break;
-
     case PLACEHOLDER_CHAR:
       // %%
       break;
-
     default:;
       // stray %
       advFormatPtr = 1;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -87,10 +87,11 @@
 static char const* unsignedToString(unsigned long value) {
   /*
    * sizeof(unsigned long) * CHAR_BIT are the bits encodable in an unsigned long,
-   * the factor 146/485, derived from a chained fraction, is about 0.3010309 or log 2.
-   * So the number within the bracket is the number of decimal digits encodable
-   * in an unsigned long.  Two extra bytes compensate the truncation error in the
-   * division and allow for a terminating NUL character.
+   * the factor 146/485, derived from a chained fraction, is about 0.3010309,
+   * slightly greater than log 2.  So the number within the brackets is the
+   * count of decimal digits encodable in an unsigned long.  Two extra bytes
+   * compensate for the truncation error of the division and allow for a
+   * terminating NUL.
    */
   static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -196,9 +196,9 @@ static char const* appendText(char const* source, enum TextType type) {
 
 /*!
  * A simple grammar scheme allows inserting data in a prepared general message.
- * The scheme is a simple downgrade of the C format string.  Allowed are only
+ * The scheme is a downgrade of the C format string.  Allowed are only
  * placeholders %s and %u that are replaced with given data.  The percent sign
- * % is available through duplication %%.  For this kind of simple grammar 5
+ * % is available through duplication %%.  For this kind of grammar 4
  * separate process states are sufficient.
  */
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -86,9 +86,6 @@
  * (see https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf).  We
  * support unsigned long in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
- *
- * The alternative to this function is strtoul.  Unfortunately this library
- * function is tagged 'unsafe' under tight memory conditions.
  * \param value an unsigned long value to be converted to a string of decimal
  *   digits.
  * \returns a pointer to a string converted from \p value.  Except for zero,

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -19,10 +19,11 @@
 #include "mmfatl.h"
 
 #if CHAR_BIT != 8
-/* C99 does not mandate a byte to be an octet, but such systems have become
- * exotic nowadays.  If you really want to run Metamath, say, on a
- * CDC 3600 (wide spread in 1965), then you are a bit on your own here.
- * We recommend a contemporary machine type to achieve reasonable results.
+/* C99 (see https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf) does
+ * not mandate a byte to be an octet, but such systems have become exotic
+ * nowadays.  If you really want to run Metamath, say, on a CDC 3600 (wide
+ * spread in 1965), then you are a bit on your own here.  We recommend
+ * contemporary hardware to achieve reasonable results.
  * 
  * Our assumption is CHAR_BIT == 8 from now on.  This allows us to map integer
  * limits roughly to required memory space.  We could alternatively evaluate
@@ -30,7 +31,7 @@
  * memory accordingly to resolve such compatibility issues.  Or introduce Boost
  * preprocessor libraries to the same effect.  We think it is not worth the effort.
  */
-#   error "machine type not supported, expect a byte to be an octet."
+# error "machine type not supported, expect a byte to be an octet."
 #endif
 
 /*!
@@ -84,11 +85,13 @@
 /*!
  * converts an unsigned long to a sequence of decimal digits representing its
  * value.  The value range is known to be at least 2^32 by the C Standard 99
- * (see https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf).  We
+ * .  We
  * support unsigned long in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
  *
- * There exist no utoa in the C99 standard library, that could be used instead.
+ * There exist no utoa in the C99 standard library, that could be used instead,
+ * and sprintf must not be used in a memory-tight situation (AS Unsafe heap,
+ * https://www.gnu.org/software/libc/manual/html_node/Formatted-Output-Functions.html).
  * \param value an unsigned long value to be converted to a string of decimal
  *   digits.
  * \returns a pointer to a string converted from \p value.  Except for zero,
@@ -99,7 +102,7 @@ static char const* unsignedToString(unsigned long value) {
   /*
    * CHAR_BIT == 8 is assumed here, so a byte's capacity is that of an octet,
    * amounting to slightly less than 2.5 decimal digits per byte.  The two
-   * extra bytes compensate truncation errors, and allow for a terminating
+   * extra bytes compensate a truncation error, and allow for a terminating
    * NUL character.
    */
   static char digits[(5 * sizeof(unsigned long)) / 2 + 2];

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -368,6 +368,8 @@ bool test_unsignedToString(void)
   ASSERT(strcmp(unsignedToString(123), "123") == 0);
   // test max unsigned by converting back and forth
   ASSERT(strtoul(unsignedToString(~0u), NULL, 10) == ~0u);
+
+  return true;
 }
 
 bool test_handleSubstitution1(char const* format, ...) {

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -87,7 +87,7 @@ static char const* unsignedToString(unsigned long value) {
    * the factor 146/485, derived from a chained fraction, is about 0.3010309 or log 2.
    * So the number within the brackets is the number of decimal digits encodable
    * in an unsigned long.  Two extra bytes compensate the truncation error and
-   * leave space for a terminal NUL character.
+   * allow for a terminating NUL character.
    */
   static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
 


### PR DESCRIPTION
@digama0 ready to review and merge.  This PR adds a function handleSubstitution that later will be invoked when the parser encounters a % character during his scan of the format string.  The purpose of this function is to check the placeholder type, fetch a parameter from a va_arg list and write the parameter to the output buffer, so that it appears to be inserted.  Afterwards the scan pointer is updated to point behind the placeholder.  There are a couple of irregular situations that are also handled: a % not followed by a recognized type character, overflowing output buffer, and a NULL pointer as a parameter to a string placeholder. 