### PR TITLE
fatal error handling, part 9

### DIFF
--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -333,7 +333,8 @@ static void parse(struct ParserState* state) {
  * not to be exposed through the interface.
  */
 
-char const* getFatalErrorPlaceholderToken(enum fatalErrorPlaceholderType type){
+char const* getFatalErrorPlaceholderToken(
+                    enum fatalErrorPlaceholderType type) {
 
   static char result[3];
 
@@ -369,6 +370,13 @@ bool fatalErrorPush(char const* format, ...) {
   }
 
   return !overflow;
+}
+
+void fatalErrorPrintAndExit(void) {
+#ifndef TEST_ENABLE // we don't want a test program terminate here
+  fputs(buffer.text, stderr);
+  exit(EXIT_FAILURE);
+#endif
 }
 
 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -17,6 +17,10 @@
  *   -DINLINE=inline -DTEST_ENABLE -c -o mmfatl.o ../src/mmfatl.c
  *
  * This should not produce an error or a warning.
+ *
+ * If you have Doxygen installed the parameter -d of the build.sh script
+ * generates a hyperlinked documentation from the comments both here and in the
+ * header file.
  */
 
 #include <limits.h>
@@ -91,9 +95,11 @@ struct Buffer {
 static struct Buffer buffer;
 
 /*!
+ * \brief initilize and empty the message buffer.
+ *
  * We do not rely on any initialization during program start.  Instead we
  * assume the worst case, a corrupted pointer overwrote the buffer.  So we
- * initialize it again immediately before use.
+ * initialize it immediately before use.
  * \pre the ellipsis appended to the writeable portion of the buffer must
  *   terminate with a LF, so printing a buffer in overflow state will keep
  *   a command prompt in a new line after program exit.
@@ -111,6 +117,8 @@ static void initBuffer(struct Buffer* buffer) {
 }
 
 /*!
+ * \brief checking the message buffer for emptiness
+ *
  * \param buffer [const, not null] the buffer to check for emptiness.
  * \return true, iff the \ref buffer is in its initial state.
  * \pre \ref initBuffer was called
@@ -120,6 +128,8 @@ inline static bool isBufferEmpty(struct Buffer const* buffer) {
 }
 
 /*!
+ * \brief last character in the message buffer
+ *
  * Get the last stored character in the buffer.  Discarded characters due to
  * overflow are ignored.  A returned NUL indicates the buffer is empty.
  * \param buffer [const, not null] the buffer to investigate.
@@ -131,6 +141,8 @@ static char getLastBufferedChar(struct Buffer const* buffer) {
 }
 
 /*!
+ * \brief check whether the buffer is overflown
+ *
  * \param buffer [const, not null] the buffer to check for overflow.
  * \return true, iff the current contents exceeds the capacity of the
  *   \ref buffer, so at least the terminating \ref NUL is cut off, maybe more.
@@ -141,6 +153,8 @@ inline static bool isBufferOverflow(struct Buffer const* buffer) {
 }
 
 /*!
+ * \brief modes to append text to the message buffer
+ *
  * used to indicate whether \ref MMFATL_PH_PREFIX is a normal character, or
  * an escape character in a format string.
  */
@@ -150,6 +164,8 @@ enum SourceType {
 };
 
 /*!
+ * \brief append text to the current contents of the message buffer
+ *
  * append characters to the current end of the buffer from a string until a
  * terminating \ref NUL, or optionally a placeholder is encountered, or the
  * buffer overflows.
@@ -170,6 +186,8 @@ static unsigned appendText(char const* source, enum SourceType type,
 }
 
 /*!
+ * \brief state of the parser scanning a formatted message in printf style
+ *
  * A simple grammar scheme allows inserting data in a prepared general message.
  * The scheme is a downgrade of the C format string.  Allowed are only
  * placeholders %s and %u that are replaced with given data.  The percent sign
@@ -211,6 +229,8 @@ struct ParserState {
 static struct ParserState state;
 
 /*!
+ * \brief initializes the parser state (but not the associated message buffer!)
+ *
  * initializes \ref state.
  * \post establish the invariant in state
  * \param state [not null] the struct \ref ParserState to initialize.
@@ -224,6 +244,8 @@ static void initState(struct ParserState* state, struct Buffer* buffer) {
 }
 
 /*!
+ * \brief converting an unsigned to a string of decimal numbers
+ *
  * converts an unsigned to a sequence of decimal digits representing its value.
  * The value range is known to be at least 2**32 on contemporary hardware, but
  * C99 guarantees just 2**16.  We support unsigned in formatted error output
@@ -260,7 +282,10 @@ static char const* unsignedToString(unsigned value) {
   return digits + ofs;
 }
 
-/*! reflect a possible buffer overflow in the parser state
+/*!
+ * \brief update the parser state in case of message buffer overflow
+ *
+ * reflect a possible buffer overflow in the parser state
  * \param state [not null] ParserState object being updated in case of
  *   overflow
  * \return false in case of overflow
@@ -275,6 +300,8 @@ static bool checkOverflow(struct ParserState* state) {
 }
 
 /*!
+ * \brief copy a portion of text verbatim to the message buffer
+ *
  * copy text verbatim from a format string to the message buffer, until either
  * the format ends, or a placeholder is encountered.
  * \param state struct ParserState* parser state going to be handled and updated
@@ -290,6 +317,8 @@ static void handleText(struct ParserState* state) {
 }
 
 /*!
+ * \brief handle a placeholder in a formatted message
+ *
  * A format specifier is a two character combination, where a placeholder
  * character \ref MMFATL_PH_PREFIX is followed by an alphabetic character
  * designating a type.  A placeholder is substituted by the next argument in
@@ -342,6 +371,8 @@ static void handleSubstitution(struct ParserState* state) {
 }
 
 /*!
+ * \brief convert a formatted message to human readable text
+ *
  * parses the submitted format string, replacing each placeholder with one of
  * the values in member args of \ref state, and appends the result to the
  * current contents of \ref buffer.
@@ -386,6 +417,8 @@ char const* getFatalErrorPlaceholderToken(
 }
 
 /*!
+ * \brief get the message buffer instance
+ *
  * gets the instance of Buffer to use with this interface (currently a global
  * singleton).  The returned instance is not guaranteed to be initialized.
  * \return [not null] a pointer to the Buffer instance
@@ -395,6 +428,8 @@ inline static struct Buffer* getBufferInstance(void) {
 }
 
 /*!
+ * \brief get the parser state instance
+ *
  * gets the instance of ParserState to use with this interface (currently a
  * global singleton).  The returned instance is not guaranteed to be
  * initialized.

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -40,8 +40,8 @@ enum {
 
 
 /*!
- * \brief declares a buffer used to generate a text message through a
- * formatting procedure.
+ * \brief a buffer used to generate a text message through a formatting
+ * procedure.
  *
  * This buffer type is used to send a final diagnostic message to the user,
  * before the program dies because of insufficient, or even corrupt memory.
@@ -91,7 +91,7 @@ struct Buffer {
 static struct Buffer buffer;
 
 /*!
- * \brief initilize and empty the message buffer.
+ * \brief initialize and empty the message buffer
  *
  * We do not rely on any initialization during program start.  Instead we
  * assume the worst case, a corrupted pointer overwrote the buffer.  So we
@@ -113,7 +113,7 @@ static void initBuffer(struct Buffer* buffer) {
 }
 
 /*!
- * \brief checking the message buffer for emptiness
+ * \brief check the message buffer for emptiness
  *
  * \param buffer [const, not null] the buffer to check for emptiness.
  * \return true, iff the \ref buffer is in its initial state.
@@ -149,9 +149,9 @@ inline static bool isBufferOverflow(struct Buffer const* buffer) {
 }
 
 /*!
- * \brief modes to append text to the message buffer
+ * \brief modes of appending text to the message buffer
  *
- * used to indicate whether \ref MMFATL_PH_PREFIX is a normal character, or
+ * Used to indicate whether \ref MMFATL_PH_PREFIX is a normal character, or
  * an escape character in a format string.
  */
 enum SourceType {
@@ -162,7 +162,7 @@ enum SourceType {
 /*!
  * \brief append text to the current contents of the message buffer
  *
- * append characters to the current end of the buffer from a string until a
+ * Append characters to the current end of the buffer from a string until a
  * terminating \ref NUL, or optionally a placeholder is encountered, or the
  * buffer overflows.
  * \param source [not null] the source from which bytes are copied.
@@ -225,9 +225,9 @@ struct ParserState {
 static struct ParserState state;
 
 /*!
- * \brief initializes the parser state (but not the associated message buffer!)
+ * \brief initialize the parser state (but not the associated message buffer!)
  *
- * initializes \ref state.
+ * Initializes \ref state.
  * \post establish the invariant in state
  * \param state [not null] the struct \ref ParserState to initialize.
  * \param buffer [not null] the buffer to use for output 
@@ -240,9 +240,9 @@ static void initState(struct ParserState* state, struct Buffer* buffer) {
 }
 
 /*!
- * \brief converting an unsigned to a string of decimal numbers
+ * \brief convert an unsigned to a string of decimal numbers
  *
- * converts an unsigned to a sequence of decimal digits representing its value.
+ * Converts an unsigned to a sequence of decimal digits representing its value.
  * The value range is known to be at least 2**32 on contemporary hardware, but
  * C99 guarantees just 2**16.  We support unsigned in formatted error output
  * to allow for macros like __LINE__ denoting error positions in text files.
@@ -281,7 +281,7 @@ static char const* unsignedToString(unsigned value) {
 /*!
  * \brief update the parser state in case of message buffer overflow
  *
- * reflect a possible buffer overflow in the parser state
+ * Reflect a possible buffer overflow in the parser state
  * \param state [not null] ParserState object being updated in case of
  *   overflow
  * \return false in case of overflow
@@ -298,7 +298,7 @@ static bool checkOverflow(struct ParserState* state) {
 /*!
  * \brief copy a portion of text verbatim to the message buffer
  *
- * copy text verbatim from a format string to the message buffer, until either
+ * Copy text verbatim from a format string to the message buffer, until either
  * the format ends, or a placeholder is encountered.
  * \param state struct ParserState* parser state going to be handled and updated
  * \pre \ref initState was called
@@ -369,7 +369,7 @@ static void handleSubstitution(struct ParserState* state) {
 /*!
  * \brief convert a formatted message to human readable text
  *
- * parses the submitted format string, replacing each placeholder with one of
+ * Parses the submitted format string, replacing each placeholder with one of
  * the values in member args of \ref state, and appends the result to the
  * current contents of \ref buffer.
  * \param state struct ParserState* parser state going to be handled and updated
@@ -415,7 +415,7 @@ char const* getFatalErrorPlaceholderToken(
 /*!
  * \brief get the message buffer instance
  *
- * gets the instance of Buffer to use with this interface (currently a global
+ * Gets the instance of Buffer to use with this interface (currently a global
  * singleton).  The returned instance is not guaranteed to be initialized.
  * \return [not null] a pointer to the Buffer instance
  */
@@ -426,7 +426,7 @@ inline static struct Buffer* getBufferInstance(void) {
 /*!
  * \brief get the parser state instance
  *
- * gets the instance of ParserState to use with this interface (currently a
+ * Gets the instance of ParserState to use with this interface (currently a
  * global singleton).  The returned instance is not guaranteed to be
  * initialized.
  * \return [not null] a pointer to the ParserState instance 

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -96,7 +96,7 @@ static struct Buffer buffer;
  * initialize it again immediately before use.
  * \pre the ellipsis appended to the writeable portion of the buffer must
  *   terminate with a LF, so printing a buffer in overflow state will keep
- *   a command prompt in a new line ater program exit.
+ *   a command prompt in a new line after program exit.
  * \post \ref buffer is initialized with all NUL characters, so NUL need
  *   not be copied
  * \param buffer [not null] the output buffer to empty and initialize

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -17,10 +17,6 @@
  *   -DINLINE=inline -DTEST_ENABLE -c -o mmfatl.o ../src/mmfatl.c
  *
  * This should not produce an error or a warning.
- *
- * If you have Doxygen installed the parameter -d of the build.sh script
- * generates a hyperlinked documentation from the comments both here and in the
- * header file.
  */
 
 #include <limits.h>

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -261,28 +261,6 @@ static bool checkOverflow(struct ParserState* state) {
 }
 
 /*!
- * \brief Preparing internal data structures for an error message.
- *
- * Empties the message buffer used to construct error messages.
- *
- * Prior to generating an error message some internal data structures need to
- * be initialized.  Usually such initialization is automatically executed on
- * program startup.  Since we are in a fatal error situation, we do not rely
- * on this.  Instead we assume memory corruption has affected this module's
- * data and renders its state useless.  So we initialize it immediately before
- * the error message is generated.  Note that we still rely on part of the
- * system be running.  We cannot overcome a fully clobbered system, we only
- * can increase our chances of bypassing some degree of memory corruption.
- *
- * \post internal data structures are initialized and ready for constructing
- *   a message from a format string and parameter values.
- */
-static void fatalErrorInit(void) {
-  initBuffer(&buffer);
-  initState(&state, &buffer);
-}
-
-/*!
  * copy text verbatim from a format string to the message buffer, until either
  * the format ends, or a placeholder is encountered.
  * \post member format of \ref state is advanced over the copied text, if no
@@ -384,6 +362,12 @@ char const* getFatalErrorPlaceholderToken(enum fatalErrorPlaceholderType type){
   }
   return result;
 }
+
+void fatalErrorInit(void) {
+  initBuffer(&buffer);
+  initState(&state, &buffer);
+}
+
 
 //=================   Regression tests   =====================
 

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -62,13 +62,17 @@
  * is constructed.  In our context, this buffer is pre-allocated, fixed in
  * size, and truncation of overflowing text enforced.
  *
- * It is not possible to simply reset memory in a memory tight situation, for
- * two reasons:
+ * Implementation hint
+ * -------------------
+ *
+ * In a memory tight situation we cannot reset the memory heap to free space
+ * again, even though we are about to exit program execution, for two reasons:
  *   - We want to gather diagnostic information, so the program structures need
- *     to be left intact;
+ *     to be intact;
  *   - The fatal error routines need not be the last portion of the program
- *     executed.  If a function is registered with atexit, it is called after an
- *     exit is triggered, and this function may rely on allocated program data.
+ *     executing.  If a function is registered with \p atexit, it is called
+ *     after an exit is triggered, and this function may rely on allocated
+ *     data.
  */
 
 /***   Export basic features of the fatal error message processing   ***/
@@ -248,7 +252,7 @@ extern bool fatalErrorPush(char const* format, ...);
  * \invariant the memory state of the rest of the program is not changed.
  * \warning the output is to stderr, not to stdout.  As long as you do not
  *   redirect stderr to, say, a log file, the error message is displayed to the
- *   user on his terminal.
+ *   user on the terminal.
  * \warning previous versions of Metamath returned the exit code 1.  Many
  *   systems define EXIT_FAILURE to this very value, but that is not mandated
  *   by the C11 standard.  In fact, some systems may interpret 1 as a success

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -61,6 +61,14 @@
  * For this kind of expansion you still need a buffer where the final message
  * is constructed.  In our context, this buffer is pre-allocated, fixed in
  * size, and truncation of overflowing text enforced.
+ *
+ * It is not possible to simply reset memory in a memory tight situation, for
+ * two reasons:
+ *   - We want to gather diagnostic information, so the program structures need
+ *     to be left intact;
+ *   - The fatal error routines need not be the last portion of the program
+ *     executed.  If a function is registered with atexit, it is called after an
+ *     exit is triggered, and this function may rely on allocated program data.
  */
 
 /***   Export basic features of the fatal error message processing   ***/
@@ -146,6 +154,7 @@ extern char const* getFatalErrorPlaceholderToken(
  * \post internal data structures are initialized and ready for constructing
  *   a message from a format string and parameter values.  Any previous
  *   contents is discarded.
+ * \invariant the memory state of the rest of the program is not changed.
  */
 extern void fatalErrorInit(void);
 
@@ -201,6 +210,7 @@ extern void fatalErrorInit(void);
  * \post the message is appended to the current buffer contents.  It is
  *   truncated if there is insufficient space for it, including the
  *   terminating NUL.
+ * \invariant the memory state of the rest of the program is not changed.
  * \warning This function does not automatically wrap messages and insert LF
  *   characters at the end of the declared screen width (g_screenWidth in
  *   mminou.h) as print2 does.  Tests show that usual terminal emulators break
@@ -235,10 +245,10 @@ extern bool fatalErrorPush(char const* format, ...);
  *   writing the buffer contents to stderr.
  * \post a line feed is appended to any non-empty message, if it is not
  *   provided
- * \warning
- *   the output is to stderr, not to stdout.  As long as you do not redirect
- *   stderr to, say, a log file, the error message is displayed to the user on
- *   his terminal.
+ * \invariant the memory state of the rest of the program is not changed.
+ * \warning the output is to stderr, not to stdout.  As long as you do not
+ *   redirect stderr to, say, a log file, the error message is displayed to the
+ *   user on his terminal.
  * \warning previous versions of Metamath returned the exit code 1.  Many
  *   systems define EXIT_FAILURE to this very value, but that is not mandated
  *   by the C11 standard.  In fact, some systems may interpret 1 as a success
@@ -283,6 +293,7 @@ extern void fatalErrorPrintAndExit(void);
  *   if NULL.
  * \post the program exits with EXIT_FAILURE return code, after writing the
  *   error location and message to stderr.
+ * \invariant the memory state of the rest of the program is not changed.
  */
 extern void fatalErrorExitAt(char const* file, unsigned line,
                              char const* msgWithPlaceholders, ...);

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -169,6 +169,11 @@ extern void fatalErrorInit(void);
  * \post the message is appended to the current buffer contents.  It is
  *   truncated if there is insufficient space for it, including the
  *   terminating NUL.
+ * \warning This function does not automatically wrap messages and insert LF
+ *   characters at the end of the declared screen width (g_screenWidth in
+ *   mminou.h) as print2 does.  Tests show that usual terminal emulators break
+ *   up text at the last column, but that may depend on the used
+ *   hard-/software.
  * \return false iff the message buffer is in overflow state.
  */
 
@@ -182,6 +187,14 @@ extern void fatalErrorInit(void);
  *   filling it with a message.
  * \post [noreturn] the program terminates with error code EXIT_FAILURE, after
  *   writing the buffer contents to stderr.
+ * \warning
+ *   the output is to stderr, not to stdout.  As long as you do not redirect
+ *   stderr to, say, a log file, the error message is displayed to the user on
+ *   his terminal.
+ * \warning previous versions of Metamath returned the exit code 1.  Many
+ *   implementations define EXIT_FAILURE to this very value, but that is not
+ *   mandated by the C11 standard.  In fact, some systems may interpret 1 as a
+ *   success code, so EXIT_FAILURE is more appropriate.
  */
 extern void fatalErrorPrintAndExit(void);
 
@@ -199,9 +212,10 @@ extern void fatalErrorPrintAndExit(void);
  *   may include placeholders, in which case it must be followed by more
  *   parameters, corresponding to the values to replace the placeholders.
  *   These values must match in type that of the placeholders, and their
- *   number must be enough (can be more) to cover all placeholders.
- * \post the program exits with failure code, after writing the error
- *   location and message to stderr.
+ *   number must be enough (can be more) to cover all placeholders.  The
+ *   details of this process is explained in \ref fatalErrorPush.
+ * \post the program exits with EXIT_FAILURE return code, after writing the
+ *   error location and message to stderr.
  */
 extern void fatalErrorExitAt(char const* file, unsigned line,
                              char const* msgWithPlaceholders, ...);

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -27,23 +27,28 @@
  * self-contained routines, independent of the rest of the program to the
  * extent possible, thus avoiding any corrupted data.
  *
- * In particular everything should be pre-allocated and initialized, so the
- * risk of a failure in a corrupted or memory-tight environment is minimized.
- * This is to the detriment of flexibility, in particular, support for dynamic
- * behavior is limited.  Many Standard C library functions like printf MUST NOT
- * be called when heap problems arise, since they use it internally.  GNU tags
- * such functions as 'AS-Unsafe heap' in their documentation (libc.pdf).
+ * In particular everything should be pre-allocated, so the risk of a failure
+ * in a corrupted or memory-tight environment is minimized.  This is to the
+ * detriment of flexibility, in particular, support for dynamic behavior is
+ * limited.  Many Standard C library functions like printf MUST NOT be called
+ * when heap problems arise, since they use it internally.  GNU tags such
+ * functions as 'AS-Unsafe heap' in their documentation (libc.pdf).
  *
  * Often it is sensible to embed details in a diagnosis message.  Placeholders
  * in the format string mark insertion points for such values, much as in
  * \p printf. The variety and functionality is greatly reduced in our case,
  * though.  Only pieces of text or unsigned integers can be embedded
- * (%s or %u placeholder).
+ * (%s or %u placeholder).  This is sufficient to embed an error location
+ * given by __FILE__ and __LINE__ into the message.
  *
  * For this kind of expansion you still need a buffer where the final message
  * is constructed.  In our context, this buffer is pre-allocated, and fixed in
  * size, truncation of overflowing text enforced.
  */
+
+
+/***   Export basic features of the fatal error message processing   ***/
+
 
 /*! the size a fatal error message including the terminating NUL character can
  * assume without truncation. Must be in the range of an int.
@@ -52,8 +57,8 @@ enum {
   MMFATL_MAX_MSG_SIZE = 1024,
 };
 
-/* the character sequence appended to a truncated fatal error message due to
- * a buffer overflow, so a reader is aware a displayed text is incomplete.
+/*! the character sequence appended to a truncated fatal error message due to
+ * a buffer overflow, so its reader is aware a displayed text is incomplete.
  */
 #define MMFATL_ELLIPSIS "..."
 
@@ -63,7 +68,7 @@ enum {
  * character \ref MMFATL_PH_PREFIX, followed by one of the type characters
  * mentioned here.  A valid placeholder in a format string is replaced with a
  * submitted value during a parse phase.  The values in the enumeration here
- * are all ASCII characters different from NUL, and distinct from each other.
+ * are all ASCII characters different from NUL, and mutally distinct.
  *
  * Two \ref MMFATL_PH_PREFIX in succession serve as a special token denoting
  * the character \ref MMFATL_PH_PREFIX itself, as an ordinary text character.
@@ -71,7 +76,8 @@ enum {
  * in this particular case.
  */
 enum fatalErrorPlaceholderType {
-  MMFATL_PH_PREFIX = '%', //!< escape character marking a placeholder
+   //! escape character marking a placeholder
+  MMFATL_PH_PREFIX = '%',
   //! type character marking a placeholder for a string
   MMFATL_PH_STRING = 's',
   //! type character marking a placeholder for an unsigned

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -76,7 +76,7 @@
  *     data.
  */
 
-/***   Export basic features of the fatal error message processing   ***/
+// ***   Export basic features of the fatal error message processing   ***/
 
 
 /*!
@@ -123,7 +123,7 @@ enum fatalErrorPlaceholderType {
   MMFATL_PH_UNSIGNED = 'u',
 };
 
-/***   Interface of fatal error message processing   ***/
+// ***   Interface of fatal error message processing   ***/
 
 
 /*!

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -185,6 +185,27 @@ extern void fatalErrorInit(void);
  */
 extern void fatalErrorPrintAndExit(void);
 
+/*!
+ * convenience function, covering a sequence of \ref fatalErrorInit,
+ * \ref fatalErrorPush and \ref fatalErrorPrintAndExit in succession.  This
+ * function does not return.
+ *
+ * \param file [null] filename of code responsible for calling this function,
+ *   suitable for macro __FILE__.  Part of an error location.
+ * \param line [unsigned] if greater 0, interpreted as a line number, where
+ *   a call to this function is initiated, suitable for macro __LINE__.
+ *   Part of an error location.
+ * \param msgWithPlaceholders the error message to display.  This message
+ *   may include placeholders, in which case it must be followed by more
+ *   parameters, corresponding to the values to replace the placeholders.
+ *   These values must match in type that of the placeholders, and their
+ *   number must be enough (can be more) to cover all placeholders.
+ * \post the program exits with failure code, after writing the error
+ *   location and message to stderr.
+ */
+extern void fatalErrorExitAt(char const* file, unsigned line,
+                             char const* msgWithPlaceholders, ...);
+
 #ifdef TEST_ENABLE
 
 extern void test_mmfatl(void);

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -47,9 +47,9 @@
  * In particular everything should be pre-allocated, so the risk of a failure
  * in a corrupted or memory-tight environment is minimized.  This is to the
  * detriment of flexibility, in particular, support for dynamic behavior is
- * limited.  Many Standard C library functions like printf MUST NOT be called
- * when heap problems arise, since they rely on it internally.  GNU tags such
- * functions as 'AS-Unsafe heap' in their documentation (libc.pdf).
+ * limited.  Many Standard C library functions like \p printf MUST NOT be
+ * called when heap problems arise, since they rely on it internally.  GNU tags
+ * such functions as 'AS-Unsafe heap' in their documentation (libc.pdf).
  *
  * Often it is sensible to embed details in a diagnosis message.  Placeholders
  * in the format string mark insertion points for such values, much as in
@@ -65,8 +65,9 @@
  * Implementation hint
  * -------------------
  *
- * In a memory tight situation we cannot reset the memory heap to free space
- * again, even though we are about to exit program execution, for two reasons:
+ * In a memory tight situation we cannot reset the memory heap, or stack, to
+ * have free space again for, say, \p printf, even though we are about to exit
+ * program execution, for two reasons:
  *   - We want to gather diagnostic information, so the program structures need
  *     to be intact;
  *   - The fatal error routines need not be the last portion of the program
@@ -121,6 +122,9 @@ enum fatalErrorPlaceholderType {
   //! type character marking a placeholder for an unsigned
   MMFATL_PH_UNSIGNED = 'u',
 };
+
+/***   Interface of fatal error message processing   ***/
+
 
 /*!
  * \brief grammar support: generate a placeholder token for insertion into a
@@ -250,6 +254,10 @@ extern bool fatalErrorPush(char const* format, ...);
  * \post a line feed is appended to any non-empty message, if it is not
  *   provided
  * \invariant the memory state of the rest of the program is not changed.
+ * \attention Although this function does not return to the caller, we must not
+ *   assume it is the last piece of program code executing.  A function
+ *   registered with \p atexit executes after \p exit is triggered.  That is
+ *   why the above invariant is important to keep.
  * \warning the output is to stderr, not to stdout.  As long as you do not
  *   redirect stderr to, say, a log file, the error message is displayed to the
  *   user on the terminal.

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -84,6 +84,25 @@ enum fatalErrorPlaceholderType {
   MMFATL_PH_UNSIGNED = 'u',
 };
 
+/*!
+ * \brief grammar support: generates a placeholder token for insertion into a
+ *   format string.
+ *
+ * The placeholders in fatal errors are a subset of those used in the C library
+ * function printf.  A flexible implementation might want to query placeholder
+ * tokens during an automatic message generation, rather than hardcoding them
+ * directly in the format string.
+ * \param type data type of the value replacing the placeholder in a format
+ *   string.  \ref MMFATL_PH_PREFIX is allowed as a type, yielding a token
+ *   standing for the character \ref MMFATL_PH_PREFIX itself.
+ * \return a placeholder of a supported type, or NULL, if you somehow
+ *   manage to dodge C type checking.
+ * \attention the result is stable only until the next call to this
+ *   function.
+ */
+extern char const* getFatalErrorPlaceholderToken(
+                enum fatalErrorPlaceholderType aType);
+
 
 #ifdef TEST_ENABLE
 

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -59,8 +59,10 @@ enum {
 
 /*! the character sequence appended to a truncated fatal error message due to
  * a buffer overflow, so its reader is aware a displayed text is incomplete.
+ * The ellipsis is followed by a line feed to seprate the message from the
+ * command prompt following an exit.
  */
-#define MMFATL_ELLIPSIS "..."
+#define MMFATL_ELLIPSIS "...\n"
 
 /*!
  * supported value types of a two character placeholder token in a format
@@ -151,6 +153,9 @@ extern void fatalErrorInit(void);
  *   NULL is equivalent to an empty format string, and supported both as a
  *   \ref format string and as a parameter for a string placeholder, to
  *   enhance robustness.
+ *
+ *   It is recommended to let the message end with a LF character, so a command
+ *   prompt following it is displayed on a new line.
  * 
  * The \p format is followed by a possibly empty list of paramaters substituted
  *   for placeholders.  Currently unsigned int values may replace a

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -94,7 +94,7 @@ enum fatalErrorPlaceholderType {
  * function printf.  A flexible implementation might want to query placeholder
  * tokens during an automatic message generation, rather than hardcoding them
  * directly in the format string.
- * \param type data type of the value replacing the placeholder in a format
+ * \param aType data type of the value replacing the placeholder in a format
  *   string.  \ref MMFATL_PH_PREFIX is allowed as a type, yielding a token
  *   standing for the character \ref MMFATL_PH_PREFIX itself.
  * \return a placeholder of a supported type, or NULL, if you somehow

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -124,6 +124,54 @@ extern char const* getFatalErrorPlaceholderToken(
 extern void fatalErrorInit(void);
 
 
+/*!
+ * \brief appends text to the current contents in the message buffer.
+ * 
+ * appends new text to the message buffer.  The submitted extra parameters
+ * following \p format must match the placeholders in the \p format string
+ * in type.  It is possible to add more parameters than necessary (they are
+ * simply ignored then), but never fewer.  The caller is responsible for
+ * this pre-condition, no runtime check is performed.
+ * 
+ * \param format [null] a format string usually containing NUL terminated
+ *   ASCII encoded text, along with embedded placeholders, that are replaced
+ *   with parameters following \p format in the call.
+ *
+ *   A placeholder begins with an escape character \ref MMFATL_PH_PREFIX,
+ *   immediately followed by a type character.  Currently two types are
+ *   implemented \ref MMFATL_PH_STRING and \ref MMFATL_PH_UNSIGNED.
+ *
+ *   If you need a \ref MMFATL_PH_PREFIX verbatim in the error message, use
+ *   two \ref MMFATL_PH_PREFIX in succession.  They will automatically be
+ *   replaced with a single one.
+ *
+ *   For convenience \ref getFatalErrorPlaceholderToken may provide the
+ *   correct placeholder token.
+ *
+ *   NULL is equivalent to an empty format string, and supported both as a
+ *   \ref format string and as a parameter for a string placeholder, to
+ *   enhance robustness.
+ * 
+ * The \p format is followed by a possibly empty list of paramaters substituted
+ *   for placeholders.  Currently unsigned int values may replace a
+ *   \ref MMFATL_PH_UNSIGNED type placeholder, and a char const* pointer a
+ *   \ref MMFATL_PH_STRING type placeholder.  If the latter pointer is NULL,
+ *   the placeholder is replaced with an empty string, else it must point to
+ *   ASCII encoded text.  No value is required for the \ref MMFATL_PH_PREFIX
+ *   type tokens.
+ * 
+ * \pre \p format if not NULL, contains NUL terminated ASCII text.
+ * \pre string parameters following
+ * \pre \ref fatalErrorInit was called before.
+ * \pre the submitted parameters following \p format must match in type the
+ *   placeholders in \p format.  Their count may exceed that of the
+ *   placeholders, but must never be less.  String parameters 
+ * \post the message is appended to the current buffer contents.  It is
+ *   truncated if there is insufficient space for it, including the
+ *   terminating NUL.
+ * \return false iff the message buffer is in overflow state.
+ */
+
 #ifdef TEST_ENABLE
 
 extern void test_mmfatl(void);

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -111,7 +111,7 @@ enum fatalErrorPlaceholderType {
 };
 
 /*!
- * \brief grammar support: generates a placeholder token for insertion into a
+ * \brief grammar support: generate a placeholder token for insertion into a
  *   format string.
  *
  * The placeholders in fatal errors are a subset of those used in the C library
@@ -130,7 +130,7 @@ extern char const* getFatalErrorPlaceholderToken(
                 enum fatalErrorPlaceholderType aType);
 
 /*!
- * \brief Preparing internal data structures for an error message.
+ * \brief Prepare internal data structures for an error message.
  * 
  * Empties the message buffer used to construct error messages by
  * \ref fatalErrorPush.
@@ -151,9 +151,9 @@ extern void fatalErrorInit(void);
 
 
 /*!
- * \brief appends text to the current contents in the message buffer.
+ * \brief append text to the current contents in the message buffer.
  * 
- * appends new text to the message buffer.  The submitted extra parameters
+ * Appends new text to the message buffer.  The submitted extra parameters
  * following \p format must match the placeholders in the \p format string
  * in type.  It is possible to add more parameters than necessary (they are
  * simply ignored then), but never fewer.  The caller is responsible for

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -59,8 +59,8 @@
  * given by __FILE__ and __LINE__ into the message.
  *
  * For this kind of expansion you still need a buffer where the final message
- * is constructed.  In our context, this buffer is pre-allocated, and fixed in
- * size, truncation of overflowing text enforced.
+ * is constructed.  In our context, this buffer is pre-allocated, fixed in
+ * size, and truncation of overflowing text enforced.
  */
 
 /***   Export basic features of the fatal error message processing   ***/
@@ -81,16 +81,15 @@ enum {
  *
  * the character sequence appended to a truncated fatal error message due to a
  * buffer overflow, so its reader is aware a displayed text is incomplete.  The
- * ellipsis is followed by a line feed to ensure even an overflown message ends
- * with one.  This is to separate a message from the command prompt following
- * an exit.
+ * ellipsis is followed by a line feed to ensure an overflown message is still
+ * on the previous line of the command prompt following program exit.
  */
 #define MMFATL_ELLIPSIS "...\n"
 
 /*!
  * \brief ASCII characters used for placeholder tokens, printf style
  *
- * supported value types of a two character placeholder token in a format
+ * Supported value types of a two character placeholder token in a format
  * string.  The first character of a placeholder is always an escape
  * character \ref MMFATL_PH_PREFIX, followed by one of the type characters
  * mentioned here.  A valid placeholder in a format string is replaced with a
@@ -192,6 +191,7 @@ extern void fatalErrorInit(void);
  *   the placeholder is replaced with an empty string, else it must point to
  *   ASCII encoded NUL terminated text.  No value is required for the
  *   \ref MMFATL_PH_PREFIX type tokens.
+ * \return false iff the message buffer is in overflow state.
  * 
  * \pre \p format if not NULL, contains NUL terminated ASCII text.
  * \pre \ref fatalErrorInit was called before.
@@ -206,7 +206,6 @@ extern void fatalErrorInit(void);
  *   mminou.h) as print2 does.  Tests show that usual terminal emulators break
  *   up text at the last column, but that may depend on the used
  *   hard-/software.
- * \return false iff the message buffer is in overflow state.
  */
 extern bool fatalErrorPush(char const* format, ...);
 
@@ -241,7 +240,7 @@ extern bool fatalErrorPush(char const* format, ...);
  *   stderr to, say, a log file, the error message is displayed to the user on
  *   his terminal.
  * \warning previous versions of Metamath returned the exit code 1.  Many
- *   systemss define EXIT_FAILURE to this very value, but that is not mandated
+ *   systems define EXIT_FAILURE to this very value, but that is not mandated
  *   by the C11 standard.  In fact, some systems may interpret 1 as a success
  *   code, so EXIT_FAILURE is more appropriate.
  */

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -59,7 +59,7 @@ enum {
 
 /*! the character sequence appended to a truncated fatal error message due to
  * a buffer overflow, so its reader is aware a displayed text is incomplete.
- * The ellipsis is followed by a line feed to seprate the message from the
+ * The ellipsis is followed by a line feed to separate the message from the
  * command prompt following an exit.
  */
 #define MMFATL_ELLIPSIS "...\n"

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -158,7 +158,7 @@ extern void fatalErrorInit(void);
  *   It is recommended to let the message end with a LF character, so a command
  *   prompt following it is displayed on a new line.  If it is missing
  *   \ref fatalErrorPrintAndExit will supply one, but relying on this adds to
- *   unnecessary steps undere severe conditions.
+ *   unnecessary steps under severe conditions.
  *   
  * 
  * The \p format is followed by a possibly empty list of paramaters substituted

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -172,6 +172,19 @@ extern void fatalErrorInit(void);
  * \return false iff the message buffer is in overflow state.
  */
 
+/*!
+ * \brief display buffer contents and exit program with code EXIT_FAILURE.
+ * 
+ * This function does not return.
+ * 
+ * \pre \ref fatalErrorInit has initialized the internal error message
+ *   buffer, possibly followed by a sequence of \ref fatalErrorPush
+ *   filling it with a message.
+ * \post [noreturn] the program terminates with error code EXIT_FAILURE, after
+ *   writing the buffer contents to stderr.
+ */
+extern void fatalErrorPrintAndExit(void);
+
 #ifdef TEST_ENABLE
 
 extern void test_mmfatl(void);

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -68,7 +68,7 @@ enum {
  * character \ref MMFATL_PH_PREFIX, followed by one of the type characters
  * mentioned here.  A valid placeholder in a format string is replaced with a
  * submitted value during a parse phase.  The values in the enumeration here
- * are all ASCII characters different from NUL, and mutally distinct.
+ * are all ASCII characters different from NUL, and mutually distinct.
  *
  * Two \ref MMFATL_PH_PREFIX in succession serve as a special token denoting
  * the character \ref MMFATL_PH_PREFIX itself, as an ordinary text character.

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -10,6 +10,19 @@
 #include <stdbool.h>
 #include "mmtest.h"
 
+/* Documentation
+ * =============
+ *
+ * Most comments are written in <a href="https://doxygen.nl/index.html">
+ * doxygen</a> (Qt variant) style.  If you have doxygen installed on your
+ * computer, you may generate a hyperlinked HTML documentation out of them with
+ * its root page placed in build/html/index.html by running build.sh with the
+ * -d option.
+ *
+ * Delete this once we have this description available in a central location.
+ * Keep this as a simple comment, so it is outside of Doxygen documentation.
+ */
+
 /*!
  * \file mmfatl.h
  * \brief supports generating of fatal error messages
@@ -49,7 +62,6 @@
  * is constructed.  In our context, this buffer is pre-allocated, and fixed in
  * size, truncation of overflowing text enforced.
  */
-
 
 /***   Export basic features of the fatal error message processing   ***/
 

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -103,6 +103,26 @@ enum fatalErrorPlaceholderType {
 extern char const* getFatalErrorPlaceholderToken(
                 enum fatalErrorPlaceholderType aType);
 
+/*!
+ * \brief Preparing internal data structures for an error message.
+ * 
+ * Empties the message buffer used to construct error messages by
+ * \ref fatalErrorPush.
+ *
+ * Prior to generating an error message some internal data structures need to
+ * be initialized.  Usually such initialization is automatically executed on
+ * program startup.  Since we are in a fatal error situation, we do not rely
+ * on this.  Instead we assume memory corruption has affected this module's
+ * data and renders its state useless.  So we initialize it immediately before
+ * the error message is generated.  Note that we still rely on part of the
+ * system be running.  We cannot overcome a fully clobbered system, we only
+ * can increase our chances of bypassing some degree of memory corruption.
+ * \post internal data structures are initialized and ready for constructing
+ *   a message from a format string and parameter values.  Any previous
+ *   contents is discarded.
+ */
+extern void fatalErrorInit(void);
+
 
 #ifdef TEST_ENABLE
 

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -265,6 +265,10 @@ extern void fatalErrorPrintAndExit(void);
  * with an error code.  If possible use \ref fatalErrorPrintAndExit directly
  * instead.
  *
+ * If you need to concat two or more pieces to form the error message, use
+ * a sequence of \ref fatalErrorInit, multiple \ref fatalErrorPush and finally
+ * \ref fatalErrorPrintAndExit instead of this function.
+ *
  * \param file [null] filename of code responsible for calling this function,
  *   suitable for macro __FILE__.  Part of an error location.  Ignored in case
  *   of NULL.


### PR DESCRIPTION
This is the design and implementation of an interface to mmfatl.  The code in mmfatl is ONLY accessed through this interface.  This allows for independent development on both sides: mmfatl and the rest of Metamath.  As usual, regression tests validate the correctness of the implementation.

Each commit is constrained to a single idea, so a review may visit each commit individually for easiest verification.
Using this interface for error reporting is a final step later done in a dedicated separate PR.

* getFatalErrorPlaceholderToken
* fatalErrorInit is part of the interface
* fatalErrorPush
* fatalErrorPrintAndExit
* fatalErrorExitAt

@digama0 From my point of view the implementation is finished and ready for use in the rest of Metamath
