### PR TITLE
revert to legacy error position handling

### DIFF
--- a/src/mmdata.c
+++ b/src/mmdata.c
@@ -731,7 +731,7 @@ void outOfMemory(const char *msg) {
         "To solve this problem, remove some unnecessary statements or file\n"
         "inclusions to reduce the size of your input source.\n"
         "Monitor memory periodically with SHOW MEMORY.\n";
-  fatalErrorExitAt(__FILE__, __LINE__, format, msg);
+  fatalErrorExit(format, msg);
 }
 
 
@@ -3068,11 +3068,11 @@ long **alloc2DMatrix(size_t xsize, size_t ysize)
   long i;
   matrix = malloc(xsize * sizeof(long *));
   if (matrix == NULL)
-    fatalErrorExitAt(__FILE__, __LINE__, "?FATAL ERROR 1376 Out of memory\n");
+    fatalErrorExit("?FATAL ERROR 1376 Out of memory\n");
   for (i = 0; i < (long)xsize; i++) {
     matrix[i] = malloc(ysize * sizeof(long));
     if (matrix[i] == NULL)
-      fatalErrorExitAt(__FILE__, __LINE__, "?FATAL ERROR 1377 Out of memory\n");
+      fatalErrorExit("?FATAL ERROR 1377 Out of memory\n");
   }
   return matrix;
 } /* alloc2DMatrix */

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -450,23 +450,10 @@ void fatalErrorPrintAndExit(void) {
 #endif // TEST_ENABLE
 }
 
-void fatalErrorExitAt(char const* file, unsigned line,
-                      char const* msgWithPlaceholders, ...) {
+void fatalErrorExit(char const* msgWithPlaceholders, ...) {
   fatalErrorInit();
 
-  // a format for the error location, only showing relevant data
-  char const* format = NULL;
-  if (file && *file)
-  {
-    if (line > 0)
-      format = "At %s:%u\n";
-    else
-      format = "In file %s:\n";
-  }
-  else if (line > 0)
-    format = "%sIn line %u:\n";
-
-  if (fatalErrorPush(format, file, line) && msgWithPlaceholders) {
+  if (msgWithPlaceholders) {
     struct ParserState* state = getParserStateInstance();
 
     state->format = msgWithPlaceholders;
@@ -859,21 +846,21 @@ static bool test_fatalErrorPrintAndExit(void) {
   return true;
 }
 
-static bool test_fatalErrorExitAt() {
-  // note that in test mode the fatalErrorExitAt neither prints to stderr
+static bool test_fatalErrorExit() {
+  // note that in test mode the fatalErrorExit neither prints to stderr
   // nor exits.  The message is still in the buffer.
 
-  fatalErrorExitAt("test.c", 1000, "%s failed!", "program");
-  ASSERT(strcmp(buffer.text, "At test.c:1000\nprogram failed!\n") == 0);
+  fatalErrorExit("%s failed!", "program");
+  ASSERT(strcmp(buffer.text, "program failed!\n") == 0);
   // ignoring line
-  fatalErrorExitAt("x.c", 0, "test %u failed!", 5);
-  ASSERT(strcmp(buffer.text, "In file x.c:\ntest 5 failed!\n") == 0);
+  fatalErrorExit("test %u failed!", 5);
+  ASSERT(strcmp(buffer.text, "test 5 failed!\n") == 0);
   // ignoring file
-  fatalErrorExitAt(NULL, 123, "%s", "need help!\n");
-  ASSERT(strcmp(buffer.text, "In line 123:\nneed help!\n") == 0);
+  fatalErrorExit("%s", "need help!\n");
+  ASSERT(strcmp(buffer.text, "need help!\n") == 0);
 
   // ignoring error location
-  fatalErrorExitAt(NULL, 0, "take lessons, you fool!");
+  fatalErrorExit("take lessons, you fool!");
   ASSERT(strcmp(buffer.text, "take lessons, you fool!\n") == 0);
 
   return true;
@@ -892,7 +879,7 @@ void test_mmfatl(void) {
   RUN_TEST(test_handleSubstitution);
   RUN_TEST(test_fatalErrorPush);
   RUN_TEST(test_fatalErrorPrintAndExit);
-  RUN_TEST(test_fatalErrorExitAt);
+  RUN_TEST(test_fatalErrorExit);
 }
 
 #endif // TEST_ENABLE

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -465,7 +465,7 @@ void fatalErrorExit(char const* msgWithPlaceholders, ...) {
   fatalErrorPrintAndExit();
 }
 
-#if 1 /* fatalErrorExitAt */
+#if 0 /* fatalErrorExitAt */
 
 /* 
  * This extension to the fatal error interface allows you to pinpoint a source

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -279,12 +279,6 @@ extern void fatalErrorPrintAndExit(void);
  * a sequence of \ref fatalErrorInit, multiple \ref fatalErrorPush and finally
  * \ref fatalErrorPrintAndExit instead of this function.
  *
- * \param[in] file [null] filename of code responsible for calling this
- *   function, suitable for macro __FILE__.  Part of an error location.
- *   Ignored in case of NULL.
- * \param[in] line [unsigned] if greater 0, interpreted as a line number, where
- *   a call to this function is initiated, suitable for macro __LINE__.  Part
- *   of an error location.
  * \param[in] msgWithPlaceholders [null] the error message to display.  This
  *   message may include placeholders in printf style, in which case it must be
  *   followed by more parameters, corresponding to the values replacing
@@ -293,12 +287,11 @@ extern void fatalErrorPrintAndExit(void);
  *   The details of this process is explained in \ref fatalErrorPush.  Ignored
  *   if NULL.
  * \post the program exits with EXIT_FAILURE return code, after writing the
- *   error location and message to stderr.
+ *   error message to stderr.
  * \invariant the memory state of the rest of the program is not changed (in
  *   case there is still a function in the atexit queue).
  */
-extern void fatalErrorExitAt(char const* file, unsigned line,
-                             char const* msgWithPlaceholders, ...);
+extern void fatalErrorExit(char const* msgWithPlaceholders, ...);
 
 #ifdef TEST_ENABLE
 


### PR DESCRIPTION
The `__FILE__` and `__LINE__` macros define a source code location, which, for example, causes an error.  This is a very standard way to mark a position.
The problem is: during development these locations may move because of code insertion or deletion.  So this form of report is not stable across program versions, and may cause confusion.  Metamath uses #nn markers instead, that can be easily found using text search, and do not have this drawback.  Discontinue forced use of this kind of location marks in mmfatl.