### PR TITLE
consistent comment after #endif directives (in files mmfatl.*)

### DIFF
--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -439,10 +439,10 @@ void fatalErrorPrintAndExit(void) {
       && !isBufferEmpty(buffer)
       && getLastBufferedChar(buffer) != LF)
     fatalErrorPush("\n");
-#ifndef TEST_ENABLE // we don't want a test program terminate here
+#ifndef TEST_ENABLE // we do not want a test program terminating here
   fputs(buffer->text, stderr);
   exit(EXIT_FAILURE);
-#endif
+#endif // TEST_ENABLE
 }
 
 void fatalErrorExitAt(char const* file, unsigned line,

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -295,6 +295,6 @@ extern void fatalErrorExitAt(char const* file, unsigned line,
 
 extern void test_mmfatl(void);
 
-#endif
+#endif // TEST_ENABLE
 
-#endif /* include guard */
+#endif // METAMATH_MMFATL_H_


### PR DESCRIPTION
I tried to make comments after `#endif` more consistent by systematically recalling the identifier that was after the mathching `#if(n)def` directive.  Please @wlammen tell me if this is correct and if I can do that for the other files.

What about removing double blank lines everywhere ? (regex `\n\n\n`)