### PR TITLE
remove VAX-related code (and rewrap some overlong lines)

### DIFF
--- a/src/metamath.c
+++ b/src/metamath.c
@@ -1107,9 +1107,6 @@ void command(int argc, char *argv[]) {
           clang (which takes (void) as an ignore indicator)
           and gcc (which doesn't but is fooled by the ! operator). */
         (void)!system(str1);
-#ifdef VAXC
-        printf("\n"); /* Last line from VAX doesn't have new line */
-#endif
         continue;
       }
     }
@@ -2250,7 +2247,7 @@ void command(int argc, char *argv[]) {
         continue;
       }
       /* Note: in older versions the "~1" string was OS-dependent, but we
-         don't support VAX or THINK C anymore...  Anyway we reopen it
+         do not support VAX or THINK C anymore...  Anyway we reopen it
          here with the renamed file in case the OS won't let us rename
          an opened file during the fSafeOpen for write above. */
       list1_fp = fSafeOpen(cat(g_fullArg[2], "~1", NULL), "r",

--- a/src/mmcmds.c
+++ b/src/mmcmds.c
@@ -4691,10 +4691,6 @@ void verifyProofs(vstring labelMatch, flag verifyFlag) {
   vstring_def(tmpStr);
 #endif
 
-#ifdef VAXC
-  vstring_def(tmpStr);
-#endif
-
 #ifdef CLOCKS_PER_SEC
   clockStart = clock();  /* Retrieve start time */
 #endif

--- a/src/mmhlpa.c
+++ b/src/mmhlpa.c
@@ -58,12 +58,12 @@ H("  UNDUPLICATE - Eliminate duplicate occurrences of lines in a file");
 H("  DUPLICATE - Extract first occurrence of any line occurring more than");
 H("      once in a file, discarding lines occurring exactly once");
 H("  UNIQUE - Extract lines occurring exactly once in a file");
-H(
-"  (UNDUPLICATE, DUPLICATE, and UNIQUE also sort the lines as a side effect.)");
+H("  (UNDUPLICATE, DUPLICATE, and UNIQUE also sort the lines as a side");
+H("      effect.)");
 H("  UPDATE (deprecated) - Update a C program for revision control");
 H("  TYPE (10 lines) - Display 10 lines of a file; similar to Unix \"head\"");
-H(
-"  COPY - Similar to Unix \"cat\" but safe (same input & output name allowed)");
+H("  COPY - Similar to Unix \"cat\" but safe (same input & output name");
+H("      allowed)");
 H("  SUBMIT - Run a script containing Tools commands.");
 H("");
 H("Command syntax ([] means optional):");
@@ -71,8 +71,8 @@ H("  From TOOLS prompt:  TOOLS> <command> [<arg1> <arg2>...]");
 H("You need to type only as many characters of the command as are needed to");
 H("uniquely specify it.  Any arguments will answer questions automatically");
 H("until the argument list is exhausted; the remaining questions will be");
-H("prompted.  An argument may be optionally enclosed in quotes.  Use \"\" for");
-H("default or null argument.");
+H("prompted.  An argument may be optionally enclosed in quotes.  Use \"\"");
+H("for default or null argument.");
 H("");
 H("Notes:");
 H("(1) The commands are not case sensitive.  File names and match strings");
@@ -322,16 +322,16 @@ H("non-keyword argument such as a file name is expected at that point,");
 H("because the CLI will think the ? is the argument.");
 H("");
 H("Some commands have one or more optional qualifiers which modify the");
-H("behavior of the command.  Qualifiers are indicated by a slash (/), such as");
-H("in ABC xyz / IJK.  Spaces are optional around the /.  If you need");
+H("behavior of the command.  Qualifiers are indicated by a slash (/), such");
+H("as in ABC xyz / IJK.  Spaces are optional around the /.  If you need");
 H("to use a slash in a command argument, as in a Unix file name, put single");
 H("or double quotes around the command argument.");
 H("");
 H("If the response to a command is more than a screenful, you will be");
 H("prompted to \"<return> to continue, Q to quit, or S to scroll to end\".");
 H("Q will complete the command internally but suppress further output until");
-H("the next \"TOOLS>\" prompt.  S will suppress further pausing until the next");
-H("\"TOOLS>\" prompt.");
+H("the next \"TOOLS>\" prompt.  S will suppress further pausing until the");
+H("next \"TOOLS>\" prompt.");
 H("");
 H("A command line enclosed in quotes is executed by your operating system.");
 H("See HELP SYSTEM.");
@@ -387,12 +387,10 @@ vstring_def(saveHelpCmd);
    for the same reason.)  */
 let(&saveHelpCmd, helpCmd);
 
-
 if (!strcmp(saveHelpCmd, "HELP CLI")) {
 H("The Metamath program was first developed on a VAX/VMS system, and some");
 H("aspects of its command line behavior reflect this heritage.  Hopefully");
-H(
-"you will find it reasonably user-friendly once you get used to it.");
+H("you will find it reasonably user-friendly once you get used to it.");
 H("");
 H("Each command line is a sequence of English-like words separated by");
 H("spaces, as in SHOW SETTINGS.  Command words are not case sensitive, and");
@@ -418,11 +416,12 @@ H("non-keyword argument such as a file name is expected at that point,");
 H("because the CLI will think the ? is the argument.");
 H("");
 H("Some commands have one or more optional qualifiers that modify the");
-H("behavior of the command.  Qualifiers are indicated by a slash (/), such as");
-H("in READ set.mm / VERIFY.  Spaces are optional around / and =.  If you need");
-H("to use / or = in a command argument, as in a Unix file name, put single");
-H("or double quotes around the command argument.  See the last section of");
-H("HELP LET for more information on special characters in arguments.");
+H("behavior of the command.  Qualifiers are indicated by a slash (/), such");
+H("as in READ set.mm / VERIFY.  Spaces are optional around / and =.  If you");
+H("need to use / or = in a command argument, as in a Unix file name, put");
+H("single or double quotes around the command argument.  See the last");
+H("section of HELP LET for more information on special characters in");
+H("arguments.");
 H("");
 H("The OPEN LOG command will save everything you see on the screen, and is");
 H("useful to help you recover should something go wrong in a proof, or if");
@@ -453,8 +452,6 @@ H("    HELP SUBMIT");
 H("    HELP UNDO (or REDO) - in Proof Assistant only");
 H("");
 }
-
-
 
 if (!strcmp(saveHelpCmd, "HELP LANGUAGE")) {
 H("The language is best learned by reading the book and studying a few proofs");

--- a/src/mminou.c
+++ b/src/mminou.c
@@ -462,12 +462,11 @@ flag print2(const char* fmt, ...) {
 
   /* Check for lines too long */
   if (lineLen > g_screenWidth + 1) { /* The +1 ignores \n */
-    /* Warning:  Don't call bug(), because it calls print2. */
+    /* Warning:  Do not call bug(), because it calls print2. */
     /* If this bug occurs, the calling function should be fixed. */
     printf("*** PROGRAM BUG #1505 (not serious, but please report it)\n");
     printf("Line exceeds screen width; caller should use printLongLine.\n");
     printf("%ld %s\n", lineLen, printBuffer);
-    /*printf(NULL);*/  /* Force crash on VAXC to see where it came from */
 #if __STDC__
     fflush(stdout);
 #endif
@@ -1152,13 +1151,6 @@ FILE *fSafeOpen(const char *fileName, const char *mode, flag noVersioningFlag) {
 #elif defined __GNUC__ /* Assume unix */
       let(&prefix, cat(fileName, "~", NULL));
       free_vstring(postfix);
-
-#elif defined VAXC /* Assume VMS */
-      /* For debugging on VMS: */
-      /* let(&prefix, cat(fileName, "-", NULL));
-         let(&postfix, "-"); */
-      /* Normal: */
-      goto skip_backup;
 
 #else /* Unknown; assume unix standard */
       /*if (1) goto skip_backup;*/  /* [if no backup desired] */

--- a/src/mmpars.c
+++ b/src/mmpars.c
@@ -906,21 +906,11 @@ void parseStatements(void) {
     symbolLenExists[g_MathToken[i].length] = 1;
   }
 
-
   g_currentScope = 0;
   beginScopeStmtNum = 0;
 
   /* Scan all statements.  Fill in statement structure and look for errors. */
   for (stmt = 1; stmt <= g_statements; stmt++) {
-
-#ifdef VAXC
-    /* This line fixes an obscure bug with the VAXC compiler.  If it is taken
-       out, the variable 'stmt' does not get referenced properly when used as
-       an array index.  May be due to some boundary condition in optimization?
-       The assembly code is significantly different with this statement
-       removed. */
-    stmt = stmt;  /* Work around VAXC bug */
-#endif
 
     g_Statement[stmt].beginScopeStatementNum = beginScopeStmtNum;
     /* endScopeStatementNum is always 0 except in ${ statements */

--- a/src/mmvstr.h
+++ b/src/mmvstr.h
@@ -457,7 +457,7 @@ temp_vstring right(const char *sin, long n);
 /*!
  * \fn temp_vstring edit(const char *sin, long control)
  * perform a combination of transformations on \p sin based on the set bits in
- * \p control.  This is an ASCII based transformation.
+ * \p control.  This is an ASCII-based transformation.
  *      Bit    |  Effect
  *      -----  |  ------
  *      1      |  Clear parity bits

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -5128,7 +5128,7 @@ flag writeBibliography(vstring bibFile,
         return 1;
       }
       /* Note: in older versions the "~1" string was OS-dependent, but we
-         don't support VAX or THINK C anymore...  Anyway we reopen it
+         do not support VAX or THINK C anymore...  Anyway we reopen it
          here with the renamed file in case the OS won't let us rename
          an opened file during the fSafeOpen for write above. */
       list1_fp = fSafeOpen(cat(bibFile, "~1", NULL), "r", 0/*noVersioningFlag*/);


### PR DESCRIPTION
Remove VAX-related code, which is a task from #17.
(I did global searches on "vax" and "vms", and also on "maci", "mmac", "think" to check no code related to Think C or the old mmmaci.c remained, except possibly in comments.)
Also rewrap some overlong lines.