### PR TITLE
fatal error, implementation done

### DIFF
--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -92,7 +92,7 @@ static char const* unsignedToString(unsigned long value) {
    * in an unsigned long.  Two extra bytes compensate the truncation error in the
    * division and allow for a terminating NUL character.
    */
-  static char [(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
+  static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
 
   unsigned ofs = sizeof(digits) - 1;
   digits[ofs] = NUL;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -370,9 +370,9 @@ bool test_unsignedToString(void)
   ASSERT(strtoul(unsignedToString(~0u), NULL, 10) == ~0u);
 }
 
-bool test_handleSubstitution1(int dummy, ...) {
-  char const* format = state.format;
-  va_start(state.args, dummy);
+bool test_handleSubstitution1(char const* format, ...) {
+  state.format = format;
+  va_start(state.args, format);
   
   // without initializing the buffer each test appends
   // to the result of the former test.
@@ -456,8 +456,8 @@ bool test_handleSubstitution1(int dummy, ...) {
 }
 
 bool test_handleSubstitution(void) {
-  state.format = "%s%s%s%s%u%u%u%s%%%;%";
-  bool result = test_handleSubstitution1(0,
+  bool result = test_handleSubstitution1(
+    "%s%s%s%s%u%u%u%s%%%;%",
     NULL, "", "abc", "%s", 0, 123, ~0u, "overflow");
   return result;
 }

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -30,7 +30,7 @@
  * format placeholder character, not NUL
  */
 #define PLACEHOLDER_CHAR '%'
-#define PLACEHOLDER_STRING  "%"
+#define PLACEHOLDER_STRING "%"
 /*!
  * marks a string type in a placeholder substitution
  */
@@ -71,8 +71,8 @@
 
 /*!
  * converts an unsigned long to a sequence of decimal digits representing its
- * value.  The value range is known to be at least 2^32 by the C Standard 99
- * .  We support unsigned long in formatted error output to allow for macros like
+ * value.  The value range is known to be at least 2**32 by the C 99 Standard.
+ * We support unsigned long in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
  *
  * There exist no utoa in the C99 standard library, that could be used instead,
@@ -215,7 +215,7 @@ struct ParserInput {
 static struct ParserInput state;
 
 /*!
- * a format specifier is a two character combination, where a PLACEHOLDER_CHAR
+ * A format specifier is a two character combination, where a PLACEHOLDER_CHAR
  * is followed by an alphabetic character designating a type.  A placeholder
  * is substituted by the next argument in member *args* of \ref state.  This
  * function handles this substitution when member *format* of \ref state points

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -88,8 +88,8 @@ static char const* unsignedToString(unsigned value) {
    * sizeof(value) * CHAR_BIT are the bits encodable in value, the factor 146/485,
    * derived from a chained fraction, is about 0.3010309, slightly greater than
    * log 2.  So the number within the brackets is the count of decimal digits
-   * encodable in an unsigned long.  Two extra bytes compensate for the
-   * truncation error of the division and allow for a terminating NUL.
+   * encodable in value.  Two extra bytes compensate for the truncation error of
+   * the division and allow for a terminating NUL.
    */
   static char digits[(sizeof(value) * CHAR_BIT * 146) / 485 + 2];
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -451,6 +451,7 @@ bool test_handleSubstitution1(int dummy, ...) {
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "%%%") == 0);
 
+  va_end(state.args);
   return true;
 }
 
@@ -458,7 +459,6 @@ bool test_handleSubstitution(void) {
   state.format = "%s%s%s%s%u%u%u%s%%%;%";
   bool result = test_handleSubstitution1(0,
     NULL, "", "abc", "%s", 0, 123, ~0u, "overflow");
-  va_end(state.args);
   return result;
 }
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -246,7 +246,7 @@ static void handleSubstitution(void) {
     case PLACEHOLDER_CHAR:
       // %%
       break;
-    default:;
+    default:
       // stray %
       advFormatPtr = 1;
   }

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -18,7 +18,7 @@
 
 #include "mmfatl.h"
 
-#if CHAR_BIT > 8
+#if CHAR_BIT != 8
 /* C99 does not mandate a byte to be an octet, but such systems have become
  * exotic nowadays.  If you really want to run Metamath, say, on a
  * CDC 3600 (wide spread in 1965), then you are a bit on your own here.
@@ -28,7 +28,7 @@
  * limits roughly to required memory space.  We could alternatively evaluate
  * CHAR_BIT in the start-up phase of the program, and dynamically pre-allocate
  * memory accordingly to resolve such compatibility issues.  Or introduce boost
- * libraries to the same effect.  We think it is not worth the effort.
+ * preprocessor libraries to the same effect.  We think it is not worth the effort.
  */
 #   error "machine type not supported, expect a byte to be an octet."
 #endif

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -384,6 +384,9 @@ bool test_unsignedToString(void)
 bool test_handleSubstitution1(int dummy, ...) {
   char const* format = state.format;
   va_start(state.args, dummy);
+  
+  // without initializing the buffer each test appends
+  // to the result of the former test.
 
   // %s NULL
   initBuffer();

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -18,22 +18,6 @@
 
 #include "mmfatl.h"
 
-#if CHAR_BIT != 8
-/* C99 (see https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf) does
- * not mandate a byte to be an octet, but such systems have become exotic
- * nowadays.  If you really want to run Metamath, say, on a CDC 3600 (wide
- * spread in 1965), then you are a bit on your own here.  We recommend
- * contemporary hardware to achieve reasonable results.
- * 
- * Our assumption is CHAR_BIT == 8 from now on.  This allows us to map integer
- * limits roughly to required memory space.  We could alternatively evaluate
- * CHAR_BIT in the start-up phase of the program, and dynamically pre-allocate
- * memory accordingly to resolve such compatibility issues.  Or introduce Boost
- * preprocessor libraries to the same effect.  We think it is not worth the effort.
- */
-# error "machine type not supported, expect a byte to be an octet."
-#endif
-
 /*!
  * string terminating character
  */
@@ -42,8 +26,8 @@
 /*!
  * format placeholder character, not NUL
  */
-#define PLACEHOLDER_CHAR '%'
-#define PLACEHOLDER_STRING  "%"
+#define PLACEHOLDER_CHAR   '%'
+#define PLACEHOLDER_STRING "%"
 /*!
  * marks a string type in a placeholder substitution
  */
@@ -99,12 +83,13 @@
  */
 static char const* unsignedToString(unsigned long value) {
   /*
-   * CHAR_BIT == 8 is assumed here, so a byte's capacity is that of an octet,
-   * amounting to slightly less than 2.5 decimal digits per byte.  The two
-   * extra bytes compensate a truncation error, and allow for a terminating
-   * NUL character.
+   * sizeof(unsigned long) * CHAR_BIT are the bits available in an unsigned long,
+   * the factor 146/485, derived from a chained fraction, is about 0.3010309 or log 2.
+   * So the number within the bracket is the number of decimal digits encodable
+   * in an unsigned long.  Two extra bytes compensate the truncation error and
+   * leave space for a terminal NUL character.
    */
-  static char digits[(5 * sizeof(unsigned long)) / 2 + 2];
+  static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
 
   unsigned ofs = sizeof(digits) - 1;
   digits[ofs] = NUL;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -456,10 +456,9 @@ bool test_handleSubstitution1(char const* format, ...) {
 }
 
 bool test_handleSubstitution(void) {
-  bool result = test_handleSubstitution1(
+  return test_handleSubstitution1(
     "%s%s%s%s%u%u%u%s%%%;%",
     NULL, "", "abc", "%s", 0, 123, ~0u, "overflow");
-  return result;
 }
 
 void test_mmfatl(void) {

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -302,6 +302,8 @@ static void parse(char const* format) {
     else
       state.format += appendText(state.format, FORMAT);
   }
+  if (isBufferOverflow())
+    state.format += strlen(format);
 }
 
 // see header file for description
@@ -313,8 +315,6 @@ bool fatalErrorPush(char const* format, ...) {
     overflow = isBufferOverflow();
     va_end(state.args);
   }
-  if (isBufferOverflow())
-    format += strlen(format);
 
   return !overflow;
 }

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -78,13 +78,12 @@
  * There exist no utoa in the C99 standard library, that could be used instead,
  * and sprintf must not be used in a memory-tight situation (AS Unsafe heap,
  * https://www.gnu.org/software/libc/manual/html_node/Formatted-Output-Functions.html).
- * \param value an unsigned long value to be converted to a string of decimal
- *   digits.
+ * \param value an unsigned value to convert.
  * \returns a pointer to a string converted from \p value.  Except for zero,
  *   the result has a leading non-zero digit.
  * \attention  The result is stable only until the next call to this function.
  */
-static char const* unsignedToString(unsigned long value) {
+static char const* unsignedToString(unsigned value) {
   /*
    * sizeof(unsigned long) * CHAR_BIT are the bits encodable in an unsigned long,
    * the factor 146/485, derived from a chained fraction, is about 0.3010309,
@@ -93,7 +92,7 @@ static char const* unsignedToString(unsigned long value) {
    * compensate for the truncation error of the division and allow for a
    * terminating NUL.
    */
-  static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
+  static char digits[(sizeof(value) * CHAR_BIT * 146) / 485 + 2];
 
   unsigned ofs = sizeof(digits) - 1;
   digits[ofs] = NUL;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -8,6 +8,9 @@
  * \file mmfatl.c a self-contained set of text printing routines using
  * dedicated pre-allocated memory, designed to likely run even under difficult
  * conditions (corrupt state, out of memory).
+ *
+ * C99 (https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf)
+ * compatible.
  */
 
 #include <limits.h>
@@ -26,8 +29,8 @@
 /*!
  * format placeholder character, not NUL
  */
-#define PLACEHOLDER_CHAR   '%'
-#define PLACEHOLDER_STRING "%"
+#define PLACEHOLDER_CHAR '%'
+#define PLACEHOLDER_STRING  "%"
 /*!
  * marks a string type in a placeholder substitution
  */
@@ -83,13 +86,13 @@
  */
 static char const* unsignedToString(unsigned long value) {
   /*
-   * sizeof(unsigned long) * CHAR_BIT are the bits available in an unsigned long,
+   * sizeof(unsigned long) * CHAR_BIT are the bits encodable in an unsigned long,
    * the factor 146/485, derived from a chained fraction, is about 0.3010309 or log 2.
-   * So the number within the brackets is the number of decimal digits encodable
-   * in an unsigned long.  Two extra bytes compensate the truncation error and
-   * allow for a terminating NUL character.
+   * So the number within the bracket is the number of decimal digits encodable
+   * in an unsigned long.  Two extra bytes compensate the truncation error in the
+   * division and allow for a terminating NUL character.
    */
-  static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
+  static char [(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
 
   unsigned ofs = sizeof(digits) - 1;
   digits[ofs] = NUL;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -19,15 +19,15 @@
 
 #if CHAR_BIT > 8
 /* C99 does not mandate a byte to be an octet, but such systems have become
- * really exotic nowadays.  If you really want to run Metamath, say, on a
+ * exotic nowadays.  If you really want to run Metamath, say, on a
  * CDC 3600 (wide spread in 1965), then you are a bit on your own here.
  * We recommend a contemporary machine type to achieve reasonable results.
  * 
  * Our assumption is CHAR_BIT == 8 from now on.  This allows us to map integer
  * limits roughly to required memory space.  We could alternatively evaluate
  * CHAR_BIT in the start-up phase of the program, and dynamically pre-allocate
- * memory accordingly to resolve these compatibility issues.  We think it is not
- * worth the effort.
+ * memory accordingly to resolve such compatibility issues.  Or introduce boost
+ * libraries to the same effect.  We think it is not worth the effort.
  */
 #   error "machine type not supported, expect a byte to be an octet."
 #endif

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -71,7 +71,7 @@
 
 /*!
  * converts an unsigned long to a sequence of decimal digits representing its
- * value.  The value range is known to be at least 2**32 by the C 99 Standard.
+ * value.  The value range is known to be at least 2**32 by the C99 standard.
  * We support unsigned long in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
  *

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -160,22 +160,22 @@ static unsigned appendText(char const* source, char escape) {
  * state 1 is reached.
  */
 struct ParserState {
-    /*! 
-     * the next reading position in a NUL-terminated format string.  Will be
-     * consumed, i.e. scanned only once from begin to end.
-     * \invariant never NULL.
-     */
-    char const* format;
-    /*!
-     * the list of parameters substituting placeholders.  This structure allows
-     * traversing all entries.
-     *
-     * \invariant The parameters match the placeholders in \ref format in
-     * type, and their number is not less than that of the placeholders.
-     * This invariant cannot be verified at runtime in this module, but must be
-     * guaranteed on invocation by the caller.
-     */
-    va_list args;
+  /*! 
+   * the next reading position in a NUL-terminated format string.  Will be
+   * consumed, i.e. scanned only once from begin to end.
+   * \invariant never NULL.
+   */
+  char const* format;
+  /*!
+   * the list of parameters substituting placeholders.  This structure allows
+   * traversing all entries.
+   *
+   * \invariant The parameters match the placeholders in \ref format in
+   * type, and their number is not less than that of the placeholders.
+   * This invariant cannot be verified at runtime in this module, but must be
+   * guaranteed on invocation by the caller.
+   */
+  va_list args;
 };
 
 static struct ParserState state;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -104,20 +104,17 @@ static char const* unsignedToString(unsigned long value) {
    */
   static char digits[(5 * sizeof(unsigned long)) / 2 + 2];
 
-  if (value == 0) {
-    digits[0] = '0';
-    digits[1] = NUL;
-  } else {
-    int ofs = sizeof(digits) - 1;
-    digits[ofs] = NUL;
+  unsigned ofs = sizeof(digits) - 1;
+  digits[ofs] = NUL;
+  if (value == 0)
+    digits[--ofs] = '0';
+  else {
     while (value) {
       digits[--ofs] = (value % 10) + '0';
       value /= 10;
     }
-    if (ofs > 0)
-      memmove(digits, digits + ofs, sizeof(digits) - ofs);
   }
-  return digits;
+  return digits + ofs;
 }
 
 /*!

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -27,7 +27,7 @@
  * Our assumption is CHAR_BIT == 8 from now on.  This allows us to map integer
  * limits roughly to required memory space.  We could alternatively evaluate
  * CHAR_BIT in the start-up phase of the program, and dynamically pre-allocate
- * memory accordingly to resolve such compatibility issues.  Or introduce boost
+ * memory accordingly to resolve such compatibility issues.  Or introduce Boost
  * preprocessor libraries to the same effect.  We think it is not worth the effort.
  */
 #   error "machine type not supported, expect a byte to be an octet."

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -71,9 +71,9 @@
 
 /*!
  * converts an unsigned to a sequence of decimal digits representing its value.
- * The value range is known to be at least 2**32 on contemporary hardware.
- * We support unsigned in formatted error output to allow for macros like
- * __LINE__ denoting error positions in text files.
+ * The value range is known to be at least 2**32 on contemporary hardware, but
+ * C99 guarantees just 2**16.  We support unsigned in formatted error output
+ * to allow for macros like __LINE__ denoting error positions in text files.
  *
  * There exist no utoa in the C99 standard library, that could be used instead,
  * and sprintf must not be used in a memory-tight situation (AS Unsafe heap,

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -127,13 +127,12 @@ inline static bool isBufferOverflow() {
  * % is available through duplication %%.  For this kind of grammar 4
  * separate process states are sufficient, encoded in the \ref format pointer:
  *
- * 1. the format pointer is NULL (buffer overflow);
- * 2. the current format pointer points to \ref NUL (regular end of parse);
- * 3. the current format pointer points to a \ref MMFATL_PH_PREFIX;
- * 4. the current format pointer points to any other character;
+ * 1. the current format pointer points to \ref NUL (end of parse);
+ * 2. the current format pointer points to a \ref MMFATL_PH_PREFIX;
+ * 3. the current format pointer points to any other character;
  * 
- * During a parse, the state alternates between 3 and 4, until one of the
- * terminating states 1 or 2 is reached.
+ * During a parse, the state alternates between 2 and 3, until the terminating
+ * state 1 is reached.
  */
 struct ParserState {
     /*! 
@@ -314,6 +313,8 @@ bool fatalErrorPush(char const* format, ...) {
     overflow = isBufferOverflow();
     va_end(state.args);
   }
+  if (isBufferOverflow())
+    format += strlen(format);
 
   return !overflow;
 }

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -387,25 +387,25 @@ bool test_handleSubstitution1(int dummy, ...) {
 
   // %s NULL
   initBuffer();
-  handleSubstitution(PLACEHOLDER_TYPE_STRING);
+  handleSubstitution();
   format += 2;
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "") == 0);
 
   // %s ""
-  handleSubstitution(PLACEHOLDER_TYPE_STRING);
+  handleSubstitution();
   format += 2;
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "") == 0);
 
   // %s "abc"
-  handleSubstitution(PLACEHOLDER_TYPE_STRING);
+  handleSubstitution();
   format += 2;
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "abc") == 0);
 
   // %s "%s"
-  handleSubstitution(PLACEHOLDER_TYPE_STRING);
+  handleSubstitution();
   format += 2;
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "abc%s") == 0);

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -70,9 +70,9 @@
 #define ELLIPSIS "..."
 
 /*!
- * converts an unsigned long to a sequence of decimal digits representing its
- * value.  The value range is known to be at least 2**32 by the C99 standard.
- * We support unsigned long in formatted error output to allow for macros like
+ * converts an unsigned to a sequence of decimal digits representing its value.
+ * The value range is known to be at least 2**32 on contemporary hardware.
+ * We support unsigned in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
  *
  * There exist no utoa in the C99 standard library, that could be used instead,
@@ -85,12 +85,11 @@
  */
 static char const* unsignedToString(unsigned value) {
   /*
-   * sizeof(unsigned long) * CHAR_BIT are the bits encodable in an unsigned long,
-   * the factor 146/485, derived from a chained fraction, is about 0.3010309,
-   * slightly greater than log 2.  So the number within the brackets is the
-   * count of decimal digits encodable in an unsigned long.  Two extra bytes
-   * compensate for the truncation error of the division and allow for a
-   * terminating NUL.
+   * sizeof(value) * CHAR_BIT are the bits encodable in value, the factor 146/485,
+   * derived from a chained fraction, is about 0.3010309, slightly greater than
+   * log 2.  So the number within the brackets is the count of decimal digits
+   * encodable in an unsigned long.  Two extra bytes compensate for the
+   * truncation error of the division and allow for a terminating NUL.
    */
   static char digits[(sizeof(value) * CHAR_BIT * 146) / 485 + 2];
 
@@ -415,7 +414,7 @@ bool test_handleSubstitution1(int dummy, ...) {
   ASSERT(format == state.format);
   ASSERT(strcmp(buffer.text, "abc%s0123") == 0);
 
-  // %u ~0
+  // %u ~0u
   initBuffer();
   handleSubstitution();
   format += 2;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -349,7 +349,7 @@ bool fatalErrorPush(char const* format, ...) {
 }
 
 // see header file for a description
-void fatalErrorPrintAndExit()
+void fatalErrorPrintAndExit(void)
 {
 #ifndef TEST_ENABLE // we don't want a test program terminate here
   fputs(buffer.text, stderr);

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -85,7 +85,7 @@ static char const* unsignedToString(unsigned long value) {
   /*
    * sizeof(unsigned long) * CHAR_BIT are the bits available in an unsigned long,
    * the factor 146/485, derived from a chained fraction, is about 0.3010309 or log 2.
-   * So the number within the bracket is the number of decimal digits encodable
+   * So the number within the brackets is the number of decimal digits encodable
    * in an unsigned long.  Two extra bytes compensate the truncation error and
    * leave space for a terminal NUL character.
    */

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -85,8 +85,7 @@
 /*!
  * converts an unsigned long to a sequence of decimal digits representing its
  * value.  The value range is known to be at least 2^32 by the C Standard 99
- * .  We
- * support unsigned long in formatted error output to allow for macros like
+ * .  We support unsigned long in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
  *
  * There exist no utoa in the C99 standard library, that could be used instead,

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -243,25 +243,20 @@ static struct ParserInput state;
  * \post the substituted value is written to \ref buffer.
  * \post the format member in \ref state is skipped
  */
-static void handleSubstitution()
-{
+static void handleSubstitution(void) {
   char const* arg = PLACEHOLDER_STRING;  // default: no substitution case
   int advFormatPtr = 2; // advance by this many characters
-  switch (*(state.format + 1))
-  {
+  switch (*(state.format + 1)) {
     case PLACEHOLDER_TYPE_STRING:
       arg = va_arg(state.args, char const*);
       break;
-
     case PLACEHOLDER_TYPE_UNSIGNED:
       // a %u format specifier is recognized. 
       arg = unsignedToString(va_arg(state.args, unsigned));
       break;
-
     case PLACEHOLDER_CHAR:
       // %%
       break;
-
     default:;
       // stray %
       advFormatPtr = 1;

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -87,10 +87,11 @@
 static char const* unsignedToString(unsigned long value) {
   /*
    * sizeof(unsigned long) * CHAR_BIT are the bits encodable in an unsigned long,
-   * the factor 146/485, derived from a chained fraction, is about 0.3010309 or log 2.
-   * So the number within the bracket is the number of decimal digits encodable
-   * in an unsigned long.  Two extra bytes compensate the truncation error in the
-   * division and allow for a terminating NUL character.
+   * the factor 146/485, derived from a chained fraction, is about 0.3010309,
+   * slightly greater than log 2.  So the number within the brackets is the
+   * count of decimal digits encodable in an unsigned long.  Two extra bytes
+   * compensate for the truncation error of the division and allow for a
+   * terminating NUL.
    */
   static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -196,9 +196,9 @@ static char const* appendText(char const* source, enum TextType type) {
 
 /*!
  * A simple grammar scheme allows inserting data in a prepared general message.
- * The scheme is a simple downgrade of the C format string.  Allowed are only
+ * The scheme is a downgrade of the C format string.  Allowed are only
  * placeholders %s and %u that are replaced with given data.  The percent sign
- * % is available through duplication %%.  For this kind of simple grammar 5
+ * % is available through duplication %%.  For this kind of grammar 4
  * separate process states are sufficient.
  */
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -86,9 +86,6 @@
  * (see https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf).  We
  * support unsigned long in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
- *
- * The alternative to this function is strtoul.  Unfortunately this library
- * function is tagged 'unsafe' under tight memory conditions.
  * \param value an unsigned long value to be converted to a string of decimal
  *   digits.
  * \returns a pointer to a string converted from \p value.  Except for zero,

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -19,10 +19,11 @@
 #include "mmfatl.h"
 
 #if CHAR_BIT != 8
-/* C99 does not mandate a byte to be an octet, but such systems have become
- * exotic nowadays.  If you really want to run Metamath, say, on a
- * CDC 3600 (wide spread in 1965), then you are a bit on your own here.
- * We recommend a contemporary machine type to achieve reasonable results.
+/* C99 (see https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf) does
+ * not mandate a byte to be an octet, but such systems have become exotic
+ * nowadays.  If you really want to run Metamath, say, on a CDC 3600 (wide
+ * spread in 1965), then you are a bit on your own here.  We recommend
+ * contemporary hardware to achieve reasonable results.
  * 
  * Our assumption is CHAR_BIT == 8 from now on.  This allows us to map integer
  * limits roughly to required memory space.  We could alternatively evaluate
@@ -30,7 +31,7 @@
  * memory accordingly to resolve such compatibility issues.  Or introduce Boost
  * preprocessor libraries to the same effect.  We think it is not worth the effort.
  */
-#   error "machine type not supported, expect a byte to be an octet."
+# error "machine type not supported, expect a byte to be an octet."
 #endif
 
 /*!
@@ -84,11 +85,13 @@
 /*!
  * converts an unsigned long to a sequence of decimal digits representing its
  * value.  The value range is known to be at least 2^32 by the C Standard 99
- * (see https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1256.pdf).  We
+ * .  We
  * support unsigned long in formatted error output to allow for macros like
  * __LINE__ denoting error positions in text files.
  *
- * There exist no utoa in the C99 standard library, that could be used instead.
+ * There exist no utoa in the C99 standard library, that could be used instead,
+ * and sprintf must not be used in a memory-tight situation (AS Unsafe heap,
+ * https://www.gnu.org/software/libc/manual/html_node/Formatted-Output-Functions.html).
  * \param value an unsigned long value to be converted to a string of decimal
  *   digits.
  * \returns a pointer to a string converted from \p value.  Except for zero,
@@ -99,7 +102,7 @@ static char const* unsignedToString(unsigned long value) {
   /*
    * CHAR_BIT == 8 is assumed here, so a byte's capacity is that of an octet,
    * amounting to slightly less than 2.5 decimal digits per byte.  The two
-   * extra bytes compensate truncation errors, and allow for a terminating
+   * extra bytes compensate a truncation error, and allow for a terminating
    * NUL character.
    */
   static char digits[(5 * sizeof(unsigned long)) / 2 + 2];

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -368,6 +368,8 @@ bool test_unsignedToString(void)
   ASSERT(strcmp(unsignedToString(123), "123") == 0);
   // test max unsigned by converting back and forth
   ASSERT(strtoul(unsignedToString(~0u), NULL, 10) == ~0u);
+
+  return true;
 }
 
 bool test_handleSubstitution1(char const* format, ...) {

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -87,7 +87,7 @@ static char const* unsignedToString(unsigned long value) {
    * the factor 146/485, derived from a chained fraction, is about 0.3010309 or log 2.
    * So the number within the brackets is the number of decimal digits encodable
    * in an unsigned long.  Two extra bytes compensate the truncation error and
-   * leave space for a terminal NUL character.
+   * allow for a terminating NUL character.
    */
   static char digits[(sizeof(unsigned long) * CHAR_BIT * 146) / 485 + 2];
 

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -31,8 +31,8 @@
  * risk of a failure in a corrupted or memory-tight environment is minimized.
  * This is to the detriment of flexibility, in particular, support for dynamic
  * behavior is limited.  Many Standard C library functions like printf MUST NOT
- * be called when heap problems arise, since they use it internally.  GNU tags
- * such functions as 'AS-Unsafe heap' in their documentation (libc.pdf).
+ * be called when heap problems arise, since they use malloc internally.  GNU
+ * tags such functions as 'AS-Unsafe heap' in their documentation (libc.pdf).
  *
  * Often it is sensible to embed details in a diagnosis message.  Placeholders
  * in the format string mark insertion points for such values, much as in
@@ -44,6 +44,158 @@
  * is constructed.  In our context, this buffer is pre-allocated, and fixed in
  * size, truncation of overflowing text enforced.
  */
+
+/* the size a fatal error message including the terminating NUL character can
+ * assume without truncation. Must be in the range of an int.
+ */
+enum {
+  MMFATL_BUFFERSIZE = 1024,
+};
+
+/* the character sequence appended to a truncated fatal error message due to
+ * a buffer overflow, so a reader is aware a displayed text is incomplete.
+ */
+#define MMFATL_ELLIPSIS "..."
+
+/*!
+ * \brief Preparing internal data structures for an error message.
+ * 
+ * Empties the message buffer used to construct error messages by
+ * \ref fatalErrorPush.
+ *
+ * Prior to generating an error message some internal data structures need to
+ * be initialized.  Usually such initialization is automatically executed on
+ * program startup.  Since we are in a fatal error situation, we do not rely
+ * on this.  Instead we assume memory corruption has affected this module's
+ * data and renders its state useless.  So we initialize it immediately before
+ * the error message is generated.  Note that we still rely on part of the
+ * system be running.  We cannot overcome a fully clobbered system, we only
+ * can increase our chances of bypassing some degree of memory corruption.
+ * \post internal data structures are initialized and ready for constructing
+ *   a message from a format string and parameter values.
+
+ */
+
+extern void fatalErrorInit(void);
+
+/*!
+ * supported value types of a two character placeholder token in a format
+ * string.  The first character of a placeholder is always an escape
+ * character \ref MMFATL_PH_PREFIX, followed by one of the type characters
+ * mentioned here.  A valid placeholder in a format string is replaced with a
+ * submitted value during a parse phase.  The values in the enumeration here
+ * are all ASCII characters different from NUL, and distinct from each other.
+ *
+ * Two \ref MMFATL_PH_PREFIX in succession serve as a special token denoting
+ * the character \ref MMFATL_PH_PREFIX itself, as an ordinary text character.
+ * It is neither necessary nor allowed to provide a value for substitution
+ * in this particular case.
+ */
+enum fatalErrorPlaceholderType {
+  MMFATL_PH_PREFIX = '%', //!< escape character marking a placeholder
+  MMFATL_PH_STRING = 's', //<! type character marking a placeholder for a string
+  MMFATL_PH_UNSIGNED = 'u', //<! type character marking a placeholder for an unsigned
+};
+
+/*!
+ * \brief grammar support: generates a placeholder for insertion into a format
+ *   string.
+ *
+ * The placeholders in fatal errors are a subset of those used in the C library
+ * function printf.  A pedantic implementation might want Metamath generate
+ * placeholders to cover all exceptions, during an automatic message
+ * generation, instead of hardcoding them directly in the format string.
+ * \param type data type of the value replacing the placeholder in a format
+ *   string.  \ref MMFATL_PH_PREFIX is allowed as a type, yielding a token
+ *   standing for the character \ref MMFATL_PH_PREFIX itself.
+ * \return a placeholder of a supported type, or NULL, if you somehow
+ *   manage to dodge the C type checking.
+ * \attention the result is stable only until the next call to this
+ *   function.
+ */
+extern char const* fatalErrorPlaceholder(enum fatalErrorPlaceholderType aType);
+
+/*!
+ * \brief appends text to the current contents in the message buffer.
+ * 
+ * appends new text to the message buffer.  The submitted extra parameters
+ * following \p format must match the placeholders in the \p format string
+ * in type.  It is possible to add more parameters than necessary (they are
+ * simply ignored then), but never fewer.  The caller is responsible for
+ * this pre-condition, no runtime check is performed.
+ * 
+ * \param format [null] a format string usually containing NUL terminated
+ *   UTF-8 (superset of ASCII) encoded text, along with embedded placeholders,
+ *   that are replaced with parameters following \p format in the call.  The
+ *   replacements should not violate UTF-8, after being embedded in
+ *   surrounding text.  No runtime check is performed to ensure this rule.
+ *
+ *   A placeholder begins with an escape character \ref MMFATL_PH_PREFIX,
+ *   immediately followed by a type character.  Currently two types are
+ *   implemented \ref MMFATL_PH_STRING and \ref MMFATL_PH_UNSIGNED.
+ *
+ *   If you need a \ref MMFATL_PH_PREFIX verbatim in the error message, use
+ *   two \ref MMFATL_PH_PREFIX in succession.  They will automatically be
+ *   replaced with a single one.
+ *
+ *   NULL is equivalent to an empty format string, and supported both as a
+ *   \ref format string and as a parameter for a string placeholder, to
+ *   enhance robustness.
+ * 
+ * The \p format is followed by a possibly empty list of paramaters substituted
+ *   for placeholders.  Currently unsigned int values may replace a
+ *   \ref MMFATL_PH_UNSIGNED type placeholder, and a char const* pointer a
+ *   \ref MMFATL_PH_STRING type placeholder.  If the latter pointer is NULL,
+ *   the placeholder is replaced with an empty string, else it must point to a
+ *   UTF-8 encoded text.  No value is required for the \ref MMFATL_PH_PREFIX
+ *   type tokens.
+ * 
+ * \pre \p format if not NULL, contains NUL terminated UTF-8 text.
+ * \pre string parameters following
+ * \pre \ref fatalErrorInit was called before.
+ * \pre the submitted parameters following \p format must match in type the
+ *   placeholders in \p format.  Their count may exceed that of the
+ *   placeholders, but must never be less.  String parameters 
+ * \post the message is appended to the current buffer contents.  It is
+ *   truncated if there is insufficient space for it, including the
+ *   terminating NUL.
+ * \return false iff the message buffer is in overflow state.
+ */
+extern bool fatalErrorPush(char const* format, ...);
+
+/*!
+ * \brief display buffer contents and exit program with code EXIT_FAILURE.
+ * 
+ * This function does not return.
+ * 
+ * \pre \ref fatalErrorInit has initialized the internal error message
+ *   buffer possibly followed by a sequence of \ref fatalErrorPush
+ *   filling it with a message.
+ * \post [noreturn] the program terminates with an error code, after
+ *   writing the buffer contents to stderr.
+ */
+extern void fatalErrorPrintAndExit();
+
+/*!
+ * convenience function, covering a sequence of \ref fatalErrorInit,
+ * \ref fatalErrorPush and \ref fatalErrorPrintAndExit in succession.  This
+ * function does not return.
+ *
+ * \param file [null] filename of code responsible for calling this function,
+ *   suitable for macro __FILE__.  Part of an error location.
+ * \param line [unsigned] if greater 0, interpreted as a line number, where
+ *   a call to this function is initiated, suitable for macro __LINE__.
+ *   Part of an error location.
+ * \param msgWithPlaceholders the error message to display.  This message
+ *   may include placeholders, in which case it must be followed by more
+ *   parameters, corresponding to the values to replace the placeholders.
+ *   These values must match in type that of the placeholders, and there
+ *   must be enough to cover all placeholders.
+ * \post the program exits with failure code, after writing the error
+ *   location and message to stderr.
+ */
+extern void fatalErrorExitAt(char const* file, unsigned line,
+                             char const* msgWithPlaceholders, ...);
 
 #ifdef TEST_ENABLE
 

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -174,7 +174,7 @@ extern bool fatalErrorPush(char const* format, ...);
  * \post [noreturn] the program terminates with an error code, after
  *   writing the buffer contents to stderr.
  */
-extern void fatalErrorPrintAndExit();
+extern void fatalErrorPrintAndExit(void);
 
 /*!
  * convenience function, covering a sequence of \ref fatalErrorInit,


### PR DESCRIPTION
.. but for now not called from Metamath.

The implementation is completely hidden behind an interface.  So this sub-module is detached from the rest of Metamath, and both sides can be developed independently from each other, unless one part breaks the interface contract.

Note that this code is helpful, if it runs as desired, but it is not a critical part of Metamath.  It covers the fatal error path, which, if dysfunctional, is not really beyond annoying.  One could argue that the level of sophistication here is an overkill for this task.  Nevertheless, the self test suite and structured design technique would be nice if elsewhere employed as well.  During development this approach already caught bugs in an early phase, and my confidence in the code is high.  It successfully passed a compile with gcc flags -std=c99 and -pedantic.

What is still missing?  
1. It should be called from out-of-memory locations in Metamath.
2. Doxygen has not been tested with the comments.
3. UTF-8 support.

This will be part of the next pull request.
@digama0 Would be nice if at least one of the pull requests gets reviewed.  This pull request covers all of #104 .