### PR TITLE
dead code elimination in mmfatl

### DIFF
--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -386,32 +386,6 @@ static void parse(struct ParserState* state) {
 
 /****    Implementation of the interface in the header file   ****/
 
-/* See the header file for descriptions
- * Global instances buffer and state are known to the following functions.
- * They must not be passed as parameters, as they are implementation details
- * not to be exposed through the interface.
- */
-
-char const* getFatalErrorPlaceholderToken(
-                    enum fatalErrorPlaceholderType type) {
-
-  static char result[3];
-
-  switch (type)
-  {
-    case MMFATL_PH_PREFIX:
-    case MMFATL_PH_STRING:
-    case MMFATL_PH_UNSIGNED:
-      result[0] = MMFATL_PH_PREFIX;
-      result[1] = type;
-      result[2] = NUL;
-      break;
-    default:
-      return NULL;
-  }
-  return result;
-}
-
 /*!
  * \brief get the message buffer instance
  *
@@ -829,16 +803,6 @@ static bool test_parse(void) {
   return true;
 }
 
-static bool test_getFatalErrorPlaceholderToken(void) {
-  char const* result = getFatalErrorPlaceholderToken(MMFATL_PH_PREFIX);
-  ASSERT(result && strcmp(result, "%%") == 0);
-  result = getFatalErrorPlaceholderToken(MMFATL_PH_UNSIGNED);
-  ASSERT(result && strcmp(result, "%u") == 0);
-  ASSERT(getFatalErrorPlaceholderToken(
-      (enum fatalErrorPlaceholderType)NUL) == NULL);
-  return true;
-}
-
 static bool test_fatalErrorPush() {
   fatalErrorInit(); // pre-condition
 
@@ -921,7 +885,6 @@ void test_mmfatl(void) {
   RUN_TEST(test_handleText);
   RUN_TEST(test_parse);
   RUN_TEST(test_handleSubstitution);
-  RUN_TEST(test_getFatalErrorPlaceholderToken);
   RUN_TEST(test_fatalErrorPush);
   RUN_TEST(test_fatalErrorPrintAndExit);
   RUN_TEST(test_fatalErrorExitAt);

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -127,25 +127,6 @@ enum fatalErrorPlaceholderType {
 
 
 /*!
- * \brief grammar support: generate a placeholder token for insertion into a
- *   format string.
- *
- * The placeholders in fatal errors are a subset of those used in the C library
- * function printf.  A flexible implementation might want to query placeholder
- * tokens during an automatic message generation, rather than hardcoding them
- * directly in the format string.
- * \param aType data type of the value replacing the placeholder in a format
- *   string.  \ref MMFATL_PH_PREFIX is allowed as a type, yielding a token
- *   standing for the character \ref MMFATL_PH_PREFIX itself.
- * \return a placeholder of a supported type, or NULL, if you somehow
- *   manage to dodge C type checking.
- * \attention the result is stable only until the next call to this
- *   function.
- */
-extern char const* getFatalErrorPlaceholderToken(
-                enum fatalErrorPlaceholderType aType);
-
-/*!
  * \brief Prepare internal data structures for an error message.
  * 
  * Empties the message buffer used to construct error messages by


### PR DESCRIPTION
In general it is a good idea that a client queries the capabilities of a service, but in case of the widespread printf format... It is very hypothetical that format strings of error messages are prepared on the assumption something weird could happen to the established grammar service side.  This is likely never be used, get rid of it.

Here I think the general critics apply, but the rest is in good shape from my point of view.  Won't do any more here unsolicited.