### PR TITLE
Minor cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,12 +120,12 @@ https://guides.lib.berkeley.edu/how-to-write-good-documentation
     an entry point to documentation a README.TXT is kept in the main folder of
     Metamath.  This file is pure [ASCII](https://en.wikipedia.org/wiki/ASCII)
     encoded [plain text](https://en.wikipedia.org/wiki/Plain_text).
-    
+
 The following rules are strong recommendations.  We encourage to follow them as
 much as possible.  But in the end we think that some sort of documentation is
 better than no documentation, so bypassing any of them is possible if somehow
 inevitable.
-    
+
 2. If your documentation is simple enough to be expressed as
     [plain text](https://en.wikipedia.org/wiki/Plain_text), we recommend to
     rely as much as possible on [ASCII](https://en.wikipedia.org/wiki/ASCII)
@@ -138,7 +138,7 @@ inevitable.
     legible in simple editors.  Its format is in detail documented
     [here](https://github.github.com/gfm), and is an extension to the
     widespread [Markdown](https://commonmark.org/help/) format.
-    
+
 4. Source code documentation within sources should follow the
     [Doxygen](https://www.doxygen.nl/index.html) style, so documentation of
     variables and functions can be generated automatically.  Doxygen extracts

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -307,7 +307,6 @@ the "copyright" line and a pointer to where the full notice is found.
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-
 Also add information on how to contact you by electronic and paper mail.
 
 If the program is interactive, make it output a short notice like this

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -225,7 +225,7 @@ impose that choice.
 
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-
+
   8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License

--- a/README.TXT
+++ b/README.TXT
@@ -1,5 +1,4 @@
-This package contains the metamath program and several Metamath
-databases.
+This package contains the metamath program and several Metamath databases.
 
 
 Copyright
@@ -8,11 +7,11 @@ Copyright
 The metamath program is copyright under the terms of the GNU GPL license
 version 2 or later.  See the file LICENSE.TXT in this directory.
 
-Individual databases (*.mm files) are either public domain or under
-the GNU GPL, as indicated by comments in their headers.
+Individual databases (*.mm files) are either public domain or under the GNU
+GPL, as indicated by comments in their headers.
 
-See http://us.metamath.org/copyright.html for further license and
-copyright information that applies to the content of this package.
+See http://us.metamath.org/copyright.html for further license and copyright
+information that applies to the content of this package.
 
 
 Instructions
@@ -20,23 +19,21 @@ Instructions
 
 For Windows, click on "metamath.exe" and type "read set.mm".
 
-For Unix/Linux/Cygwin/MacOSX using the gcc compiler, compile with the
-command "cd src && gcc m*.c -o metamath", then type
-"./metamath set.mm" to run.
+For Unix/Linux/Cygwin/MacOSX using the gcc compiler, compile with the command
+"cd src && gcc m*.c -o metamath", then type "./metamath set.mm" to run.
 
-As an alternative, if you have autoconf, automake, and a C compiler, you
-can compile with the command "cd src && autoreconf -i && ./configure && make".
-This "autoconf" approach automatically finds your compiler and its
-options, and configure takes the usual options (e.g., "--prefix=/usr").
-The resulting executable will typically be faster because it will check for
-and enable available optimizations; tests found that the "improve"
-command ran 28% faster on gcc when using an autoconf-generated "configure".
-You can again type "./metamath set.mm" to run.  After "make" you may
-install it elsewhere using "sudo make install" (note that this installs
-".mm" files in the pkgdata directory, by default
-"/usr/local/share/metamath/").  If you install it this way, you can then
-run metamath as "metamath /usr/share/metamath/set.mm", copy set.mm
-locally (cp /usr/share/metamath/set.mm . ; metamath set.mm), or run
+As an alternative, if you have autoconf, automake, and a C compiler, you can
+compile with the command "cd src && autoreconf -i && ./configure && make".
+This "autoconf" approach automatically finds your compiler and its options, and
+configure takes the usual options (e.g., "--prefix=/usr").  The resulting
+executable will typically be faster because it will check for and enable
+available optimizations; tests found that the "improve" command ran 28% faster
+on gcc when using an autoconf-generated "configure".  You can again type
+"./metamath set.mm" to run.  After "make" you may install it elsewhere using
+"sudo make install" (note that this installs ".mm" files in the pkgdata
+directory, by default "/usr/local/share/metamath/").  If you install it this
+way, you can then run metamath as "metamath /usr/share/metamath/set.mm", copy
+set.mm locally (cp /usr/share/metamath/set.mm . ; metamath set.mm), or run
 metamath and type:  read "/usr/share/metamath/set.mm" (note that inside
 metamath, filenames containing "/" must be quoted).
 
@@ -49,21 +46,18 @@ For optimized performance under gcc, you can compile as follows:
   gcc m*.c -o metamath -O3 -funroll-loops -finline-functions \
      -fomit-frame-pointer -Wall -pedantic
 
-If your compiler supports it, you can also add the option -DINLINE=inline
-to achieve the 28% performance increase described above.
+If your compiler supports it, you can also add the option -DINLINE=inline to
+achieve the 28% performance increase described above.
 
+On Linux/MacOSX/Unix, the Metamath program will be more pleasant to use if you
+run it inside of rlwrap http://utopia.knoware.nl/~hlub/rlwrap/ (checked
+3-Jun-2015) which provides up-arrow command history and other command-line
+editing features.  After you install rlwrap per its instructions, invoke the
+Metamath program with "rlwrap ./metamath set.mm".
 
-On Linux/MacOSX/Unix, the Metamath program will be more pleasant to use
-if you run it inside of rlwrap http://utopia.knoware.nl/~hlub/rlwrap/
-(checked 3-Jun-2015) which provides up-arrow command history and other
-command-line editing features.  After you install rlwrap per its
-instructions, invoke the Metamath program with "rlwrap ./metamath
-set.mm".
-
-
-In some Linux distributions (such as Debian Woody), if the Backspace
-key doesn't delete characters typed after the "MM>" prompt, try adding
-this line to your ~/.bash_profile file:
+In some Linux distributions (such as Debian Woody), if the Backspace key does
+not delete characters typed after the "MM>" prompt, try adding this line to
+your ~/.bash_profile file:
 
   stty echoe echok echoctl echoke
 
@@ -73,11 +67,11 @@ Using rlwrap as described above will also solve this problem.
 Additional MacOSX information
 -----------------------------
 
-On MacOSX, select the Terminal application from Applications/Utilities
-to get to the command line.  On recent versions of MacOSX, you need to
-install gcc separately.  Typing "whereis gcc" will return "/usr/bin/gcc"
-if it is installed.  The XCode package is typically used to install it,
-but it can also be installed without XCode; see
+On MacOSX, select the Terminal application from Applications/Utilities to get
+to the command line.  On recent versions of MacOSX, you need to install gcc
+separately.  Typing "whereis gcc" will return "/usr/bin/gcc" if it is
+installed.  The XCode package is typically used to install it, but it can also
+be installed without XCode; see
 
   https://github.com/kennethreitz/osx-gcc-installer/ (checked 15-Feb-2014)
 
@@ -85,24 +79,24 @@ but it can also be installed without XCode; see
 Optional rlwrap user interface enhancement
 ------------------------------------------
 
-On Linux/MacOSX/Unix, the Metamath program will be more pleasant to use
-if you run it inside of rlwrap:
+On Linux/MacOSX/Unix, the Metamath program will be more pleasant to use if you
+run it inside of rlwrap:
 
   http://utopia.knoware.nl/~hlub/uck/rlwrap/ (checked 15-Feb-2014)
 
 which provides up-arrow command history and other command-line editing
-features.  After you install rlwrap per its instructions, invoke the
-Metamath program with "rlwrap ./metamath set.mm".
+features.  After you install rlwrap per its instructions, invoke the Metamath
+program with "rlwrap ./metamath set.mm".
 
-(The Windows version of the Metamath program was compiled with lcc,
-which has similar features built-in.)
+The Windows version of the Metamath program was compiled with lcc, which has
+similar features built-in.)
 
 
 Windows Compilation
 -------------------
 
-To reproduce the included metamath.exe for Windows, use lcc-win32
-version 3.8, with the following command:
+To reproduce the included metamath.exe for Windows, use lcc-win32 version 3.8,
+with the following command:
 
   lc -O m*.c -o metamath.exe
 
@@ -117,11 +111,11 @@ information, see the Metamath book available at http://metamath.org .
 To uninstall
 ------------
 
-To uninstall, just delete the "metamath" directory - nothing else
-(Registry, etc.) is touched in your system.
+To uninstall, just delete the "metamath" directory - nothing else (Registry,
+etc.) is touched in your system.
 
-If you used autoconf's "make install" to install it in system locations,
-you can use "make uninstall" to remove it.
+If you used autoconf's "make install" to install it in system locations, you
+can use "make uninstall" to remove it.
 
 
 List of databases
@@ -142,7 +136,7 @@ The database files included are:
   big-unifier.mm - A unification stress test (see comments in the file).
   peano.mm - A nicely commented presentation of Peano arithmetic, written
       by Robert Solovay (unlike the ones above, this database is NOT public
-      domain but is copyright under the terms of the GNU GPL license)
+      domain but is copyright under the terms of the GNU GPL license).
 
 
 Source code documentation
@@ -152,6 +146,6 @@ Many comments in the source code are written in
 
 https://doxygen.nl/index.html
 
-Doxygen (Qt variant) style.  If you have Doxygen installed on your
-computer, you may generate HTML documentation out of them with its root
-page placed in build/html/index.html by running build.sh with the -d option.
+Doxygen (Qt variant) style.  If you have Doxygen installed on your computer,
+you may generate HTML documentation from them with its root page placed in
+build/html/index.html by running build.sh with the -d option.

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -1,6 +1,6 @@
 # Building the Metamath executable from sources
 
-## Introductionary notes
+## Introductory notes
 
 In this file we describe how to build the executable metamath on a __Unix/Linux__
 system from scratch using only the sources and a few auxiliary files, all
@@ -12,7 +12,7 @@ distributed through the Github Metamath git repository.
 It bundles files and subdirectories into a single folder called __repository__.
 Unlike a simple folder a repository tracks changes to its contents, so you can
 checkout older versions of a file, or different versions if multiple persons
-work on files simultaniously.  It is out of the scope of this particular
+work on files simultaneously.  It is out of the scope of this particular
 document to detail on how this system works.  Instead we assume you have a
 fresh set of metamath source files ready in a single folder.  It is of no
 importance here how you got it.  The name of the folder is arbitrary, but for
@@ -62,7 +62,7 @@ A few decades ago that was less obvious, and the system had to be checked for
 its existence.  The shell script _configure_ carries out this check, and it has
 know-how built in to deal with lots of variants of both the file itself, and
 where to find it on a system.  The test result is then issued to the _config.h_
-result.  Either the above is copied verbatim, or 
+result.  Either the above is copied verbatim, or
 ```
 /* Define to 1 if stdbool.h conforms to C99. */
 #define HAVE_STDBOOL_H 1
@@ -152,7 +152,7 @@ _M4_ macros adapted to _automake_ directed commands.  This extends the
 functionality of _autoconf_ in a way that it can parse and process the
 _configure.ac_ file.
 
-_autoreconf_ automatically calls this program during the build process. 
+_autoreconf_ automatically calls this program during the build process.
 
 #### aclocal.m4
 
@@ -199,13 +199,13 @@ This Unix program called __autoconf__, or its sibling __autoreconf__, is
 capable of generating a _configure_ shell script from the input _configure.ac_.
 It uses functions defined in _aclocal.m4_ to perform its task.
 
-[Dokumentation](https://www.gnu.org/software/autoconf/)
+[Documentation](https://www.gnu.org/software/autoconf/)
 
 ### Makefile.am
 
 ### automake
 
-[Dokumentation](https://www.gnu.org/software/automake/manual)
+[Documentation](https://www.gnu.org/software/automake/manual)
 
 ### invoking configure
 
@@ -220,6 +220,5 @@ individual settings evaluated by _configure_ are compiled in.  So this script
 can recreate _config.h_ multiple times without carrying out the OS checks.
 
 ### config.h
-
 
 ... to be continued

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -58,7 +58,6 @@
       See the README.TXT file for more information.
 */
 
-
 /*! \def MVERSION
  * The current version of metamath.  It is incremented each time the software
  * is modified.  When main versions are released, the version consists of a
@@ -701,7 +700,6 @@
 
 /*****************************************************************************/
 
-
 /*----------------------------------------------------------------------*/
 
 #include <string.h>
@@ -758,7 +756,6 @@ int main(int argc, char *argv[]) {
      of a program as C-style comments embedded in the newer version.) */
   g_listMode = 0; /* Force Metamath mode as startup */
 
-
   g_toolsMode = g_listMode;
 
   if (!g_listMode) {
@@ -782,9 +779,7 @@ int main(int argc, char *argv[]) {
   }
 
   return 0;
-
 }
-
 
 void command(int argc, char *argv[]) {
   /* Command line user interface -- this is an infinite loop; it fetches and
@@ -1178,7 +1173,6 @@ void command(int argc, char *argv[]) {
       }
       continue;
     }
-
 
     if (cmdMatches("SET SCROLL")) {
       if (cmdMatches("SET SCROLL CONTINUOUS")) {
@@ -1889,7 +1883,6 @@ void command(int argc, char *argv[]) {
         continue;
       }
 
-
       if (cmdMatches("NUMBER")) {
         list1_fp = fSafeOpen(g_fullArg[1], "w", 0/*noVersioningFlag*/);
         if (!list1_fp) continue; /* Couldn't open it (error msg was provided) */
@@ -2143,7 +2136,6 @@ void command(int argc, char *argv[]) {
       continue;
     } /* End of WRITE SOURCE */
 
-
     if (cmdMatches("WRITE THEOREM_LIST")) {
       /* Write out an HTML summary of the theorems to
          mmtheorems.html, mmtheorems1.html,... */
@@ -2183,7 +2175,6 @@ void command(int argc, char *argv[]) {
       continue;
     }  /* End of "WRITE THEOREM_LIST" */
 
-
     if (cmdMatches("WRITE BIBLIOGRAPHY")) {
       /* This command builds the bibliographical cross-references to various
          textbooks and updates the user-specified file normally called
@@ -2195,7 +2186,6 @@ void command(int argc, char *argv[]) {
           1); /* 1 = check external files (gifs and bib) */
       continue;
     }  /* End of "WRITE BIBLIOGRAPHY" */
-
 
     if (cmdMatches("WRITE RECENT_ADDITIONS")) {
       /* This utility creates a list of recent proof descriptions and updates
@@ -2307,7 +2297,6 @@ void command(int argc, char *argv[]) {
             g_outputToString = 1;
             print2("\n"); /* Blank line for HTML human readability */
             printLongLine(cat(
-
                 /*
                 (stmt < g_extHtmlStmt) ?
                      "<TR>" :
@@ -2415,7 +2404,6 @@ void command(int argc, char *argv[]) {
             g_outputToString = 0;
             fprintf(list2_fp, "%s", g_printString);
             free_vstring(g_printString);
-
           }
         } /* Next stmt - statement number */
         /* Decrement date */
@@ -2431,7 +2419,6 @@ void command(int argc, char *argv[]) {
           }
         }
       } /* next while - Scan next date */
-
 
       /* Discard the input file up to the special "<!-- #END# -->" comment */
       while (1) {
@@ -2478,7 +2465,6 @@ void command(int argc, char *argv[]) {
       }
       continue;
     }  /* End of "WRITE RECENT_ADDITIONS" */
-
 
     if (cmdMatches("SHOW LABELS")) {
       linearFlag = 0;
@@ -2576,7 +2562,6 @@ void command(int argc, char *argv[]) {
       continue;
     } /* if (cmdMatches("SHOW SOURCE")) */
 
-
     if (cmdMatches("SHOW STATEMENT") && (
         switchPos("/ HTML")
         || switchPos("/ BRIEF_HTML")
@@ -2670,7 +2655,6 @@ void command(int argc, char *argv[]) {
              compared to g_extHtmlStmt in printTexHeader in mmwtex.c */
           g_showStatement = 1;
         }
-
 
         /*** Open the html file ***/
         g_htmlFlag = 1;
@@ -2908,7 +2892,6 @@ void command(int argc, char *argv[]) {
           } /* next i (statement number) */
           g_outputToString = 0;  /* closing will write out the string */
           free_vstring(bgcolor); /* Deallocate (to improve fragmentation) */
-
         } else { /* s > 0 */
 
           if (printTime == 1) {
@@ -2928,7 +2911,6 @@ void command(int argc, char *argv[]) {
                 timeIncr,
                 g_texFileName);
           }
-
         } /* if s <= 0 */
 
        ABORT_S:
@@ -2937,7 +2919,6 @@ void command(int argc, char *argv[]) {
         fclose(g_texFilePtr);
         g_texFileOpenFlag = 0;
         free_vstring(g_texFileName);
-
       } /* next s */
 
       if (!q) {
@@ -2953,7 +2934,6 @@ void command(int argc, char *argv[]) {
      htmlDone:
       continue;
     } /* if (cmdMatches("SHOW STATEMENT") && switchPos("/ HTML")...) */
-
 
     /* Write mnemosyne.txt */
     if (cmdMatches("SHOW STATEMENT") && switchPos("/ MNEMONICS")) {
@@ -3015,7 +2995,6 @@ void command(int argc, char *argv[]) {
           fprintf(g_texFilePtr, "%s</FONT></TD>", str1);
         }
 
-
         let(&str1, "</TABLE>");
         fprintf(g_texFilePtr, "%s", str1);
 
@@ -3065,7 +3044,6 @@ void command(int argc, char *argv[]) {
         briefFlag = 1;
       }
 
-
       if (switchPos("/ FULL")) {
         briefFlag = 0;
         commentOnlyFlag = 0;
@@ -3113,7 +3091,6 @@ void command(int argc, char *argv[]) {
         q = 1; /* Flag that at least one matching statement was found */
 
         g_showStatement = s;
-
 
         typeStatement(g_showStatement,
             briefFlag,
@@ -3238,7 +3215,6 @@ void command(int argc, char *argv[]) {
       continue;
     } /* if (cmdMatches("SHOW ELAPSED_TIME")) */
 
-
     if (cmdMatches("SHOW TRACE_BACK")) {
       essentialFlag = 0;
       axiomFlag = 0;
@@ -3319,7 +3295,6 @@ void command(int argc, char *argv[]) {
                 0 /* testOnlyFlag */);
           }
         }
-
       } /* next i */
       if (g_showStatement == 0) {
         printLongLine(cat("?There are no $p labels matching \"",
@@ -3331,7 +3306,6 @@ void command(int argc, char *argv[]) {
       free_vstring(traceToList); /* Deallocate memory */
       continue;
     } /* if (cmdMatches("SHOW TRACE_BACK")) */
-
 
     if (cmdMatches("SHOW USAGE")) {
 
@@ -3439,7 +3413,6 @@ void command(int argc, char *argv[]) {
       continue;
     } /* if cmdMatches("SHOW USAGE") */
 
-
     if (cmdMatches("SHOW PROOF")
         || cmdMatches("SHOW NEW_PROOF")
         || cmdMatches("SAVE PROOF")
@@ -3518,7 +3491,6 @@ void command(int argc, char *argv[]) {
           continue;
         }
       }
-
 
       /* Establish defaults for omitted qualifiers */
       startStep = 0;
@@ -3599,7 +3571,6 @@ void command(int argc, char *argv[]) {
         if (!pipFlag) let(&labelMatch, g_fullArg[2]);
       }
 
-
       if (texFlag) {
         if (!g_texFileOpenFlag) {
           print2(
@@ -3625,7 +3596,6 @@ void command(int argc, char *argv[]) {
         print2(
             "Reformatting and saving (but not recompressing) all proofs...\n");
       }
-
 
       q = 0;  /* Flag that at least one matching statement was found */
       for (stmt = 1; stmt <= g_statements; stmt++) {
@@ -3729,7 +3699,6 @@ void command(int argc, char *argv[]) {
                 outStatement /*statemNum, used only if explicitTargets*/));
           }
 
-
           if (saveFlag) {
             /* ??? This is a problem when mixing html and save proof */
             if (g_printString[0]) bug(1114);
@@ -3738,7 +3707,6 @@ void command(int argc, char *argv[]) {
             /* Set flag for print2() to put output in g_printString instead
                of displaying it on the screen */
             g_outputToString = 1;
-
           } else {
             if (!print2("Proof of \"%s\":\n", g_Statement[outStatement].labelName))
               break; /* Break for speedup if user quit */
@@ -3870,7 +3838,6 @@ void command(int argc, char *argv[]) {
             g_printString = "";
             g_outputToString = 0;
 
-
             if (!pipFlag) {
               if (!(fastFlag && !strcmp("*", labelMatch))) {
                 printLongLine(
@@ -3889,7 +3856,6 @@ void command(int argc, char *argv[]) {
               print2("SAVE PROOF run time = %6.2f sec for \"%s\"\n", timeIncr,
                   g_Statement[outStatement].labelName);
             }
-
           } else {
             /*print2("\n");*/ /* Add a blank line to make clipping easier */
             print2(cat(
@@ -3944,7 +3910,6 @@ void command(int argc, char *argv[]) {
             }
           }
         }
-
 
         if (texFlag) print2("Outputting proof of \"%s\"...\n",
             g_Statement[outStatement].labelName);
@@ -4046,7 +4011,6 @@ void command(int argc, char *argv[]) {
       continue;
     } /* if (cmdMatches("SHOW/SAVE [NEW_]PROOF" or" MIDI") */
 
-
 /*E*/ /*???????? DEBUG command for debugging only */
     if (cmdMatches("DBG")) {
       print2("DEBUGGING MODE IS FOR DEVELOPER'S USE ONLY!\n");
@@ -4084,7 +4048,6 @@ void command(int argc, char *argv[]) {
         continue; /* Error msg was provided if not unique */
       }
       g_proveStatement = i;
-
 
       /* 1 means to override usage locks */
       overrideFlag = ( (switchPos("/ OVERRIDE")) ? 1 : 0)
@@ -4171,7 +4134,6 @@ void command(int argc, char *argv[]) {
       processUndoStack(&g_ProofInProgress, PUS_PUSH, "", 0);
       continue;
     }
-
 
     if (cmdMatches("UNDO")) {
       processUndoStack(&g_ProofInProgress, PUS_UNDO, "", 0);
@@ -4416,11 +4378,9 @@ void command(int argc, char *argv[]) {
 
         autoUnify(1);
 
-
         g_proofChangedFlag = 1; /* Flag to push 'undo' stack */
         g_proofChanged = 1; /* Cumulative flag */
         processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
-
       }
 
       if (cmdMatches("LET STEP")) {
@@ -4463,7 +4423,6 @@ void command(int argc, char *argv[]) {
           0 /*g_htmlFlag*/);
       continue;
     }
-
 
     if (cmdMatches("ASSIGN")) {
       s = getStepNum(g_fullArg[1], g_ProofInProgress.proof,
@@ -4571,9 +4530,7 @@ void command(int argc, char *argv[]) {
       g_proofChanged = 1; /* Cumulative flag */
       processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
       continue;
-
     } /* cmdMatches("ASSIGN") */
-
 
     if (cmdMatches("REPLACE")) {
       /* 1 means to override usage locks */
@@ -4714,7 +4671,6 @@ void command(int argc, char *argv[]) {
               "", " ");
       }
 
-
       /* Automatically display new unknown steps
          ???Future - add switch to enable/defeat this */
       if (g_proofChangedFlag)
@@ -4735,9 +4691,7 @@ void command(int argc, char *argv[]) {
             0 /*g_htmlFlag*/);
 
       continue;
-
     } /* REPLACE */
-
 
     if (cmdMatches("IMPROVE")) {
 
@@ -4966,7 +4920,6 @@ void command(int argc, char *argv[]) {
                   improveDepth,
                   overrideFlag,
                   mathboxFlag);
-
               }
               if (!nmbrLen(nmbrTmpPtr)) {
                 /* REPLACE algorithm also failed */
@@ -5008,7 +4961,6 @@ void command(int argc, char *argv[]) {
           }
 
           if (searchAlg == 1) break; /* Old algorithm does just 1st pass */
-
         } /* Next improveAllIter */
 
         if (g_proofChangedFlag) {
@@ -5025,7 +4977,6 @@ void command(int argc, char *argv[]) {
              the message if the proof is complete */
           autoUnify(1); /* 1 = 'Congrats' if done */
         }
-
       } /* End if IMPROVE ALL */
 
       /* Automatically display new unknown steps
@@ -5048,9 +4999,7 @@ void command(int argc, char *argv[]) {
             0 /*g_htmlFlag*/);
 
       continue;
-
     } /* cmdMatches("IMPROVE") */
-
 
     if (cmdMatches("MINIMIZE_WITH")) {
 
@@ -5256,7 +5205,6 @@ void command(int argc, char *argv[]) {
               }
             }
 
-
             /* Because of the slow speed of traceBack(),
                we only want to check the /NO_NEW_AXIOMS_FROM list in the
                relatively rare case where a minimization occurred.  If the
@@ -5353,7 +5301,6 @@ void command(int argc, char *argv[]) {
                 continue; /* Continue at 'Next k' loop end below */
               }
             } /* end if (true) */
-
 
             /* Make sure the compressed proof length
                decreased, otherwise revert.  Also, we will use the
@@ -5521,9 +5468,7 @@ void command(int argc, char *argv[]) {
             /* Save the changed proof in case we have to restore
                it later */
             copyProofStruct(&saveProofForReverting, g_ProofInProgress);
-
           }
-
         } /* Next k (statement) */
 
         if (g_proofChangedFlag && forwRevPass == 2) {
@@ -5547,7 +5492,6 @@ void command(int argc, char *argv[]) {
             print2("The forward scan results were used.\n");
           }
         }
-
       } /* next forwRevPass */
 
       if (prntStatus == 1 && !mayGrowFlag)
@@ -5599,9 +5543,7 @@ void command(int argc, char *argv[]) {
         processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
       }
       continue;
-
     } /* End if MINIMIZE_WITH */
-
 
     if (cmdMatches("EXPAND")) {
 
@@ -5648,7 +5590,6 @@ void command(int argc, char *argv[]) {
       free_nmbrString(nmbrTmp);
       continue;
     } /* EXPAND */
-
 
     if (cmdMatches("DELETE STEP") || (cmdMatches("DELETE ALL"))) {
 
@@ -5707,7 +5648,6 @@ void command(int argc, char *argv[]) {
       processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
 
       continue;
-
     }
 
     if (cmdMatches("DELETE FLOATING_HYPOTHESES")) {
@@ -5768,7 +5708,6 @@ void command(int argc, char *argv[]) {
       }
 
       continue;
-
     } /* End if DELETE FLOATING_HYPOTHESES */
 
     if (cmdMatches("INITIALIZE")) {
@@ -5825,9 +5764,7 @@ void command(int argc, char *argv[]) {
       g_proofChanged = 1; /* Cumulative flag */
       processUndoStack(&g_ProofInProgress, PUS_PUSH, g_fullArgString, 0);
       continue;
-
     }
-
 
     if (cmdMatches("SEARCH")) {
       if (switchPos("/ ALL")) {
@@ -6017,7 +5954,6 @@ void command(int argc, char *argv[]) {
       continue;
     }
 
-
     if (cmdMatches("SET ECHO")) {
       if (cmdMatches("SET ECHO ON")) {
         g_commandEcho = 1;
@@ -6042,7 +5978,6 @@ void command(int argc, char *argv[]) {
       continue;
     }
 
-
     if (cmdMatches("SET JEREMY_HENTY_FILTER")) {
       if (cmdMatches("SET JEREMY_HENTY_FILTER ON")) {
         print2("The unification equivalence filter has been turned on.\n");
@@ -6055,7 +5990,6 @@ void command(int argc, char *argv[]) {
       }
       continue;
     }
-
 
     if (cmdMatches("SET EMPTY_SUBSTITUTION")) {
       if (cmdMatches("SET EMPTY_SUBSTITUTION ON")) {
@@ -6073,7 +6007,6 @@ void command(int argc, char *argv[]) {
         continue;
       }
     }
-
 
     if (cmdMatches("SET SEARCH_LIMIT")) {
       s = (long)val(g_fullArg[2]); /* Timeout value */
@@ -6095,7 +6028,6 @@ void command(int argc, char *argv[]) {
       continue;
     }
 
-
     if (cmdMatches("SET HEIGHT")) {
       s = (long)val(g_fullArg[2]); /* Screen height value */
       if (s < 2) s = 2;  /* Less than 2 makes no sense */
@@ -6107,7 +6039,6 @@ void command(int argc, char *argv[]) {
          prompt line after pausing. */
       continue;
     }
-
 
     if (cmdMatches("SET DISCOURAGEMENT")) {
       if (!strcmp(g_fullArg[2], "ON")) {
@@ -6129,14 +6060,12 @@ void command(int argc, char *argv[]) {
       continue;
     }
 
-
     if (cmdMatches("SET CONTRIBUTOR")) {
       print2("\"Contributed by...\" name was changed from \"%s\" to \"%s\"\n",
           g_contributorName, g_fullArg[2]);
       let(&g_contributorName, g_fullArg[2]);
       continue;
     }
-
 
     if (cmdMatches("SET ROOT_DIRECTORY")) {
       let(&str1, g_rootDirectory); /* Save previous one */
@@ -6165,7 +6094,6 @@ void command(int argc, char *argv[]) {
       continue;
     }
 
-
     if (cmdMatches("SET UNDO")) {
       s = (long)val(g_fullArg[2]); /* Maximum UNDOs */
       if (s < 0) s = 0;  /* Less than 0 UNDOs makes no sense */
@@ -6186,7 +6114,6 @@ void command(int argc, char *argv[]) {
       continue;
     }
 
-
     if (cmdMatches("SET UNIFICATION_TIMEOUT")) {
       s = (long)val(g_fullArg[2]); /* Timeout value */
       print2("Unification timeout has been changed from %ld to %ld\n",
@@ -6194,7 +6121,6 @@ void command(int argc, char *argv[]) {
       g_userMaxUnifTrials = s;
       continue;
     }
-
 
     if (cmdMatches("OPEN LOG")) {
         /* Open a log file */
@@ -6284,7 +6210,6 @@ void command(int argc, char *argv[]) {
       continue;
     } /* end MORE */
 
-
     if (cmdMatches("FILE SEARCH")) {
       /* Search the contents of a file and type on the screen */
 
@@ -6354,17 +6279,14 @@ void command(int argc, char *argv[]) {
       }
       free_pntrString(pntrTmp);
 
-
       continue;
     }
-
 
     if (cmdMatches("SET UNIVERSE") || cmdMatches("ADD UNIVERSE") ||
         cmdMatches("DELETE UNIVERSE")) {
 
       /*continue;*/ /* ???Not implemented */
     } /* end if xxx UNIVERSE */
-
 
     if (cmdMatches("SET DEBUG FLAG")) {
       print2("Notice:  The DEBUG mode is intended for development use only.\n");
@@ -6455,8 +6377,5 @@ void command(int argc, char *argv[]) {
 
     print2("?This command has not been implemented.\n");
     continue;
-
   }
-} /* command */
-
-
+} // command

--- a/src/mmcmdl.c
+++ b/src/mmcmdl.c
@@ -37,7 +37,6 @@ flag g_memoryStatus = 0; /* Always show memory */
 flag g_sourceHasBeenRead = 0; /* 1 if a source file has been read in */
 vstring_def(g_rootDirectory); /* Directory prefix to use for included files */
 
-
 static flag getFullArg(long arg, const char *cmdList);
 
 flag processCommandLine(void) {
@@ -313,7 +312,6 @@ flag processCommandLine(void) {
           }
           /* break; */ /* Break if only 1 switch is allowed */
         } /* End while for switch loop */
-
       }
       goto pclgood;
     }
@@ -331,7 +329,6 @@ flag processCommandLine(void) {
           goto pclbad;
         if (!getFullArg(3, "* What is the string to search for? "))
           goto pclbad;
-
 
         /* Get any switches */
         i = 3;
@@ -370,7 +367,6 @@ flag processCommandLine(void) {
           /* break; */ /* Break if only 1 switch is allowed */
         } /* End while for switch loop */
 
-
         goto pclgood;
       } /* End if (cmdMatches("FILE SEARCH")) */
       goto pclgood;
@@ -396,7 +392,6 @@ flag processCommandLine(void) {
       } else {
         let(&defaultArg, "");
       }
-
 
       if (cmdMatches("SHOW TRACE_BACK")) {
         if (g_sourceHasBeenRead == 0) {
@@ -471,7 +466,6 @@ flag processCommandLine(void) {
         goto pclgood;
       } /* End if (cmdMatches("SHOW USAGE")) */
 
-
       if (cmdMatches("SHOW LABELS")) {
         if (g_sourceHasBeenRead == 0) {
           print2("?No source file has been read in.  Use READ first.\n");
@@ -534,7 +528,6 @@ flag processCommandLine(void) {
         goto pclgood;
       }
 
-
       if (cmdMatches("SHOW PROOF")) {
         if (g_sourceHasBeenRead == 0) {
           print2("?No source file has been read in.  Use READ first.\n");
@@ -594,7 +587,6 @@ flag processCommandLine(void) {
         goto pclgood;
       } /* End if (cmdMatches("SHOW PROOF")) */
 
-
       if (cmdMatches("SHOW NEW_PROOF")) {
         if (g_sourceHasBeenRead == 0) {
           print2("?No source file has been read in.  Use READ first.\n");
@@ -646,7 +638,6 @@ flag processCommandLine(void) {
         goto pclgood;
       } /* End if (cmdMatches("SHOW NEW_PROOF")) */
 
-
       goto pclgood;
     } /* End of SHOW */
 
@@ -675,7 +666,6 @@ flag processCommandLine(void) {
         /*break;*/ /* Break if only 1 switch is allowed */
       }
       goto pclgood;
-
     } /* End of SEARCH */
 
     if (cmdMatches("SAVE")) {
@@ -695,7 +685,6 @@ flag processCommandLine(void) {
       } else {
         let(&defaultArg, "");
       }
-
 
       if (cmdMatches("SAVE PROOF")) {
         if (g_sourceHasBeenRead == 0) {
@@ -726,7 +715,6 @@ flag processCommandLine(void) {
         goto pclgood;
       } /* End if (cmdMatches("SAVE PROOF")) */
 
-
       if (cmdMatches("SAVE NEW_PROOF")) {
         if (g_sourceHasBeenRead == 0) {
           print2("?No source file has been read in.  Use READ first.\n");
@@ -752,7 +740,6 @@ flag processCommandLine(void) {
         }
         goto pclgood;
       } /* End if (cmdMatches("SAVE NEW_PROOF")) */
-
 
       goto pclgood;
     } /* End of SAVE */
@@ -1092,7 +1079,6 @@ flag processCommandLine(void) {
         goto pclgood;
       }
 
-
       if (cmdMatches("SET JEREMY_HENTY_FILTER")) {
         if (g_hentyFilter) {
           if (!getFullArg(2, "ON|OFF|<OFF>")) goto pclbad;
@@ -1167,7 +1153,6 @@ flag processCommandLine(void) {
         }
         goto pclgood;
       }
-
     } /* end if SET */
 
     if (cmdMatches("ERASE")) {
@@ -1337,7 +1322,6 @@ flag processCommandLine(void) {
 
       goto pclgood;
     }
-
   } else { /* g_toolsMode */
     /* Text tools mode */
     let(&tmpStr, cat(
@@ -1588,7 +1572,6 @@ flag processCommandLine(void) {
 
   /* Should never get here */
 
-
  pclgood:
   /* Strip off the last g_fullArg if a null argument was added by getFullArg
      in the case when "$" (nothing) is allowed */
@@ -1613,7 +1596,6 @@ flag processCommandLine(void) {
   }
   let(&g_fullArgString, right(g_fullArgString, 2)); /* Strip leading space */
 
-
   /* Deallocate memory */
   free_vstring(defaultArg);
   free_vstring(tmpStr);
@@ -1625,7 +1607,6 @@ flag processCommandLine(void) {
   free_vstring(tmpStr);
   return 0;
 } /* processCommandLine */
-
 
 /* This function converts the user's abbreviated keyword in
    g_rawArgPntr[arg] to a full, upper-case keyword,
@@ -1672,7 +1653,6 @@ static flag getFullArg(long arg, const char *cmdList1) {
       let((vstring *)(&g_rawArgPntr[arg]), argLine);
       free_vstring(argLine);
       g_rawArgNmbr[arg] = len(cmdList) - 1;/* Line position for error msgs */
-
     } /* End of asking user for additional argument */
 
     /* Make sure that the argument is a non-negative integer */
@@ -1696,7 +1676,6 @@ static flag getFullArg(long arg, const char *cmdList1) {
     free_vstring(tmpStr);
     goto getFullArg_ret;
   }
-
 
   /* Handle special case - any arbitrary string is OK */
   /* '*' means any string, '&' means a file */
@@ -1777,7 +1756,6 @@ static flag getFullArg(long arg, const char *cmdList1) {
     }
     goto getFullArg_ret;
   }
-
 
   /* Parse the choices available */
   long possCmds = 0;
@@ -1953,7 +1931,6 @@ getFullArg_ret:
   return ret;
 } /* getFullArg */
 
-
 /* This function breaks up line into individual tokens
    and puts them into g_rawArgPntr[].  g_rawArgs is the number of tokens.
    g_rawArgPntr[] is the starting position of each token on the line;
@@ -2107,7 +2084,6 @@ parseCommandLine_ret:
   }
 } /* parseCommandLine */
 
-
 flag lastArgMatches(vstring argString) {
   /* This functions checks to see if the last field was argString */
   if (!strcmp(argString, g_fullArg[pntrLen(g_fullArg)-1])) {
@@ -2145,7 +2121,6 @@ flag cmdMatches(vstring cmdString) {
     return 0;
   }
 } /* cmdMatches */
-
 
 long switchPos(vstring swString) {
   /* This function checks that fields i through j of g_fullArg match
@@ -2194,7 +2169,6 @@ long switchPos(vstring swString) {
   free_vstring(swString1);
   return j + 1;
 } /* switchPos */
-
 
 void printCommandError(vstring line1, long arg, vstring errorMsg)
 {

--- a/src/mmcmdl.h
+++ b/src/mmcmdl.h
@@ -57,5 +57,4 @@ extern flag g_memoryStatus;
 extern flag g_sourceHasBeenRead; /*!< 1 if a source file has been read in */
 extern vstring g_rootDirectory; /*!< Directory to use for included files */
 
-
-#endif /* METAMATH_MMCMDL_H_ */
+#endif // METAMATH_MMCMDL_H_

--- a/src/mmcmds.c
+++ b/src/mmcmds.c
@@ -24,7 +24,6 @@
 vstring bigAdd(vstring bignum1, vstring bignum2);
 vstring bigSub(vstring bignum1, vstring bignum2);
 
-
 /* For HTML output */
 vstring_def(g_printStringForReferencedBy);
 
@@ -303,7 +302,6 @@ void typeStatement(long showStmt,
             str2 = tokenToTex(g_MathToken[nmbrTmpPtr1[k]].tokenName, showStmt);
                  /* tokenToTex allocates str2; we must deallocate it */
             let(&htmlDistinctVars, cat(htmlDistinctVars, str2, NULL));
-
           }
           nmbrLet(&nmbrDDList, nmbrAddElement(nmbrDDList, nmbrTmpPtr1[k]));
         }
@@ -321,7 +319,6 @@ void typeStatement(long showStmt,
             str2 = tokenToTex(g_MathToken[nmbrTmpPtr2[k]].tokenName, showStmt);
                  /* tokenToTex allocates str2; we must deallocate it */
             let(&htmlDistinctVars, cat(htmlDistinctVars, str2, NULL));
-
           }
           nmbrLet(&nmbrDDList, nmbrAddElement(nmbrDDList, nmbrTmpPtr2[k]));
         }
@@ -352,7 +349,6 @@ void typeStatement(long showStmt,
         if (g_Statement[g_Statement[showStmt].reqHypList[i]].type
           == (char)f_) k++;
       }
-
     }
     if (k) {
       if (texFlag) {
@@ -456,7 +452,6 @@ void typeStatement(long showStmt,
         /* print2("    \\label{eq:%s}\n",g_Statement[showStmt].labelName); */
         print2("\\end{align}\n");
 
-
         /* Distinguish axiom, definition, theorem for LaTeX */
         /* Note: changes here must be mirrored in the \begin{...} above */
         if (g_Statement[showStmt].type == a_) {
@@ -473,7 +468,6 @@ void typeStatement(long showStmt,
         fprintf(g_texFilePtr, "%s", g_printString);
         let(&g_printString, "");
         g_outputToString = 0;
-
       } else { /* old TeX code */
         let(&str3, space((long)strlen(str2))); /* 3rd argument of printTexLongMath
             cannot be temp allocated */
@@ -597,7 +591,6 @@ void typeStatement(long showStmt,
         }
       } /* if (i && type == p_) */
 
-
       if (texFlag && htmlFlag) { /* It's a web page */
 
         if (htmlDistinctVars[0] != 0) {
@@ -634,7 +627,6 @@ void typeStatement(long showStmt,
           printLongLine(str2, "", "\"");
           g_outputToString = 0;
         }
-
       } /* if (texFlag && htmlFlag) */
 
       if (texFlag) {
@@ -739,7 +731,6 @@ void typeStatement(long showStmt,
       } /* Next i */
     } /* if (subType == SYNTAX) */
 
-
     /* For definitions, we pretend that the definition is a "wff" (hard-coded
        here; the .mm database provided by the user must use this convention).
        We use the proof assistant tools to prove that the statement is
@@ -823,7 +814,6 @@ void typeStatement(long showStmt,
           /* Deallocate storage */
           free_vstring(str1);
           free_nmbrString(nmbrTmpPtr2);
-
         } else { /* if (nmbrLen(nmbrTmpPtr2)) else */
           /* Proof was not found - probable syntax error */
           if (g_outputToString != 0) bug(246);
@@ -833,22 +823,16 @@ void typeStatement(long showStmt,
               "\".", NULL), "    ", " ");
         }
 
-
         /* Restore the zapped statement structure */
         g_Statement[showStmt].type = (char)a_;
         (g_Statement[showStmt].mathString)[0] = zapStatement1stToken;
 
         /* Deallocate storage */
         free_nmbrString(nmbrTmpPtr1);
-
       } /* if (wffToken >= 0) */
-
     } /* if (subType == DEFINITION) */
-
-
   } /* if (htmlFlag && texFlag) */
   /* End of finding definition for syntax statement */
-
 
   /* Start of creating used-by list for html page */
   if (htmlFlag && texFlag) {
@@ -914,13 +898,10 @@ void typeStatement(long showStmt,
             let(&str2, "");
           }
         } /* next m (statement number) */
-
-
       } else {
         /* There is no usage of this statement; print "(None)" */
         let(&str5, "");
         let(&str2, cat(str2, " (None)", NULL));
-
       } /* if (str1[0] == 'Y') */
       /* Include buffer in output string */
       let(&str2, cat(str5, str2, "</FONT></TD></TR>", NULL));
@@ -946,7 +927,6 @@ void typeStatement(long showStmt,
     g_outputToString = 0;
   } /* if (htmlFlag && texFlag) */
   /* End of used-by list for html page */
-
 
   /* After the block above, so referenced statements
      show up first for convenience */
@@ -987,7 +967,6 @@ void typeStatement(long showStmt,
   free_vstring(str5);
   free_vstring(htmlDistinctVars);
 } /* typeStatement */
-
 
 /* Get the HTML string of dummy variables used by a proof for the
    theorem's web page.  It should be called only if we're in
@@ -1110,7 +1089,6 @@ vstring htmlDummyVars(long showStmt)
         NULL));
   } /* htmlDummyVars */
 
-
  RETURN_POINT:
   /* Deallocate strings */
   free_vstring(dummyVarUsed);
@@ -1118,7 +1096,6 @@ vstring htmlDummyVars(long showStmt)
 
   return htmlDummyVarList;
 } /* htmlDummyVars */
-
 
 /* Get the HTML string of "allowed substitutions" list for an axiom
    or theorem's web page.  It should be called only if we're in
@@ -1259,7 +1236,6 @@ vstring htmlAllowedSubst(long showStmt)
       }
     }
     let(&htmlAllowedList, cat(htmlAllowedList, ")", NULL));
-
   } /* next i (wff or class var) */
 
  RETURN_POINT:
@@ -1290,7 +1266,6 @@ vstring htmlAllowedSubst(long showStmt)
 
   return htmlAllowedList;
 } /* htmlAllowedSubst */
-
 
 /* Displays a proof (or part of a proof, depending on arguments). */
 /* Note that parseProof() and verifyProof() are assumed to have been called,
@@ -1415,7 +1390,6 @@ void typeProof(long statemNum,
 
   if (htmlFlag && texFlag) {
 
-
     g_outputToString = 1; /* Flag for print2 to add to g_printString */
     if (essentialFlag) {
 
@@ -1527,7 +1501,6 @@ void typeProof(long statemNum,
     } /* next step */
   }
 
-
   /* Collect local labels */
   for (step = 0; step < plen; step++) {
     stmt = proof[step];
@@ -1632,7 +1605,6 @@ void typeProof(long statemNum,
     }
   }
 
-
   /* Get local labels and maximum label length */
   /* lent = target length, lens = source length */
   for (step = 0; step < plen; step++) {
@@ -1657,7 +1629,6 @@ void typeProof(long statemNum,
            the proof display, but this is felt to be too rare to be a serious
            drawback. */
         localLabelNames[step] = stepRenumber[step];
-
       }
       lens = (long)strlen(g_Statement[stmt].labelName);
     }
@@ -1800,13 +1771,11 @@ void typeProof(long statemNum,
           /* Add hypothesis list after label */
           let(&srcLabel, cat(hypStr, " ", srcLabel, NULL));
         }
-
       } else {
         let(&srcLabel, cat("=", g_Statement[stmt].labelName, NULL));
       }
       type = g_Statement[stmt].type;
     }
-
 
 #define PF_INDENT_INC 2
     /* Print the proof line */
@@ -1859,8 +1828,8 @@ void typeProof(long statemNum,
             str((double)(stepRenumber[step])),
             tmpStr,
             " ", NULL));
-        let(&startStringWithoutNum, space(maxStepNumLen + 1));
 
+        let(&startStringWithoutNum, space(maxStepNumLen + 1));
 
         let(&startPrefix, cat(
             startStringWithNum,
@@ -1917,7 +1886,6 @@ void typeProof(long statemNum,
               cat(startPrefix, " $", chr(type), " ", NULL),
               contPrefix, stmt, indentationLevel[step]);
         }
-
       } else { /* pipFlag */
         if (texFlag) {
           /* It doesn't make sense to do this and it hasn't been tested anyway */
@@ -1959,10 +1927,8 @@ void typeProof(long statemNum,
                 cat(startPrefix, " $", chr(type), " ", NULL),
                 contPrefix, 0, 0);
           }
-
         }
         if (nmbrLen(g_ProofInProgress.user[step])) {
-
           if (!texFlag) {
             printLongLine(cat(userPrefix, "  = ",
                 nmbrCvtMToVString(g_ProofInProgress.user[step]),
@@ -1974,12 +1940,9 @@ void typeProof(long statemNum,
                 cat(userPrefix, "  = ", NULL),
                 contPrefix, 0, 0);
           }
-
         }
       }
     }
-
-
   } /* Next step */
 
   if (!pipFlag) {
@@ -2176,8 +2139,6 @@ void typeProof(long statemNum,
           let(&tmpStr, cat(tmpStr, "<A HREF=\"",
               g_Statement[stmt].labelName, ".html\">",
               g_Statement[stmt].labelName, "</A>", tmpStr1, NULL));
-
-
         }
       }
       if (tmpStr[0]) {
@@ -2186,7 +2147,6 @@ void typeProof(long statemNum,
         printLongLine(tmpStr, "", "\"");
       }
       /* End of syntax hints list */
-
 
       /* Get list of axioms and definitions assumed by proof */
       free_vstring(statementUsedFlags);
@@ -2256,7 +2216,6 @@ void typeProof(long statemNum,
 "<TR><TD ALIGN=left >&nbsp;<B><FONT COLOR=\"#FF6600\">",
 "WARNING: This theorem has an incomplete proof.</FONT></B><BR></TD></TR>",
               NULL), "", "\"");
-
         } else {
           printLongLine(cat(
 "<TR><TD ALIGN=left >&nbsp;</TD><TD><B><FONT COLOR=\"#FF6600\">",
@@ -2285,9 +2244,7 @@ void typeProof(long statemNum,
            g_printStringForReferencedBy should never be empty */
         bug(263);
       }
-
     }  /* if essentialFlag */
-
 
     /* Printing of the trailer in mmwtex.c will close out string later */
     g_outputToString = 0;
@@ -2353,7 +2310,6 @@ void showDetailStep(long statemNum, long detailStep) {
   getStep.stepNum = detailStep; /* Non-zero is flag for verifyProof */
   parseProof(statemNum); /* ???Do we need to do this again? */
   verifyProof(statemNum);
-
 
   nmbrLet(&proof, g_WrkProof.proofString); /* The proof */
   plen = nmbrLen(proof);
@@ -2618,7 +2574,6 @@ void showDetailStep(long statemNum, long detailStep) {
   free_nmbrString(localLabelNames);
   free_nmbrString(proof);
   free_nmbrString(targetHyps);
-
 } /* showDetailStep */
 
 /* Summary of statements in proof for SHOW PROOF / STATEMENT_SUMMARY */
@@ -2791,7 +2746,6 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
         printTexLongMath(g_Statement[stmt].mathString,
             str2, str3, 0, 0);
       }
-
     } /* End if (statementUsedFlag[stmt] == 'Y') */
   } /* Next stmt */
 
@@ -2802,9 +2756,7 @@ void proofStmtSumm(long statemNum, flag essentialFlag, flag texFlag) {
   free_nmbrString(statementList);
   free_nmbrString(proof);
   free_nmbrString(essentialFlags);
-
 } /* proofStmtSumm */
-
 
 /* Traces back the statements used by a proof, recursively. */
 /* Returns 1 if at least one label is printed (or would be printed in
@@ -3029,7 +2981,6 @@ void traceProofWork(long statemNum,
   free_nmbrString(statementList);
   free_vstring(str1);
   return;
-
 } /* traceProofWork */
 
 nmbrString_def(stmtFoundList);
@@ -3059,7 +3010,6 @@ void traceProofTree(long statemNum,
   free_nmbrString(stmtFoundList);
 } /* traceProofTree */
 
-
 void traceProofTreeRec(long statemNum,
   flag essentialFlag, long endIndent, long recursDepth)
 {
@@ -3070,7 +3020,6 @@ void traceProofTreeRec(long statemNum,
   flag unprovedFlag = 0;
   nmbrString_def(proof);
   nmbrString_def(essentialFlags);
-
 
   free_vstring(outputStr);
   outputStr = getDescription(statemNum); /* Get statement comment */
@@ -3195,9 +3144,7 @@ void traceProofTreeRec(long statemNum,
   free_nmbrString(localPrintedList);
   free_nmbrString(proof);
   free_nmbrString(essentialFlags);
-
 } /* traceProofTreeRec */
-
 
 /* Called by SHOW TRACE_BACK <label> / COUNT_STEPS */
 /* Counts the number of steps a completely exploded proof would require */
@@ -3347,7 +3294,6 @@ double countSteps(long statemNum, flag essentialFlag)
             free_vstring(tmpBig1);
             tmpBig1 = bigSub(stepBigCount, "1");
             let(&stepBigCount, tmpBig1);
-
           }
         }
       }
@@ -3359,7 +3305,6 @@ double countSteps(long statemNum, flag essentialFlag)
       stepNodeCount = stepNodeCount + stmtNodeCount[stmt];
       stepDistSum = stepDistSum + stmtAveDist[stmt] + 1;
     }
-
   } /* Next step */
 
  returnPoint:
@@ -3438,7 +3383,6 @@ double countSteps(long statemNum, flag essentialFlag)
                  " x 10^",
                  str((double)strlen(stepBigCount) - 1), NULL),
 
-
        " steps if fully expanded back to axiom references.  ",
        "The maximum path length is ",
        str((double)(stmtDist[statemNum])),
@@ -3459,7 +3403,6 @@ double countSteps(long statemNum, flag essentialFlag)
       free_vstring(stmtBigCount[stmt]);
     }
     free(stmtBigCount);
-
   }
 
   /* Deallocate local strings */
@@ -3468,7 +3411,6 @@ double countSteps(long statemNum, flag essentialFlag)
 
   return stepCount;
 } /* countSteps */
-
 
 /* Add two arbitrary precision nonnegative integers represented
    as strings of digits e.g. bigAdd("1234", "55") returns "1289".
@@ -3509,7 +3451,6 @@ vstring bigAdd(vstring bignum1, vstring bignum2) {
   return bignum3;
 }
 
-
 /* Subtract a nonnegative number (2nd arg) from a larger nonnegative number
    (1st arg).  If the 1st arg is smaller than the 2nd, results are
    not meaningful; there is no error checking for this.  */
@@ -3545,7 +3486,6 @@ vstring bigSub(vstring bignum1, vstring bignum2) {
   free_vstring(bignum1cmpl); /* Deallocate */
   return bignum3;
 }
-
 
 /**** 12-Nov-2018 nm In case multiplication is ever needed, this
   code will do it but is commented out because currently there
@@ -3620,7 +3560,6 @@ vstring bigMul(vstring bignum1, vstring bignum2) {
   return bignum3;
 }
 **** end commented out section added 12-Nov-2018 ***/
-
 
 /* Traces what statements require the use of a given statement */
 /* The output string must be deallocated by the user. */
@@ -3736,7 +3675,6 @@ vstring traceUsage(long statemNum,
   return (statementUsedFlags);
 } /* traceUsage */
 
-
 /* This implements the READ command (although the / VERIFY qualifier is
    processed separately in metamath.c). */
 void readInput(void)
@@ -3761,7 +3699,6 @@ void readInput(void)
 
  RETURN_POINT:
   free_vstring(fullInput_fn);
-
 } /* readInput */
 
 /* This function implements the WRITE SOURCE command. */
@@ -3850,13 +3787,11 @@ void writeSource(
 
   print2("%ld source statement(s) were written.\n", g_statements);
 
-
  RETURN_POINT:
   free_vstring(buffer); /* Deallocate vstring */
   free_vstring(fullOutput_fn); /* Deallocate vstring */
   return;
 } /* writeSource */
-
 
 /* Get info for WRITE SOURCE ... / EXTRACT */
 void writeExtractedSource(
@@ -3898,7 +3833,6 @@ void writeExtractedSource(
   vstring_def(hdrSuffix);
   FILE *fp;
   vstring_def(buf);
-
 
   /* Note that extractNeeded is 1-based to match 1-based
      indices of the g_Statement array.  We also may need labelSection of entry
@@ -4071,7 +4005,6 @@ void writeExtractedSource(
       break; /* Found the $t, so no reason to continue */
     }
   }
-
 
   /* Get header information about which headers to use */
   print2("Analyzing scopes of section headings...\n");
@@ -4362,7 +4295,6 @@ void writeExtractedSource(
           fprintf(fp, "\n");
         }
       } /* if (stmt != statements + 1) */
-
     } /* if (extractNeeded[stmt] == 'Y') */
   } /* next stmt */
 
@@ -4432,7 +4364,6 @@ void writeExtractedSource(
   free_vstring(buf);
   return;
 } /* getExtractionInfo */
-
 
 /* Some labels in comments may not exist in statements extracted
    with WRITE SOURCE ... / EXTRACT.  This function changes them
@@ -4520,7 +4451,6 @@ void fixUndefinedLabels(vstring extractNeeded/*'Y'/'N' list*/,
   return;
 } /* fixUndefinedLabels */
 
-
 void writeDict(void)
 {
   print2("This function has not been implemented yet.\n");
@@ -4605,7 +4535,6 @@ void eraseSource(void)    /* ERASE command */
       /* Deallocate proof if not original source */
       free_vstring(g_Statement[i].proofSectionPtr);
     }
-
   } /* Next i (statement) */
 
   /* g_MathToken[g_mathTokens].tokenName is assigned in
@@ -4664,9 +4593,7 @@ void eraseSource(void)    /* ERASE command */
 
   /* getContrib uses g_statements (global var), so don't do this earlier */
   g_statements = 0; /* getContrib uses g_statements for loop limit */
-
 } /* eraseSource */
-
 
 /* If verify = 0, parse the proofs only for gross error checking.
    If verify = 1, do the full verification. */
@@ -4745,15 +4672,12 @@ void verifyProofs(vstring labelMatch, flag verifyFlag) {
 #else
       print2("All proofs in the database were verified.\n");
 #endif
-
     } else {
       print2("All proofs in the database passed the syntax-only check.\n");
     }
   }
   free_vstring(emptyProofList); /* Deallocate */
-
 } /* verifyProofs */
-
 
 void verifyMarkup(vstring labelMatch,
     flag dateCheck, /* 1 = check date consistency */
@@ -4877,10 +4801,7 @@ void verifyMarkup(vstring labelMatch,
         }
       }
     }
-
-
   } /* next stmtNum */
-
 
   /* Check for math tokens containing "@" or "?" */
   /* Note:  g_MathToken[] is 0-based, not 1-based */
@@ -4916,7 +4837,6 @@ void verifyMarkup(vstring labelMatch,
     }
   }
 
-
   /* Check $a ax-* vs. $p ax* */
   for (stmtNum = 1; stmtNum <= g_statements; stmtNum++) {
     if (g_Statement[stmtNum].type != a_) {
@@ -4942,7 +4862,6 @@ void verifyMarkup(vstring labelMatch,
     if (verboseMode == 1) {
       print2("Comparing \"%s\" to \"%s\"...\n", str2, str1);
     }
-
 
     /* Compare statements */
     if (nmbrEq(g_Statement[stmtNum].mathString,
@@ -5017,7 +4936,6 @@ void verifyMarkup(vstring labelMatch,
     } /* next p2 */
   } /* next stmtNum */
 
-
   /* Check line lengths */
   free_vstring(str1); /* Prepare to use as pointer */
   free_vstring(str2); /* Prepare to use as pointer */
@@ -5081,11 +4999,9 @@ void verifyMarkup(vstring labelMatch,
             NULL), "    ", " ");
         errFound = 1;
       }
-
     } /* next p1 */
     str1 = ""; /* Restore pointer for use as vstring */
   } /* end of line length check - if (g_statements >= 1... */
-
 
   /* Check $t comment content */
 
@@ -5113,7 +5029,6 @@ void verifyMarkup(vstring labelMatch,
             fileCheck /* 1 = GIF file existence check */  );
   }
   if (f != 0) errFound = 1;
-
 
   /* Check date consistency and comment markup in all statements */
   print2("Checking statement comments...\n");
@@ -5161,7 +5076,6 @@ void verifyMarkup(vstring labelMatch,
         let(&mostRecentDate, str1);
         mostRecentStmt = stmtNum;
       }
-
     }
 
     free_vstring(descr);
@@ -5252,7 +5166,6 @@ void verifyMarkup(vstring labelMatch,
     }
   } /* if (topDateCheck) */
 
-
   print2("Checking section header comments...\n");
   for (stmtNum = 1; stmtNum <= g_statements; stmtNum++) {
     if (g_Statement[stmtNum].type != a_ && g_Statement[stmtNum].type != p_) {
@@ -5307,7 +5220,6 @@ void verifyMarkup(vstring labelMatch,
 "    (The warning above refers to a header above the referenced statement.)\n");
     if (f != 0) errFound = 1;
   } /* next stmtNum */
-
 
   /* Use the errors-only (no output) feature of writeBibliography() */
   print2("Checking bibliographic references...\n");
@@ -5415,9 +5327,7 @@ void verifyMarkup(vstring labelMatch,
   free_vstring(smallHdrComment);
   free_vstring(tinyHdrComment);
   return;
-
 } /* verifyMarkup */
-
 
 /* Function to process markup in an arbitrary non-Metamath HTML file, treating
    the file as a giant comment. */
@@ -5487,7 +5397,6 @@ void processMarkup(vstring inputFileName, vstring outputFileName,
   free_vstring(g_printString);
   return;
 }
-
 
 /* List "discouraged" statements with "(Proof modification is discouraged."
    and "(New usage is discouraged.)" comment markup tags. */
@@ -5677,7 +5586,6 @@ long getStepNum(vstring relStep, /* User's argument */
   return actualStepVal;
 } /* getStepNum */
 
-
 /* Convert the actual step numbers of an unassigned step to the relative
    -1, -2, etc. offset for SHOW NEW_PROOF ...  /UNKNOWN, to make it easier
    for the user to ASSIGN the relative step number. A 0 is returned
@@ -5708,7 +5616,6 @@ nmbrString *getRelStepNums(nmbrString *pfInProgress) {
 
   return relSteps;
 } /* getRelStepNums */
-
 
 /* This procedure finds the next statement number whose label matches
    stmtName.  Wildcards are allowed.  If uniqueFlag is 1,
@@ -5874,13 +5781,11 @@ long getStatementNum(vstring stmtName, /* Possibly with wildcards */
   return matchStmt;
 } /* getStatementNum */
 
-
 /* Called by help() - prints a help line */
 void H(vstring helpLine)
 {
     print2("%s\n", helpLine);
 } /* H */
-
 
 /******** The MIDI output algorithm is in this function, outputMidi(). ******/
 /*** Warning:  If you want to experiment with the MIDI output, please
@@ -6058,7 +5963,6 @@ void outputMidi(long plen, nmbrString *indentationLevels,
 
   /* End of parsing user's parameter string */
 
-
   /* Map keyboard key numbers to MIDI notes */
   absMinKey = MIN_NOTE; /* Initialize for ALLKEYSFLAG case */
   absMaxKey = MAX_NOTE;
@@ -6200,7 +6104,6 @@ void outputMidi(long plen, nmbrString *indentationLevels,
         }
       }
       midiTime += 24; /* Add 24 to the MIDI time stamp */
-
     } else {
 
       /*** Process the deeper sustained notes for logical steps ***/
@@ -6226,7 +6129,6 @@ void outputMidi(long plen, nmbrString *indentationLevels,
           midiNote);
       midiTime += 24; /* Add 24 to the MIDI time stamp */
       midiPreviousLogicalStep = midiNote; /* Save for next step */
-
     }
   } /* next step */
 
@@ -6250,4 +6152,4 @@ void outputMidi(long plen, nmbrString *indentationLevels,
   free_vstring(midiFileName);
   free_vstring(tmpStr);
   free_vstring(midiLocalParam);
-} /* outputMidi */
+} // outputMidi

--- a/src/mmcmds.h
+++ b/src/mmcmds.h
@@ -85,7 +85,6 @@ void writeDict(void);
 void eraseSource(void);
 void verifyProofs(vstring labelMatch, flag verifyFlag);
 
-
 /*! If checkFiles = 0, do not open external files.
    If checkFiles = 1, check for presence of gifs and biblio file */
 void verifyMarkup(vstring labelMatch, flag dateCheck, flag topDateCheck,
@@ -146,5 +145,4 @@ extern vstring g_midiParam; /*!< Parameter string for MIDI file */
 void outputMidi(long plen, nmbrString *indentationLevels,
   nmbrString *logicalFlags, vstring g_midiParameter, vstring statementLabel);
 
-
-#endif /* METAMATH_MMCMDS_H_ */
+#endif // METAMATH_MMCMDS_H_

--- a/src/mmdata.c
+++ b/src/mmdata.c
@@ -29,7 +29,6 @@ mmdata.c
 flag g_listMode = 0; /* 0 = metamath, 1 = list utility */
 flag g_toolsMode = 0; /* In metamath: 0 = metamath, 1 = text tools utility */
 
-
 /* For use by getMarkupFlag() */
 vstring_def(g_proofDiscouragedMarkup);
 vstring_def(g_usageDiscouragedMarkup);
@@ -422,7 +421,6 @@ void *poolFixedMalloc(long size /* bytes */)
   }
 }
 
-
 /* poolMalloc tries first to use an array in the memFreePool before actually
    malloc'ing */
 void *poolMalloc(long size /* bytes */)
@@ -568,7 +566,6 @@ void poolFree(void *ptr)
   return;
 }
 
-
 /* addToUsedPool adds a (partially used) array to the memUsedPool */
 void addToUsedPool(void *ptr)
 {
@@ -651,7 +648,6 @@ void memFreePoolPurge(flag untilOK)
   return;
 }
 
-
 /* Get statistics for SHOW MEMORY command */
 void getPoolStats(long *freeAlloc, long *usedAlloc, long *usedActual)
 {
@@ -670,7 +666,6 @@ void getPoolStats(long *freeAlloc, long *usedAlloc, long *usedActual)
 /*E*/ if (!db9)print2("poolTotalFree %ld  alloc %ld\n", poolTotalFree, *freeAlloc +
 /*E*/   *usedAlloc);
 }
-
 
 void initBigArrays(void)
 {
@@ -731,7 +726,6 @@ void outOfMemory(const char *msg) {
         "Monitor memory periodically with SHOW MEMORY.\n";
   fatalErrorExitAt(__FILE__, __LINE__, format, msg);
 }
-
 
 /* Bug check */
 void bug(int bugNum)
@@ -850,7 +844,6 @@ flag matchesList(const char *testString, const char *pattern, char wildCard,
   g_startTempAllocStack = saveTempAllocStack;
   return matchVal;
 }
-
 
 /* This function returns a 1 if the first argument matches the pattern of
    the second argument.  The second argument may have wildcard characters.
@@ -987,7 +980,6 @@ flag matches(const char *testString, const char *pattern, char wildCard,
   return (0); /* Dummy return - never used */
 }
 
-
 /*******************************************************************/
 /*********** Number string functions *******************************/
 /*******************************************************************/
@@ -997,7 +989,6 @@ long g_nmbrStartTempAllocStack = 0;   /* Where to start freeing temporary alloca
                                     when nmbrLet() is called (normally 0, except in
                                     special nested vstring functions) */
 temp_nmbrString *nmbrTempAllocStack[M_MAX_ALLOC_STACK];
-
 
 temp_nmbrString *nmbrTempAlloc(long size)
                                 /* nmbrString memory allocation/deallocation */
@@ -1025,7 +1016,6 @@ temp_nmbrString *nmbrTempAlloc(long size)
   }
 }
 
-
 /* Make string have temporary allocation to be released by next nmbrLet() */
 /* Warning:  after nmbrMakeTempAlloc() is called, the nmbrString may NOT be
    assigned again with nmbrLet() */
@@ -1046,7 +1036,6 @@ temp_nmbrString *nmbrMakeTempAlloc(nmbrString *s)
 /*E*/db3=db3-(nmbrLen(s)+1)*(long)(sizeof(nmbrString));
   return s;
 }
-
 
 /* nmbrString assignment */
 /* This function must ALWAYS be called to make assignment to */
@@ -1099,7 +1088,6 @@ void nmbrLet(nmbrString **target, const nmbrString *source) {
           }
         }
 
-
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("k0a: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
       } else {
         /* Free old string space and allocate new space */
@@ -1136,9 +1124,7 @@ void nmbrLet(nmbrString **target, const nmbrString *source) {
           }
         }
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("k0b: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
-
       }
-
     } else {    /* source is 0 length, target is not */
       poolFree(*target);
       *target= NULL_NMBRSTRING;
@@ -1157,9 +1143,7 @@ void nmbrLet(nmbrString **target, const nmbrString *source) {
 
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("k1: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
   nmbrTempAlloc(0); /* Free up temporary strings used in expression computation*/
-
 }
-
 
 temp_nmbrString *nmbrCat(const nmbrString *string1,...) /* String concatenation */
 #define M_MAX_CAT_ARGS 30
@@ -1199,9 +1183,7 @@ temp_nmbrString *nmbrCat(const nmbrString *string1,...) /* String concatenation 
     j += argLength[i];
   }
   return ptr;
-
 }
-
 
 /* Find out the length of a nmbrString */
 long nmbrLen(const nmbrString *s)
@@ -1210,7 +1192,6 @@ long nmbrLen(const nmbrString *s)
   return (((long)(((const long *)s)[-1] - (long)(sizeof(nmbrString))))
               / (long)(sizeof(nmbrString)));
 }
-
 
 /* Find out the allocated length of a nmbrString */
 long nmbrAllocLen(const nmbrString *s)
@@ -1238,7 +1219,6 @@ void nmbrZapLen(nmbrString *s, long length) {
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("l: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
 }
 
-
 /* Copy a string to another (pre-allocated) string */
 /* Dangerous for general purpose use */
 void nmbrCpy(nmbrString *s, const nmbrString *t) {
@@ -1250,7 +1230,6 @@ void nmbrCpy(nmbrString *s, const nmbrString *t) {
   }
   s[i] = t[i]; /* End of string */
 }
-
 
 /* Copy a string to another (pre-allocated) string */
 /* Like strncpy, only the 1st n characters are copied. */
@@ -1266,7 +1245,6 @@ void nmbrNCpy(nmbrString *s, const nmbrString *t, long n) {
   s[i] = t[i]; /* End of string */
 }
 
-
 /* Compare two strings */
 /* Unlike strcmp, this returns a 1 if the strings are equal
    and 0 otherwise. */
@@ -1280,7 +1258,6 @@ flag nmbrEq(const nmbrString *s, const nmbrString *t) {
       return 1;
   return 0;
 }
-
 
 /* Extract sin from character position start to stop into sout */
 temp_nmbrString *nmbrSeg(const nmbrString *sin, long start, long stop) {
@@ -1324,7 +1301,6 @@ temp_nmbrString *nmbrRight(const nmbrString *sin, long n) {
   nmbrCpy(sout, &sin[n - 1]);
   return sout;
 }
-
 
 /* Allocate and return an "empty" string n "characters" long */
 temp_nmbrString *nmbrSpace(long n) {
@@ -1379,7 +1355,6 @@ long nmbrRevInstr(long start_position, const nmbrString *string1,
    return start_position;
 }
 
-
 /* Converts nmbrString to a vstring with one space between tokens */
 temp_vstring nmbrCvtMToVString(const nmbrString *s) {
   long i, j, outputLen, mstrLen;
@@ -1410,7 +1385,6 @@ temp_vstring nmbrCvtMToVString(const nmbrString *s) {
   g_startTempAllocStack = saveTempAllocStack;
   return makeTempAlloc(tmpStr); /* Flag it for deallocation */
 }
-
 
 /* Converts proof to a vstring with one space between tokens */
 temp_vstring nmbrCvtRToVString(const nmbrString *proof,
@@ -1486,7 +1460,6 @@ temp_vstring nmbrCvtRToVString(const nmbrString *proof,
         maxTargetLabelLen = (long)strlen(g_Statement[stmt].labelName);
       }
     }
-
   } /* next step */
 
   /* localLabelNames[] holds an integer which, when converted to string,
@@ -1511,10 +1484,8 @@ temp_vstring nmbrCvtRToVString(const nmbrString *proof,
             ((explicitTargets == 1) ? g_Statement[targetHyps[step]].labelName : ""),
             ((explicitTargets == 1) ? "=" : ""),
             str((double)(localLabelNames[stmt])), " ", NULL));
-
       } else if (stmt != -(long)'?') {
         let(&tmpStr, cat("??", str((double)stmt), " ", NULL)); /* For safety */
-
       } else {
         if (stmt != -(long)'?') bug(1391); /* Must be an unknown step */
         let(&tmpStr, cat(
@@ -1522,10 +1493,8 @@ temp_vstring nmbrCvtRToVString(const nmbrString *proof,
             ((explicitTargets == 1) ? "=" : ""),
             chr(-stmt), " ", NULL));
       }
-
     } else if (stmt < 1 || stmt > g_statements) {
       let(&tmpStr, cat("??", str((double)stmt), " ", NULL)); /* For safety */
-
     } else {
       free_vstring(tmpStr);
       if (nmbrElementIn(1, localLabels, step)) {
@@ -1570,7 +1539,6 @@ temp_vstring nmbrCvtRToVString(const nmbrString *proof,
   return makeTempAlloc(proofStr); /* Flag it for deallocation */
 }
 
-
 /* This function returns a nmbrString of length of reason with
    step numbers assigned to tokens which are steps, and 0 otherwise.
    The returned string is allocated; THE CALLER MUST DEALLOCATE IT. */
@@ -1614,7 +1582,6 @@ nmbrString *nmbrGetProofStepNumbs(const nmbrString *reason) {
   return stepNumbs;
 }
 
-
 /* Converts any nmbrString to an ASCII string of numbers
    -- used for debugging only. */
 temp_vstring nmbrCvtAnyToVString(const nmbrString *s) {
@@ -1632,7 +1599,6 @@ temp_vstring nmbrCvtAnyToVString(const nmbrString *s) {
   g_startTempAllocStack = saveTempAllocStack;
   return makeTempAlloc(tmpStr); /* Flag it for deallocation */
 }
-
 
 /* Extract variables from a math token string */
 temp_nmbrString *nmbrExtractVars(const nmbrString *m) {
@@ -1658,7 +1624,6 @@ temp_nmbrString *nmbrExtractVars(const nmbrString *m) {
   return v;
 }
 
-
 /* Determine if an element (after start) is in a nmbrString; return position
    if it is.  Like nmbrInstr(), but faster.  Warning:  start must NOT
    be greater than length, otherwise results are unpredictable!!  This
@@ -1672,7 +1637,6 @@ long nmbrElementIn(long start, const nmbrString *g, long element) {
   return 0;
 }
 
-
 /* Add a single number to end of a nmbrString - faster than nmbrCat */
 temp_nmbrString *nmbrAddElement(const nmbrString *g, long element) {
   long length;
@@ -1684,7 +1648,6 @@ temp_nmbrString *nmbrAddElement(const nmbrString *g, long element) {
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("bbg2: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
   return v;
 }
-
 
 /* Get the set union of two math token strings (presumably
    variable lists) */
@@ -1710,7 +1673,6 @@ temp_nmbrString *nmbrUnion(const nmbrString *m1, const nmbrString *m2) {
   return v;
 }
 
-
 /* Get the set intersection of two math token strings (presumably
    variable lists) */
 temp_nmbrString *nmbrIntersection(const nmbrString *m1, const nmbrString *m2)
@@ -1731,7 +1693,6 @@ temp_nmbrString *nmbrIntersection(const nmbrString *m1, const nmbrString *m2)
 /*E*/db2=db2-(len2-nmbrLen(v))*(long)(sizeof(nmbrString));
   return v;
 }
-
 
 /* Get the set difference m1-m2 of two math token strings (presumably
    variable lists) */
@@ -1754,7 +1715,6 @@ temp_nmbrString *nmbrSetMinus(const nmbrString *m1, const nmbrString *m2)
   return v;
 }
 
-
 /* This is a utility function that returns the length of a subproof that
    ends at step */
 /* 22-Aug-2012 nm - this doesn't seem to be used outside of mmdata.c -
@@ -1776,7 +1736,6 @@ long nmbrGetSubproofLen(const nmbrString *proof, long step)
   }
   return (step - pos);
 }
-
 
 /* This function returns a packed or "squished" proof, putting in local label
    references to previous subproofs. */
@@ -1828,7 +1787,6 @@ temp_nmbrString *nmbrSquishProof(const nmbrString *proof) {
   return nmbrMakeTempAlloc(newProof); /* Flag it for deallocation */
 }
 
-
 /* This function unpacks a "squished" proof, replacing local label references
    to previous subproofs by the subproofs themselves. */
 temp_nmbrString *nmbrUnsquishProof(const nmbrString *proof) {
@@ -1852,7 +1810,6 @@ temp_nmbrString *nmbrUnsquishProof(const nmbrString *proof) {
   free_nmbrString(subProof);
   return nmbrMakeTempAlloc(newProof); /* Flag it for deallocation */
 }
-
 
 /* This function returns the indentation level vs. step number of a proof
    string.  This information is used for formatting proof displays.  The
@@ -1899,7 +1856,6 @@ temp_nmbrString *nmbrGetIndentation(const nmbrString *proof, long startingLevel)
   free_nmbrString(nmbrTmp); /* Deallocate */
   return nmbrMakeTempAlloc(indentationLevel); /* Flag it for deallocation */
 } /* nmbrGetIndentation */
-
 
 /* This function returns essential (1) or floating (0) vs. step number of a
    proof string.  This information is used for formatting proof displays.  The
@@ -1955,7 +1911,6 @@ nmbrString *nmbrGetEssential(const nmbrString *proof) {
   free_nmbrString(nmbrTmp); /* Deallocate */
   return nmbrMakeTempAlloc(essentialFlags); /* Flag it for deallocation */
 } /* nmbrGetEssential */
-
 
 /* This function returns the target hypothesis vs. step number of a proof
    string.  This information is used for formatting proof displays.  The
@@ -2016,7 +1971,6 @@ temp_nmbrString *nmbrGetTargetHyp(const nmbrString *proof, long statemNum) {
   return nmbrMakeTempAlloc(targetHyp); /* Flag it for deallocation */
 } /* nmbrGetTargetHyp */
 
-
 /* Converts a proof string to a compressed-proof-format ASCII string.
    Normally, the proof string would be packed with nmbrSquishProof first,
    although it's not a requirement (in which case the compressed proof will
@@ -2062,7 +2016,6 @@ temp_vstring compressProof(const nmbrString *proof, long statemNum,
   nmbrString_def(explWorth);
   long explWidth;
   vstring_def(explIncluded);
-
 
   /* Compression standard with all cap letters */
   /* (For 500-700 step proofs, we only lose about 18% of file size --
@@ -2134,7 +2087,6 @@ temp_vstring compressProof(const nmbrString *proof, long statemNum,
 
   /* To obtain the old algorithm, we simply skip the new label re-ordering */
   if (oldCompressionAlgorithm) goto OLD_ALGORITHM;
-
 
   /* This algorithm, based on an idea proposed by Mario Carneiro, sorts
      the explicit labels so that the most-used labels occur first, optimizing
@@ -2321,7 +2273,6 @@ temp_vstring compressProof(const nmbrString *proof, long statemNum,
      reordered */
   nmbrLet(&assertionList, newExplList);
 
-
  OLD_ALGORITHM:
   /* Combine all label lists */
   nmbrLet(&labelList, nmbrCat(hypList, assertionList, localList, NULL));
@@ -2401,7 +2352,6 @@ temp_vstring compressProof(const nmbrString *proof, long statemNum,
     }
     if (i != numchrs) bug(1374);
 
-
     /***** Local labels ******/
     /* See if a local label is declared in this step */
     if (!localLabelFlags[step]) continue;
@@ -2417,7 +2367,6 @@ temp_vstring compressProof(const nmbrString *proof, long statemNum,
     }
     output[outputLen] = labelChar;
     outputLen++;
-
   } /* Next step */
 
   /* Create the final compressed proof */
@@ -2448,7 +2397,6 @@ temp_vstring compressProof(const nmbrString *proof, long statemNum,
   return makeTempAlloc(output); /* Flag it for deallocation */
 } /* compressProof */
 
-
 /* Compress the input proof, create the ASCII compressed proof,
    and return its size in bytes. */
 /* TODO: call this in MINIMIZE_WITH in metamath.c */
@@ -2467,7 +2415,6 @@ long compressedProofSize(const nmbrString *proof, long statemNum) {
   free_nmbrString(tmpNmbr);
   return bytes;
 } /* compressedProofSize */
-
 
 /*******************************************************************/
 /*********** Pointer string functions ******************************/
@@ -2546,7 +2493,6 @@ temp_pntrString *pntrTempAlloc(long size) {
   }
 }
 
-
 temp_pntrString *pntrMakeTempAlloc(pntrString *s) {
   if (g_pntrTempAllocStackTop>=(M_MAX_ALLOC_STACK-1)) {
     printf(
@@ -2563,7 +2509,6 @@ temp_pntrString *pntrMakeTempAlloc(pntrString *s) {
 /*E*/db3=db3-(pntrLen(s)+1)*(long)(sizeof(pntrString));
   return s;
 }
-
 
 void pntrLet(pntrString **target, const pntrString *source) {
   long targetLength,sourceLength;
@@ -2612,7 +2557,6 @@ void pntrLet(pntrString **target, const pntrString *source) {
           }
         }
 
-
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("k0a: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
       } else {
         /* Free old string space and allocate new space */
@@ -2649,9 +2593,7 @@ void pntrLet(pntrString **target, const pntrString *source) {
           }
         }
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("k0b: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
-
       }
-
     } else {    /* source is 0 length, target is not */
       poolFree(*target);
       *target= NULL_PNTRSTRING;
@@ -2670,9 +2612,7 @@ void pntrLet(pntrString **target, const pntrString *source) {
 
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("k1: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
   pntrTempAlloc(0); /* Free up temporary strings used in expression computation*/
-
 }
-
 
 /* String concatenation */
 temp_pntrString *pntrCat(const pntrString *string1,...) {
@@ -2713,9 +2653,7 @@ temp_pntrString *pntrCat(const pntrString *string1,...) {
     j=j+argLength[i];
   }
   return ptr;
-
 }
-
 
 /* Find out the length of a pntrString */
 long pntrLen(const pntrString *s) {
@@ -2723,7 +2661,6 @@ long pntrLen(const pntrString *s) {
   return ((((const long *)s)[-1] - (long)(sizeof(pntrString)))
       / (long)(sizeof(pntrString)));
 }
-
 
 /* Find out the allocated length of a pntrString */
 long pntrAllocLen(const pntrString *s) {
@@ -2748,7 +2685,6 @@ void pntrZapLen(pntrString *s, long length) {
   ((long *)s)[-1] = (length + 1) * (long)(sizeof(pntrString));
 /*E*/if(db9)getPoolStats(&i1,&j1_,&k1); if(db9)printf("l: pool %ld stat %ld\n",poolTotalFree,i1+j1_);
 }
-
 
 /* Copy a string to another (pre-allocated) string */
 /* Dangerous for general purpose use */
@@ -2794,7 +2730,6 @@ void pntrCpy(pntrString *s, const pntrString *t) {
   s[i] = t[i]; /* End of string */
 }
 
-
 /* Copy a string to another (pre-allocated) string */
 /* Like strncpy, only the 1st n characters are copied. */
 /* Dangerous for general purpose use */
@@ -2809,7 +2744,6 @@ void pntrNCpy(pntrString *s, const pntrString *t, long n) {
   s[i] = t[i]; /* End of string */
 }
 
-
 /* Compare two strings */
 /* Unlike strcmp, this returns a 1 if the strings are equal
    and 0 otherwise. */
@@ -2822,7 +2756,6 @@ flag pntrEq(const pntrString *s, const pntrString *t) {
       return 1;
   return 0;
 }
-
 
 /* Extract sin from character position start to stop into sout */
 temp_pntrString *pntrSeg(const pntrString *sin, long start, long stop) {
@@ -2867,7 +2800,6 @@ temp_pntrString *pntrRight(const pntrString *sin, long n) {
   pntrCpy(sout, &sin[n-1]);
   return sout;
 }
-
 
 /* Allocate and return an "empty" string n "characters" long */
 /* Each entry in the allocated array points to an empty vString. */
@@ -2929,8 +2861,7 @@ long pntrInstr(long start_position, const pntrString *string1,
      }
      if (j == ls2) return (i+1);
    }
-   return (0);
-
+   return 0;
 }
 
 /* Search for string2 in string 1 in reverse starting at start_position */
@@ -2949,9 +2880,8 @@ long pntrRevInstr(long start_position, const pntrString *string1,
         /* Clear temporaries to prevent overflow caused by "mid" */
      if (start_position < 1) return 0;
    }
-   return (start_position);
+   return start_position;
 }
-
 
 /* Add a single null string element to a pntrString - faster than pntrCat */
 temp_pntrString *pntrAddElement(const pntrString *g)
@@ -2965,7 +2895,6 @@ temp_pntrString *pntrAddElement(const pntrString *g)
   return v;
 }
 
-
 /* Add a single null pntrString element to a pntrString -faster than pntrCat */
 temp_pntrString *pntrAddGElement(const pntrString *g)
 {
@@ -2977,11 +2906,9 @@ temp_pntrString *pntrAddGElement(const pntrString *g)
   return v;
 }
 
-
 /*******************************************************************/
 /*********** Miscellaneous utility functions ***********************/
 /*******************************************************************/
-
 
 /* 0/1 knapsack algorithm */
 /* Returns the maximum worth (value) for items that can fit into maxSize */
@@ -3047,7 +2974,6 @@ long knapsack01(long items, /* # of items available to populate knapsack */
   return a;
 } /* knapsack01 */
 
-
 /* Allocate a 2-dimensional long integer matrix */
 /* Warning:  only entries 0,...,xsize-1 and 0,...,ysize-1 are allocated;
    don't use entry xsize or ysize! */
@@ -3066,7 +2992,6 @@ long **alloc2DMatrix(size_t xsize, size_t ysize)
   return matrix;
 } /* alloc2DMatrix */
 
-
 /* Free a 2-dimensional long integer matrix */
 /* Note: the ysize argument isn't used, but is commented out as
    a reminder so the caller doesn't confuse x and y */
@@ -3081,7 +3006,6 @@ void free2DMatrix(long **matrix, size_t xsize /*, size_t ysize*/)
   free(matrix);
   return;
 } /* free2DMatrix */
-
 
 /* Returns the amount of indentation of a statement label.  Used to
    determine how much to indent a saved proof. */
@@ -3107,7 +3031,6 @@ long getSourceIndentation(long statemNum) {
   return indentation;
 } /* getSourceIndentation */
 
-
 /* Returns the last embedded comment (if any) in the label section of
    a statement.  This is used to provide the user with information in the SHOW
    STATEMENT command.  The caller must deallocate the result. */
@@ -3128,7 +3051,6 @@ vstring getDescription(long statemNum) {
       8 + 128 /* discard leading and trailing blanks */));
   return description;
 } /* getDescription */
-
 
 /* Returns the label section of a statement with all comments except the
    last removed.  Unlike getDescription, this function returns the comment
@@ -3187,7 +3109,6 @@ vstring getDescriptionAndLabel(long stmt) {
 
   return descriptionAndLabel;
 } /* getDescriptionAndLabel */
-
 
 /* Returns 0 or 1 to indicate absence or presence of an indicator in
    the comment of the statement. */
@@ -3267,7 +3188,6 @@ flag getMarkupFlag(long statemNum, flag mode) {
   bug(1394);
   return 0;
 } /* getMarkupFlag */
-
 
 /* Extract contributor or date from statement description per the
    following mode argument:
@@ -3511,7 +3431,6 @@ vstring getContrib(long stmtNum, char mode) {
          seg(description, sMid + 1, sEnd - 1));
     }
 
-
     /* Get the most recent date */
     let((vstring *)(&(mostRecentDateList[stmtNum])),
         (vstring)(contribDateList[stmtNum]));
@@ -3653,7 +3572,6 @@ vstring getContrib(long stmtNum, char mode) {
         str((double)stmtNum), ", label \"", g_Statement[stmtNum].labelName, "\".",
         NULL), "    ", " ");
   }
-
 
   /*********  Turn off this warning unless we decide not to allow this
   if ((firstR != rStart) || (firstS != sStart)) {
@@ -3809,7 +3727,6 @@ vstring getContrib(long stmtNum, char mode) {
     let(&returnStr, "P");  /* pass */
   }
 
-
  RETURN_POINT:
 
   free_vstring(description);
@@ -3829,7 +3746,6 @@ vstring getContrib(long stmtNum, char mode) {
 
   return returnStr;
 } /* getContrib */
-
 
 /* Extract up to 2 dates after a statement's proof.  If no date is present,
    date1 will be blank.  If no 2nd date is present, date2 will be blank.
@@ -3861,7 +3777,6 @@ void getProofDate(long stmtNum, vstring *date1, vstring *date2) {
   return;
 } /* getProofDate */
 
-
 /* Get date, month, year fields from a dd-mmm-yyyy date string,
    where dd may be 1 or 2 digits, mmm is 1st 3 letters of month,
    and yyyy is 2 or 4 digits.  A 1 is returned if an error was detected. */
@@ -3886,7 +3801,6 @@ flag parseDate(vstring dateStr, long *dd, long *mmm, long *yyyy) {
   return err;
 } /* parseDate */
 
-
 /* Build date from numeric fields.  mmm should be a number from 1 to 12.
    There is no error-checking. */
 void buildDate(long dd, long mmm, long yyyy, vstring *dateStr) {
@@ -3894,7 +3808,6 @@ void buildDate(long dd, long mmm, long yyyy, vstring *dateStr) {
       str((double)yyyy), NULL));
   return;
 } /* buildDate */
-
 
 /* Compare two dates in the form dd-mmm-yyyy.  -1 = date1 < date2,
    0 = date1 = date2,  1 = date1 > date2.  There is no error checking. */
@@ -3926,7 +3839,6 @@ flag compareDates(vstring date1, vstring date2) {
     return 1;
   }
 } /* compareDates */
-
 
 /* Compare strings via pointers for qsort */
 /* g_qsortKey is a global string key at which the sort starts; if empty,

--- a/src/mmdata.h
+++ b/src/mmdata.h
@@ -179,7 +179,7 @@ typedef nmbrString temp_nmbrString;
  * \ref pgStack "stack of temporary data".  Pointers of this type should ONLY
  * refer to dynamically allocated memory on the heap.  Special commands support
  * dependency tracking and free all pointers on and after a particular one in
- * such a stack. 
+ * such a stack.
  */
 typedef pntrString temp_pntrString;
 
@@ -363,7 +363,7 @@ void *poolMalloc(long size /* bytes */);
  * \pre
  *   - \p ptr refers to dynamically allocated memory on the heap.
  *   - all memory pointed to by \p ptr is considered free.  This holds even if it
- *     it is kept in \ref memUsedPool. 
+ *     it is kept in \ref memUsedPool.
  * \post
  *   - \ref poolTotalFree is updated
  *   - Exit on out-of-memory (the \ref memFreePool overflows)
@@ -458,7 +458,6 @@ void outOfMemory(const char *msg);
  */
 void bug(int bugNum);
 
-
 /*! Null nmbrString -- -1 flags the end of a nmbrString */
 struct nullNmbrStruct {
     long poolLoc;
@@ -546,7 +545,7 @@ extern struct nullPntrStruct g_PntrNull;
  * \def free_pntrString
  * \param[in,out] x variable name
  * Assigns \ref NULL_PNTRSTRING to a variable \ref pntrString \p x.  Frees all
- * \ref pntrTempAllocStack, beginning with index 
+ * \ref pntrTempAllocStack, beginning with index
  * \ref g_pntrStartTempAllocStack.  See \ref pntrLet.
  * \pre
  *   - the \ref pgBlock assigned to \p x does not contain any valuable data.
@@ -563,7 +562,6 @@ extern struct nullPntrStruct g_PntrNull;
  */
 #define free_pntrString(x) pntrLet(&x, NULL_PNTRSTRING)
 
-
 /*! This function returns a 1 if any entry in a comma-separated list
    matches using the matches() function. */
 flag matchesList(const char *testString, const char *pattern, char wildCard,
@@ -574,7 +572,6 @@ flag matchesList(const char *testString, const char *pattern, char wildCard,
    exactly-1 character match wildcards, typically '*' and '?'.*/
 flag matches(const char *testString, const char *pattern, char wildCard,
     char oneCharWildCard);
-
 
 /*******************************************************************/
 /*********** Number string functions *******************************/
@@ -596,7 +593,6 @@ temp_nmbrString *nmbrMakeTempAlloc(nmbrString *s);
                                     released by next nmbrLet() */
 
 /**************************************************/
-
 
 /*! String assignment - MUST be used to assign vstrings */
 void nmbrLet(nmbrString **target, const nmbrString *source);
@@ -665,7 +661,6 @@ temp_nmbrString *nmbrIntersection(const nmbrString *m1, const nmbrString *m2);
    variable lists) */
 temp_nmbrString *nmbrSetMinus(const nmbrString *m1,const nmbrString *m2);
 
-
 /*! This is a utility function that returns the length of a subproof that
    ends at step */
 long nmbrGetSubproofLen(const nmbrString *proof, long step);
@@ -711,7 +706,6 @@ temp_vstring compressProof(const nmbrString *proof, long statemNum,
 /*! Gets length of the ASCII form of a compressed proof */
 long compressedProofSize(const nmbrString *proof, long statemNum);
 
-
 /*******************************************************************/
 /*********** Pointer string functions ******************************/
 /*******************************************************************/
@@ -756,7 +750,6 @@ extern long g_pntrStartTempAllocStack; /* Where to start freeing temporary
 temp_pntrString *pntrMakeTempAlloc(pntrString *s);
 
 /**************************************************/
-
 
 /*!
  * \fn void pntrLet(pntrString **target, const pntrString *source)
@@ -877,12 +870,12 @@ flag pntrEq(const pntrString *sout, const pntrString *sin);
  *   \ref pgBlock.  It is assumed it is an array of pointer to \ref vstring.
  * \return a copy of \p g, the terminal NULL replaced with a \ref vstring ""
  *   followed by NULL.
- * \attention   
+ * \attention
  *   the pointers in \p g are copied to the result.  If some of them
  *   reference allocated memory, check for possible double free, for example.
  * \pre
  *   Intended to be used with arrays of \ref vstring * only.
- * \post 
+ * \post
  *   the elements of \p g are duplicated.
  */
 temp_pntrString *pntrAddElement(const pntrString *g);
@@ -920,7 +913,6 @@ flag getMarkupFlag(long statemNum, char mode);
    See GC_RESET etc. modes above.  Caller must deallocate returned
    string. */
 vstring getContrib(long stmtNum, char mode);
-
 
 /*! Extract up to 2 dates after a statement's proof.  If no date is present,
    date1 will be blank.  If no 2nd date is present, date2 will be blank. */

--- a/src/mmfatl.c
+++ b/src/mmfatl.c
@@ -38,9 +38,7 @@ enum {
   LF = '\n',
 };
 
-
 // ***     utility code used in the implementation of the interface    ***
-
 
 /*!
  * \brief a buffer used to generate a text message through a formatting
@@ -233,7 +231,7 @@ static struct ParserState state;
  *
  * Initializes \ref state.
  * \param[in,out] state [not null] the struct \ref ParserState to initialize.
- * \param[in,out] buffer [not null] the buffer to use for output 
+ * \param[in,out] buffer [not null] the buffer to use for output
  * \post establish the invariant in state
  */
 static void initState(struct ParserState* state, struct Buffer* buffer) {
@@ -351,7 +349,7 @@ static void handleSubstitution(struct ParserState* state) {
       arg = va_arg(state->args, char const*);
       break;
     case MMFATL_PH_UNSIGNED:
-      // a %u format specifier is recognized. 
+      // a %u format specifier is recognized.
       arg = unsignedToString(va_arg(state->args, unsigned));
       break;
     case MMFATL_PH_PREFIX:
@@ -408,7 +406,7 @@ inline static struct Buffer* getBufferInstance(void) {
  * Gets the instance of ParserState to use with this interface (currently a
  * global singleton).  The returned instance is not guaranteed to be
  * initialized.
- * \return [not null] a pointer to the ParserState instance 
+ * \return [not null] a pointer to the ParserState instance
  */
 inline static struct ParserState* getParserStateInstance(void) {
   return &state;
@@ -477,7 +475,6 @@ void fatalErrorExitAt(char const* file, unsigned line,
 
   fatalErrorPrintAndExit();
 }
-
 
 //=================   Regression tests   =====================
 
@@ -586,7 +583,6 @@ static bool test_appendText(void) {
   // uncomment to deliberately trigger an error message
   // TESTCASE_appendText("_$", 1, "x$", -1, 2, 1);
 
-
   // corner case 1: insertion at the very beginning of the buffer
   TESTCASE_appendText("_$", 1, "$", -1, 2, 1);
   // corner case 2: empty text, placeholder handling
@@ -620,7 +616,7 @@ static bool test_isBufferEmpty(void) {
   limitFreeBuffer(0);
   ASSERT(!isBufferEmpty(&buffer));
 
-  return true;  
+  return true;
 }
 
 static bool test_getLastBufferedChar(void) {
@@ -632,7 +628,7 @@ static bool test_getLastBufferedChar(void) {
   appendText("bc", STRING, &buffer);
   ASSERT(getLastBufferedChar(&buffer) == 'b');
 
-  return true;  
+  return true;
 }
 
 static bool test_handleText(void) {
@@ -657,8 +653,8 @@ static bool test_handleText(void) {
   state.format = "%s";
   handleText(&state);
   ASSERT(*state.format == '%');
-  ASSERT(buffer.begin == buffer.text + 1);  
-  
+  ASSERT(buffer.begin == buffer.text + 1);
+
   state.format = "abc";
   handleText(&state);
   ASSERT(strcmp(buffer.text, "$a$") == 0);
@@ -679,7 +675,7 @@ bool test_unsignedToString(void)
 
 static bool test_handleSubstitution1(char const* format, ...) {
   va_start(state.args, format);
-  
+
   // without initializing the buffer each test appends
   // to the result of the former test.
 
@@ -774,7 +770,7 @@ static char const* testcase_parse(char const* expect, char const* format, ...) {
   parse(&state);
   va_end(state.args);
   return strcmp(buffer.text, expect) == 0?
-    NULL 
+    NULL
     : "text mismatch";
 }
 
@@ -841,15 +837,15 @@ static bool test_fatalErrorPrintAndExit(void) {
   fatalErrorInit(); // pre-condition
   fatalErrorPrintAndExit();
   ASSERT(strcmp(buffer.text, "") == 0);
-  
+
   fatalErrorPush("aaa");
   fatalErrorPrintAndExit();
   ASSERT(strcmp(buffer.text, "aaa\n") == 0);
-  
-  // no second \n is appended 
+
+  // no second \n is appended
   fatalErrorPrintAndExit();
   ASSERT(strcmp(buffer.text, "aaa\n") == 0);
-  
+
   // in overflow condition do not append a LF
   fatalErrorInit();
   while (!isBufferOverflow(&buffer)) // fill the buffer with "a"
@@ -878,7 +874,6 @@ static bool test_fatalErrorExitAt() {
 
   return true;
 }
-
 
 void test_mmfatl(void) {
   RUN_TEST(test_unsignedToString);

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -84,7 +84,6 @@
 
 // ***   Export basic features of the fatal error message processing   ***/
 
-
 /*!
  * \brief size of a text buffer used to construct a message
  *
@@ -131,10 +130,9 @@ enum fatalErrorPlaceholderType {
 
 // ***   Interface of fatal error message processing   ***/
 
-
 /*!
  * \brief Prepare internal data structures for an error message.
- * 
+ *
  * Empties the message buffer used to construct error messages by
  * \ref fatalErrorPush.
  *
@@ -154,16 +152,15 @@ enum fatalErrorPlaceholderType {
  */
 extern void fatalErrorInit(void);
 
-
 /*!
  * \brief append text to the current contents in the message buffer.
- * 
+ *
  * Appends new text to the message buffer.  The submitted extra parameters
  * following \p format must match the placeholders in the \p format string
  * in type.  It is possible to add more parameters than necessary (they are
  * simply ignored then), but never fewer.  The caller is responsible for
  * this pre-condition, no runtime check is performed.
- * 
+ *
  * \param[in] format [null] a format string containing NUL terminated ASCII
  *   encoded text, along with embedded placeholders, that are replaced with
  *   parameters following \p format in the call.
@@ -187,8 +184,7 @@ extern void fatalErrorInit(void);
  *   prompt following it is displayed on a new line.  If it is missing
  *   \ref fatalErrorPrintAndExit will supply one, but relying on this adds an
  *   unnecessary correction under severe conditions.
- *   
- * 
+ *
  * The \p format is followed by a possibly empty list of parameters substituted
  *   for placeholders.  Currently unsigned int values may replace a
  *   \ref MMFATL_PH_UNSIGNED type placeholder (%u), and a char const* pointer a
@@ -197,7 +193,7 @@ extern void fatalErrorInit(void);
  *   to ASCII encoded NUL terminated text.  No value is required for the
  *   \ref MMFATL_PH_PREFIX type tokens.
  * \return false iff the message buffer is in overflow state.
- * 
+ *
  * \pre the buffer is initialized, by calling \ref fatalErrorInit prior
  * \pre the submitted parameters following \p format must match in type and
  *   order the placeholders in \p format.  Their count may exceed that of the
@@ -217,7 +213,7 @@ extern bool fatalErrorPush(char const* format, ...);
 
 /*!
  * \brief display buffer contents and exit program with code EXIT_FAILURE.
- * 
+ *
  * This function does not return.
  *
  * A NUL terminated message has been prepared in an internal buffer using a

--- a/src/mmhlpa.c
+++ b/src/mmhlpa.c
@@ -85,7 +85,6 @@ H("type it ahead to let you know when the current command is finished.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP ADD")) {
 H("This command adds a character string prefix and/or suffix to each");
 H("line in a file.  To add only a prefix, set <endstr> to the empty string,");
@@ -159,13 +158,11 @@ H("Syntax:  SUBSTITUTE <iofile> <oldstr> <newstr> <occurrence> <matchstr>");
 H("Note: The SUBSTITUTE command may be abbreviated by S.");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SWAP")) {
 H("This command swaps the parts of each line before and after a");
 H("specified string <middle>.");
 H("Syntax:  SWAP <iofile> <middle>");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP INSERT")) {
 H("This command inserts a string at a specified column in each line");
@@ -175,7 +172,6 @@ H("line is shorter than <column>, then it is padded with spaces so that");
 H("<string> is still added at <column>.");
 H("Syntax:  INSERT <iofile> <string> <column>");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP BREAK")) {
 H("This command breaks up a file into tokens, one per line, breaking at");
@@ -191,13 +187,11 @@ H("as many as will fit per line, separating them with spaces.");
 H("Syntax:  BUILD <iofile>");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP MATCH")) {
 H("This command extracts from a file those lines containing (Y) or not");
 H("containing (N) a specified string.");
 H("Syntax:  MATCH <iofile> <matchstr> <Y/N>");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP SORT")) {
 H("This command sorts a file, comparing lines starting at a key string.");
@@ -206,12 +200,10 @@ H("If a line doesn't contain the key, it is compared starting at column 1.");
 H("Syntax:  SORT <iofile> <key>");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP UNDUPLICATE")) {
 H("This command sorts a file then removes any duplicate lines from the output.");
 H("Syntax:  UNDUPLICATE <iofile>");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP DUPLICATE")) {
 H("This command finds all duplicate lines in a file and places them, in");
@@ -219,19 +211,16 @@ H("sorted order, into the output file.");
 H("Syntax:  DUPLICATE <iofile>");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP UNIQUE")) {
 H("This command finds all unique lines in a file and places them, in");
 H("sorted order, into the output file.");
 H("Syntax:  UNIQUE <iofile>");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP REVERSE")) {
 H("This command reverses the order of the lines in a file.");
 H("Syntax:  REVERSE <iofile>");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP RIGHT")) {
 H("This command right-justifies the lines in a file by putting spaces in");
@@ -240,7 +229,6 @@ H("in the file.");
 H("Syntax:  RIGHT <iofile>");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP PARALLEL")) {
 H("This command puts two files side-by-side.");
 H("The two files should have the same number of lines; if not, a warning is");
@@ -248,13 +236,11 @@ H("issued and the longer file paralleled with empty strings at the end.");
 H("Syntax:  PARALLEL <inpfile1> <inpfile2> <outfile> <btwnstr>");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP NUMBER")) {
 H("This command creates a list of numbers.  Hint:  Use the RIGHT command to");
 H("right-justify the list after creating it.");
 H("Syntax:  NUMBER <outfile> <first> <last> <incr>");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP COUNT")) {
 H("This command counts the occurrences of a string in a file and displays");
@@ -264,7 +250,6 @@ H("numbers.");
 H("Syntax:  COUNT <inpfile> <string>");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP TYPE") || !strcmp(helpCmd, "HELP T")) {
 H("This command displays (i.e. types out) the first n lines of a file on the");
 H("terminal screen.  If n is not specified, it will default to 10.  If n is");
@@ -272,7 +257,6 @@ H("the string \"ALL\", then the whole file will be typed.");
 H("Syntax:  TYPE <inpfile> <n>");
 H("Note: The TYPE command may be abbreviated by T.");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP COPY") || !strcmp(helpCmd, "HELP C")) {
 H("This command copies (concatenates) all input files in a comma-separated");
@@ -357,7 +341,6 @@ H("SUBMIT can be called recursively, i.e., SUBMIT commands are allowed");
 H("inside of a command file.");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SYSTEM")) {
 H("A line enclosed in single or double quotes will be executed by your");
 H("computer's operating system, if it has such a feature.  For example, on a");
@@ -375,7 +358,6 @@ free_vstring(saveHelpCmd); /* Deallocate memory */
 
 return;
 } /* help0 */
-
 
 void help1(vstring helpCmd) {
 
@@ -604,7 +586,6 @@ H("       recursive, or self reference to a file is ignored");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP MARKUP")) {
 H("(See HELP VERIFY MARKUP for the markup language used in database");
 H("comments.)");
@@ -658,7 +639,6 @@ H("characters in math symbols.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP EXPLORE")) {
 H("When you first enter Metamath, you will first want to READ in a Metamath");
 H("source file.  The source file provided for set theory is called set.mm;");
@@ -694,7 +674,6 @@ H("    SHOW USAGE <label> - Shows what later proofs make use of this");
 H("        statement.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP HTML")) {
 H("(Note: See HELP WRITE SOURCE for the \"<HTML>\" tag in comments.)");
@@ -825,7 +804,6 @@ H("containing a $t token.  See the set.mm file for an example.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP BEEP") || !strcmp(helpCmd, "HELP B")) {
 H("Syntax:  BEEP");
 H("");
@@ -840,14 +818,12 @@ H("command.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP QUIT")) {
 H("Syntax:  QUIT [/ FORCE]");
 H("");
 H("This command is a synonym for EXIT.  See HELP EXIT.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP EXIT")) {
 H("Syntax:  EXIT [/ FORCE]");
@@ -875,7 +851,6 @@ H("unconditionally.  This means any unsaved work will be lost.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP _EXIT_PA")) {
 H("Syntax:  _EXIT_PA [/ FORCE]");
 H("");
@@ -885,7 +860,6 @@ H("can help prevent accidentally exiting Metamath when a script fails to");
 H("enter the Proof Assistant (PROVE command).  See HELP EXIT.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP READ")) {
 H("Syntax:  READ <file> [/ VERIFY]");
@@ -915,7 +889,6 @@ H("See also HELP ERASE.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP ERASE")) {
 H("Syntax:  ERASE");
 H("");
@@ -925,7 +898,6 @@ H("database.  The user will be prompted for confirmation if the database was");
 H("changed but not saved with WRITE SOURCE.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP OPEN LOG")) {
 H("Syntax:  OPEN LOG <file>");
@@ -942,7 +914,6 @@ H("closed upon exiting Metamath.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP CLOSE LOG")) {
 H("Syntax:  CLOSE LOG");
 H("");
@@ -950,7 +921,6 @@ H("The CLOSE LOG command closes a log file if one is open.  See also OPEN");
 H("LOG.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP OPEN TEX")) {
 H("Syntax:  OPEN TEX <file> [/ NO_HEADER] [/ OLD_TEX]");
@@ -976,7 +946,6 @@ H("See also CLOSE TEX.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP CLOSE TEX")) {
 H("Syntax:  CLOSE TEX");
 H("");
@@ -986,7 +955,6 @@ H("");
 H("See also OPEN TEX.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP TOOLS")) {
 H("Syntax:  TOOLS");
@@ -1159,7 +1127,6 @@ H("See also");
 H("https://github.com/metamath/set.mm/pull/1761#issuecomment-672433658");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP WRITE RECENT_ADDITIONS")) {
 H("Syntax:  WRITE RECENT_ADDITIONS <filename>");
 H("");
@@ -1184,8 +1151,6 @@ H("GIF format unless ALT_HTML was previously set as shown in SHOW SETTINGS.");
 H("");
 }
 
-
-free_vstring(saveHelpCmd); /* Deallocate memory */
+free_vstring(saveHelpCmd); // deallocate memory
 return;
-
-} /* help1 */
+} // help1

--- a/src/mmhlpb.c
+++ b/src/mmhlpb.c
@@ -57,7 +57,6 @@ if (!strcmp(saveHelpCmd, "HELP COMMENTS")) {
     H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP INVOKE")) {
 H("To invoke Metamath from a Unix/Linux/MacOSX prompt, assuming that the");
 H("Metamath program is in the current directory, type");
@@ -107,14 +106,12 @@ H("on modern machines with virtual memory.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SHOW SETTINGS")) {
 H("Syntax:  SHOW SETTINGS");
 H("");
 H("This command shows the state of various parameters.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP SHOW ELAPSED_TIME")) {
 H("Syntax:  SHOW ELAPSED_TIME");
@@ -123,7 +120,6 @@ H("This command shows the time elapsed in the session and from any");
 H("previous use of SHOW ELAPSED_TIME.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP SHOW LABELS")) {
 H("Syntax:  SHOW LABELS <label-match> [/ ALL] [/ LINEAR]");
@@ -138,7 +134,6 @@ H("    / LINEAR - Display only one label per line.  This can be useful for");
 H("        building scripts in conjunction with the TOOLS utility.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP SHOW DISCOURAGED")) {
 H("Syntax:  SHOW DISCOURAGED");
@@ -160,7 +155,6 @@ H("but SHOW SOURCE can be used to see statements with multiple comments");
 H("and to see the exact content of the Metamath database.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP SHOW STATEMENT")) {
 H("Syntax:  SHOW STATEMENT <label-match> [/ COMMENT] [/ FULL] [/ TEX]");
@@ -204,7 +198,6 @@ H("        Mnemosyne http://www.mnemosyne-proj.org/principles.php.  Should");
 H("        not be used with any other qualifier.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP SHOW PROOF")) {
 H("Syntax:  SHOW PROOF <label-match> [<qualifiers (see below)>]");
@@ -276,7 +269,6 @@ H("        HELP SAVE PROOF.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP MIDI")) {
 H("Syntax:  MIDI <label> [/ PARAMETER \"<parameter string>\"]");
 H("");
@@ -320,7 +312,6 @@ H("Quotes around the parameter string are optional if it has no spaces.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SHOW NEW_PROOF")) {
 H("Syntax:  SHOW NEW_PROOF [<qualifiers (see below)]");
 H("");
@@ -345,7 +336,6 @@ H("See also:  SHOW PROOF");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SHOW USAGE")) {
 H("Syntax:  SHOW USAGE <label-match> [/ RECURSIVE]");
 H("");
@@ -367,7 +357,6 @@ free_vstring(saveHelpCmd); /* Deallocate memory */
 return;
 } /* help2 */
 
-
 /* Split up help2 into help2 and help3 so lcc optimizer wouldn't overflow */
 void help3(vstring helpCmd) {
 
@@ -378,7 +367,6 @@ vstring_def(saveHelpCmd);
    allocated copy here.  (And after this let(), helpCmd will become invalid
    for the same reason.)  */
 let(&saveHelpCmd, helpCmd);
-
 
 if (!strcmp(saveHelpCmd, "HELP SHOW TRACE_BACK")) {
 H("Syntax:  SHOW TRACE_BACK <label-match> [/ ESSENTIAL] [/ AXIOMS] [/ TREE]");
@@ -412,7 +400,6 @@ H("        multiple paths from ac6s back to ax-reg, all statements involved");
 H("        in all paths are listed.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP SEARCH")) {
 H("Syntax:  SEARCH <label-match> \"<symbol-match>\" [/ ALL] [/ COMMENTS]");
@@ -489,7 +476,6 @@ H("characters.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SET ECHO")) {
 H("Syntax:  SET ECHO ON or SET ECHO OFF");
 H("");
@@ -503,7 +489,6 @@ H("prepended to each echoed command line.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SET SCROLL")) {
 H("Syntax:  SET SCROLL PROMPTED or SET SCROLL CONTINUOUS");
 H("");
@@ -513,7 +498,6 @@ H("screenful of a long listing.  In CONTINUOUS mode, long listings will be");
 H("scrolled without pausing.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP SET WIDTH")) {
 H("Syntax:  SET WIDTH <number>");
@@ -532,7 +516,6 @@ H("");
 H("Note:  This command was SET SCREEN_WIDTH prior to Version 0.07.9.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP SET HEIGHT")) {
 H("Syntax:  SET HEIGHT <number>");
@@ -599,7 +582,6 @@ H("again.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SET EMPTY_SUBSTITUTION")) {
 H("Syntax:  SET EMPTY_SUBSTITUTION ON or SET EMPTY_SUBSTITUTION OFF");
 H("");
@@ -620,7 +602,6 @@ H("empty assumption lists would be permissible.)");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SET SEARCH_LIMIT")) {
 H("Syntax:  SET SEARCH_LIMIT <number>");
 H("");
@@ -633,7 +614,6 @@ H("value.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SET JEREMY_HENTY_FILTER")) {
 H("Syntax:  SET JEREMY_HENTY_FILTER ON or SET JEREMY_HENTY_FILTER OFF");
 H("");
@@ -645,7 +625,6 @@ H("\"equivalent\" ones in a sense defined by Henty.  Normally this filter");
 H("is ON, and the only reason to turn it off would be for debugging.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP VERIFY PROOF")) {
 H("Syntax:  VERIFY PROOF <label-match> [/ SYNTAX_ONLY]");
@@ -667,7 +646,6 @@ H("from errors in Metamath language but will not check the markup language");
 H("in comments.  See HELP VERIFY MARKUP.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP VERIFY MARKUP")) {
 H("Syntax:  VERIFY MARKUP <label-match> [/ DATE_SKIP] [/ TOP_DATE_CHECK]");
@@ -717,7 +695,6 @@ H("see the 21-Dec-2017 entry in http://us.metamath.org/mpeuni/mmnotes.txt .");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SUBMIT")) {
 H("Syntax:  SUBMIT <filename> [/ SILENT]");
 H("");
@@ -740,7 +717,6 @@ H("        file itself).  The screen output of any operating system commands");
 H("        inside the command file (see HELP SYSTEM) is not suppressed.");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SYSTEM")) {
 H("A line enclosed in single or double quotes will be executed by your");
 H("computer's operating system, if it has such a feature.  For example, on a");
@@ -753,7 +729,6 @@ H("For your convenience, the trailing quote is optional, for example:");
 H("    MM> 'ls | less -EX");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP MM-PA")) {
 H("See HELP PROOF_ASSISTANT");
@@ -770,7 +745,6 @@ H("do this, such as \"less -EX\" in Linux.)");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP FILE SEARCH")) {
 H("Syntax:  FILE SEARCH <filename> \"<search string>\" [/ FROM_LINE");
 H("             <number>] [/ TO_LINE <number>]");
@@ -782,7 +756,6 @@ H("deprecated.  See HELP SYSTEM to invoke your operating system's");
 H("equivalent command, such as \"grep\" in Linux.)");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP PROVE")) {
 H("Syntax:  PROVE <label> [/ OVERRIDE]");
@@ -799,7 +772,6 @@ H("");
 H("See also:  HELP PROOF_ASSISTANT and HELP EXIT");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP PROOF_ASSISTANT")) {
 H("Before using the Proof Assistant, you must add a $p to your source file");
@@ -912,7 +884,6 @@ H("See also HELP REDO and HELP SET UNDO.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP REDO")) {
 H("Syntax:  REDO");
 H("");
@@ -923,7 +894,6 @@ H("were issued after the last UNDO.  A sequence of REDOs will reverse as");
 H("many UNDOs as were issued since the last proof-changing command.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP SET UNDO")) {
 H("Syntax:  SET UNDO <number>");
@@ -938,7 +908,6 @@ H("If this command is issued while inside of the Proof Assistant, the");
 H("UNDO stack is reset (i.e. previous possible UNDOs will be lost).");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP ASSIGN")) {
 H("Syntax:  ASSIGN <step> <label> [/ NO_UNIFY] [/ OVERRIDE]");
@@ -972,7 +941,6 @@ H("        if \"(New usage is discouraged.)\" is present in the statement's");
 H("        description comment.  This qualifier will allow the assignment.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP REPLACE")) {
 H("Syntax:  REPLACE <step> <label> [/ OVERRIDE]");
@@ -1041,7 +1009,6 @@ H("    / ESSENTIAL_ONLY - in the MATCH ALL statement, only the steps that");
 H("        would be listed in SHOW NEW_PROOF display are matched.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP LET")) {
 H("Syntax:  LET VARIABLE <variable> = \"<symbol sequence>\"");
@@ -1113,7 +1080,6 @@ H("  MM-PA> SHOW NEW_PROOF/UNKNOWN");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP UNIFY")) {
 H("HELP UNIFY");
 H("Syntax:  UNIFY STEP <step>");
@@ -1135,7 +1101,6 @@ H("it to 1000000 can help difficult cases.  The LET VARIABLE command to");
 H("manually assign unknown variables also helps difficult cases.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP INITIALIZE")) {
 H("Syntax:  INITIALIZE ALL");
@@ -1163,7 +1128,6 @@ H("See also:  UNIFY and DELETE");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP DELETE")) {
 H("Syntax:  DELETE STEP <step>");
 H("         DELETE ALL");
@@ -1182,7 +1146,6 @@ H("step with a $f hypothesis as the target is completely known, the IMPROVE");
 H("command can usually fill in the proof for that step.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP IMPROVE")) {
 H("Syntax:  IMPROVE <step> [/ DEPTH <number>] [/ NO_DISTINCT] [/ 2] [/ 3]");
@@ -1271,7 +1234,6 @@ H("See also:  HELP SET SEARCH_LIMIT");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP MINIMIZE_WITH")) {
 H("Syntax:  MINIMIZE_WITH <label-match> [/ VERBOSE] [/ MAY_GROW]");
 H("              [/ EXCEPT <label-match>] [/ INCLUDE_MATHBOXES]");
@@ -1343,7 +1305,6 @@ H("    / TIME - prints out the run time used by the MINIMIZE_WITH run.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP EXPAND")) {
 H("Syntax:  EXPAND <label-match>");
 H("");
@@ -1359,7 +1320,6 @@ H("labels rather than EXPAND * because the proof size grows exponentially as");
 H("each layer is eliminated.");
 H("");
 }
-
 
 if (!strcmp(saveHelpCmd, "HELP SAVE PROOF")) {
 H("Syntax:  SAVE PROOF <label-match> [/ <qualifier>] [/ <qualifier>]...");
@@ -1401,7 +1361,6 @@ H("affecting any proofs.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP SAVE NEW_PROOF")) {
 H("Syntax:  SAVE NEW_PROOF <label-match> [/ <qualifier>] [/ <qualifier>]...");
 H("");
@@ -1430,7 +1389,6 @@ H("Note that if no qualifier is specified, / NORMAL is assumed.");
 H("");
 }
 
-
 if (!strcmp(saveHelpCmd, "HELP DEMO")) {
 H("For a quick demo that enables you to see Metamath do something, type");
 H("the following:");
@@ -1446,7 +1404,6 @@ H("will show all statements with subset then union in them.");
 H("");
 }
 
-if (strcmp(helpCmd, saveHelpCmd)) bug(1401); /* helpCmd got corrupted */
-free_vstring(saveHelpCmd); /* Deallocate memory */
-
+if (strcmp(helpCmd, saveHelpCmd)) bug(1401); // helpCmd got corrupted
+free_vstring(saveHelpCmd); // deallocate memory
 }

--- a/src/mminou.c
+++ b/src/mminou.c
@@ -39,7 +39,6 @@ extern int cprintf(const char *f__mt,...);
  */
 #define QUOTED_SPACE 3 /* ASCII 3 that temporarily zaps a space */
 
-
 int g_errorCount = 0;
 
 /* Global variables used by print2() */
@@ -279,7 +278,6 @@ flag print2(const char* fmt, ...) {
           if (!backFromCmdInput)
             localScrollMode = 0; /* Continuous scroll */
           break;
-
         }
         if (backBufferPos > 1) {
           if (c == 'b' || c == 'B') {
@@ -316,11 +314,9 @@ flag print2(const char* fmt, ...) {
     }
   }
 
-
   /* User typed 'q' above or earlier; don't return if we're outputting to
     a string since we want to complete the writing to the string. */
   if (g_quitPrint && !g_outputToString) goto PRINT2_RETURN;
-
 
 /* step (4) evaluate the output text */
 
@@ -395,7 +391,6 @@ flag print2(const char* fmt, ...) {
       */
       fflush(stdout);
 #endif
-
     } else {
 
 /* step (7) print to screen, part 2 */
@@ -487,7 +482,6 @@ flag print2(const char* fmt, ...) {
  PRINT2_RETURN:
   return !g_quitPrint;
 }
-
 
 /* printLongLine automatically puts a newline \n in the output line. */
 /* startNextLine is the string to place before continuation lines. */
@@ -594,14 +588,12 @@ void printLongLine(const char *line, const char *startNextLine, const char *brea
     }
   } /* if (breakMatch1[0] == '\"') */
 
-
   /* The tilde is a special flag for printLongLine to print a
      tilde before the carriage return in a split line, not after */
   if (startNextLine1[0] == '~') {
     tildeFlag = 1;
     let(&startNextLine1, " ");
   }
-
 
   while (multiLine[0]) { /* While there are multiple caller-inserted newlines */
 
@@ -738,7 +730,6 @@ void printLongLine(const char *line, const char *startNextLine, const char *brea
       print2("%s\n",longLine);
     }
     g_screenWidth = saveScreenWidth; /* Restore to normal */
-
   } /* end while multiLine != "" */
 
   free_vstring(multiLine); /* Deallocate */
@@ -796,7 +787,6 @@ vstring cmdInput(FILE *stream, const char *ask) {
 #if __STDC__
       fflush(stdout);
 #endif
-
     } else {
       /* The last line in the file has no new-line */
       if (g[i - 1] != '\n') {
@@ -953,7 +943,6 @@ vstring cmdInput1(const char *ask) {
         /* Put line in list.tmp as comment */
         fprintf(g_listFile_fp, "! %s\n", commandLn);
       }
-
     } else { /* Get line from SUBMIT file */
       commandLn = cmdInput(g_commandFilePtr[g_commandFileNestingLevel], NULL);
       if (!commandLn) { /* EOF found */
@@ -985,7 +974,6 @@ vstring cmdInput1(const char *ask) {
   free_vstring(ask1);
   return commandLn;
 } /* cmdInput1 */
-
 
 void errorMessage(vstring line, long lineNum, long column, long tokenLength,
   vstring error, vstring fileName, long statementNum, flag severity)
@@ -1100,7 +1088,6 @@ void errorMessage(vstring line, long lineNum, long column, long tokenLength,
   if (line1) free_vstring(line1);
 } /* errorMessage() */
 
-
 /* Opens files with error message; opens output files with
    backup of previous version.   Mode must be "r" or "w" or "d" (delete). */
 FILE *fSafeOpen(const char *fileName, const char *mode, flag noVersioningFlag) {
@@ -1156,7 +1143,6 @@ FILE *fSafeOpen(const char *fileName, const char *mode, flag noVersioningFlag) {
 
 #endif
 
-
       /* See if the lowest version already exists. */
       let(&bakName, cat(prefix, str(1), postfix, NULL));
       fp = fopen(bakName, "r");
@@ -1193,7 +1179,6 @@ FILE *fSafeOpen(const char *fileName, const char *mode, flag noVersioningFlag) {
           let(&newBakName, cat(prefix, str((double)v + 1), postfix, NULL));
           rename(bakName/*old*/, newBakName/*new*/);
         }
-
       }
       let(&bakName, cat(prefix, str(1), postfix, NULL));
       rename(fileName, bakName);
@@ -1236,10 +1221,8 @@ FILE *fSafeOpen(const char *fileName, const char *mode, flag noVersioningFlag) {
   } /* End if mode = "w" or "d" */
 
   bug(1510); /* Illegal mode */
-  return(NULL);
-
+  return NULL;
 } /* fSafeOpen() */
-
 
 /* Renames a file with backup of previous version.  If non-zero
    is returned, there was an error. */
@@ -1284,7 +1267,6 @@ int fSafeRename(const char *oldFileName, const char *newFileName) {
   return error;
 } /* fSafeRename */
 
-
 /* Finds the name of the first file of the form filePrefix +
    nnn + ".tmp" that does not exist.  THE CALLER MUST DEALLOCATE
    THE RETURNED STRING [i.e. assign function return directly
@@ -1312,7 +1294,6 @@ vstring fGetTmpName(const char *filePrefix) {
   }
   return fname; /* Caller must deallocate! */
 } /* fGetTmpName() */
-
 
 /* This function returns a character string containing the entire contents of
    an ASCII file, or Unicode file with only ASCII characters.   On some
@@ -1482,7 +1463,6 @@ vstring readFileToString(const char *fileName, char verbose, long *charCount) {
   return (char *)fileBuf;
 } /* readFileToString */
 
-
 /* Returns total elapsed time in seconds since starting session (for the
    lcc compiler) or the CPU time used (for the gcc compiler).  The
    argument is assigned the time since the last call to this function. */
@@ -1503,7 +1483,6 @@ double getRunTime(double *timeSinceLastCall) {
   return 0;
 #endif
 }
-
 
 void freeInOu(void) {
   long i, j;

--- a/src/mminou.c
+++ b/src/mminou.c
@@ -111,7 +111,7 @@ flag localScrollMode = 1;
  * \ref printedLines.  The moment this value indicates a full page, a new empty
  * page is pushed on the stack, and output is suspended to let the user read
  * displayed contents in rest.  A user prompt asks for resuming pending output,
- * alternatively s/he may step backwards and forward through the sequence of
+ * or alternatively step backwards and forward through the sequence of
  * saved pages for redisplay.  The variable \ref backBufferPos tracks which
  * page the user requested last (or points to the currently built-up page).
  *

--- a/src/mminou.h
+++ b/src/mminou.h
@@ -52,7 +52,6 @@ extern flag g_outputToString;
  */
 extern vstring g_printString;
 
-
 /* Global variables used by cmdInput() */
 
 /*!
@@ -97,7 +96,6 @@ extern flag g_commandFileSilent[MAX_COMMAND_FILE_NESTING + 1];
  * SUBMIT ... /SILENT commands.  Initialized to 0 on program start.
  */
 extern flag g_commandFileSilentFlag; /* For SUBMIT ... /SILENT */
-
 
 extern FILE *g_input_fp;  /*!< File pointers */
 extern vstring g_input_fn, g_output_fn;  /*!< File names */
@@ -277,7 +275,7 @@ extern vstring g_input_fn, g_output_fn;  /*!< File names */
  * \param[in] fmt (not null) NUL-terminated text to display with embedded
  *   placeholders for insertion of data (which are converted into text if
  *   necessary) pointed to by the following parameters.  The format string uses
- *   the same syntax as 
+ *   the same syntax as
  *   <a href="https://en.cppreference.com/w/c/io/fprintf">[printf]</a>.  A LF
  *   character must only be in final position, and ETX (0x03) is not allowed.
  *   This parameter is ignored when \ref backFromCmdInput is 1.

--- a/src/mmpars.c
+++ b/src/mmpars.c
@@ -27,13 +27,11 @@ long g_numLabelKeys; /* Number of assertion labels */
 long *g_allLabelKeyBase; /* Start of all labels */
 long g_numAllLabelKeys; /* Number of all labels */
 
-
 /* Working structure for parsing proofs */
 /* This structure should be deallocated by the ERASE command. */
 long g_wrkProofMaxSize = 0; /* Maximum size so far - it may grow */
 long wrkMathPoolMaxSize = 0; /* Max mathStringPool size so far - it may grow */
 struct wrkProof_struct g_WrkProof;
-
 
 /* This function returns a pointer to a buffer containing the contents of an
    input file and its 'include' calls.  'Size' returns the buffer's size.
@@ -82,7 +80,6 @@ char *readRawSource(vstring fileBuf, long *size) {
       fbPtr++;
       continue;
     }
-
 
     /* Detect missing whitespace around keywords (per current
        Metamath language spec) */
@@ -136,7 +133,6 @@ char *readRawSource(vstring fileBuf, long *size) {
           /* $[ ... $] should have been processed by readSourceAndIncludes() */
           rawSourceError(fileBuf, fbPtr - 1, 2,
               "\"$[\" is unterminated or has ill-formed \"$]\".");
-
         }
         continue;
       case ']':
@@ -169,8 +165,7 @@ char *readRawSource(vstring fileBuf, long *size) {
   print2("%ld bytes were read into the source buffer.\n", charCount);
 
   if (*size != charCount) bug(1761);
-  return (fileBuf);
-
+  return fileBuf;
 } /* readRawSource */
 
 /* This function initializes the g_Statement[] structure array and assigns
@@ -415,14 +410,12 @@ void parseKeywords(void)
      pinkHTML() in mmwtex.c */
   g_Statement[g_statements].pinkNumber = j;
 
-
 /*E*/if(db5){for (i=1; i<=g_statements; i++){
 /*E*/  if (i == 5) { print2("(etc.)\n");} else { if (i<5) {
 /*E*/  assignStmtFileAndLineNum(i);
 /*E*/  print2("Statement %ld: line %ld file %s.\n",i,g_Statement[i].lineNum,
 /*E*/      g_Statement[i].fileName);
 /*E*/}}}}
-
 }
 
 /* This function parses the label sections of the g_Statement[] structure array.
@@ -442,7 +435,6 @@ void parseLabels(void) {
   illegalLabelChar['-'] = 0;
   illegalLabelChar['_'] = 0;
   illegalLabelChar['.'] = 0;
-
 
   /* Scan all statements and extract their labels */
   for (stmt = 1; stmt <= g_statements; stmt++) {
@@ -522,7 +514,6 @@ void parseLabels(void) {
 /*E*/    print2("%s ",g_Statement[g_labelKeyBase[i]].labelName);
 /*E*/  } print2("\n");}
 
-
   /* Copy the keys for all possible labels for lookup by the
      squishProof command when local labels are generated in packed proofs. */
   g_allLabelKeyBase = malloc((size_t)g_numLabelKeys * sizeof(long));
@@ -554,7 +545,6 @@ void parseLabels(void) {
          "This label is declared more than once.  All labels must be unique.");
     }
   }
-
 }
 
 /* This functions retrieves all possible math symbols from $c and $v
@@ -618,7 +608,6 @@ void parseMathDecl(void) {
           g_MathToken[g_mathTokens].endStatement = g_statements; /* Unknown for now */
                 /* (Assign to 'g_statements' in case it's active until the end) */
           g_mathTokens++;
-
         }
 
         /* Create the symbol list for this statement */
@@ -657,7 +646,6 @@ void parseMathDecl(void) {
   g_MathToken[g_mathTokens].statement = 0; /* Never used */
   g_MathToken[g_mathTokens].endStatement = g_statements; /* Never used */
 
-
   /* Sort the math symbols for later lookup */
   g_mathKey = malloc((size_t)g_mathTokens * sizeof(long));
   if (!g_mathKey) outOfMemory("#11 (g_mathKey)");
@@ -670,7 +658,6 @@ void parseMathDecl(void) {
 /*E*/    if (i >= g_mathTokens) break;
 /*E*/    print2("%s ",g_MathToken[g_mathKey[i]].tokenName);
 /*E*/  } print2("\n");}
-
 
   /* Check for labels with the same name as math tokens */
   /* (This section implements the Metamath spec change proposed by O'Cat that
@@ -701,7 +688,6 @@ void parseMathDecl(void) {
     }
   }
 }
-
 
 /* This functions parses statement contents, except for proofs */
 void parseStatements(void) {
@@ -765,7 +751,6 @@ void parseStatements(void) {
   nmbrString *wrkHypPtr3;
   long activeHypStackSize = 30; /* Starting value; could be as large as
                                    g_statements. */
-
 
   struct activeDisjHypStack_struct { /* Stack of disjoint variables in $d's */
     long tokenNumA; /* First variable in disjoint pair */
@@ -999,7 +984,6 @@ void parseStatements(void) {
           }
         }
 
-
         i = 0; /* Symbol position in mathString */
         nmbrTmpPtr = g_Statement[stmt].mathString;
         while (1) {
@@ -1029,7 +1013,6 @@ void parseStatements(void) {
                 }
               }
             }
-
 
             /* Make sure that no constant has the same name
                as a variable or vice-versa */
@@ -1263,7 +1246,6 @@ void parseStatements(void) {
           }
         }
 
-
         /* Assign mathString to statement array */
         nmbrTmpPtr = poolFixedMalloc(
             (mathStringLen + 1) * (long)(sizeof(nmbrString)));
@@ -1279,7 +1261,6 @@ void parseStatements(void) {
         break;  /* Switch case break */
       default:
         bug(1707);
-
     } /* End switch */
 
     /****** Process hypothesis and variable stacks *******/
@@ -1295,9 +1276,7 @@ void parseStatements(void) {
       case p_:
         /* Flag the label as active */
         labelActiveFlag[stmt] = 1;
-
     } /* End switch */
-
 
     switch (type) {
       case d_:
@@ -1369,7 +1348,6 @@ void parseStatements(void) {
 
               activeDisjHypStackPtr++;
             }
-
           } /* Next j */
         } /* Next i */
 
@@ -1565,9 +1543,7 @@ void parseStatements(void) {
             j++;
             tokenNum = nmbrTmpPtr[j];
           } /* End while */
-
         } /* Next i */
-
 
         /* Error check:  make sure that all variables in the original statement
            appeared in some hypothesis */
@@ -1589,7 +1565,6 @@ void parseStatements(void) {
           j++;
           k = nmbrTmpPtr[j];
         }
-
 
         /* We have finished determining required $e & $f hyps, so allocate the
            permanent list for the statement array */
@@ -1636,7 +1611,6 @@ void parseStatements(void) {
           nmbrTmpPtr[optHyps] = -1;
           g_Statement[stmt].optHypList = nmbrTmpPtr;
         }
-
 
         /* Scan the list of disjoint variable ($d) hypotheses to find those
            that are required */
@@ -1714,9 +1688,7 @@ void parseStatements(void) {
               * sizeof(nmbrString));
           nmbrTmpPtr[optHyps] = -1;
           g_Statement[stmt].optDisjVarsStmt = nmbrTmpPtr;
-
         }
-
 
         /* Create list of optional variables (i.e. active but not required) */
         optVars = 0;
@@ -1739,7 +1711,6 @@ void parseStatements(void) {
         }
 
         if (optVars + reqVars != activeVarStackPtr) bug(1708);
-
 
         break;  /* Switch case break */
     }
@@ -1843,7 +1814,6 @@ void parseStatements(void) {
         } /* if not $f else is $f */
       } /* next i ($e hyp scan of this statement, or its $a/$p) */
     } /* if stmt is $a or $p */
-
   } /* Next stmt */
 
   if (g_currentScope > 0) {
@@ -1856,7 +1826,6 @@ void parseStatements(void) {
         g_Statement[g_statements].labelSectionLen, 2, 0,
         cat(tmpStr," missing at the end of the file.",NULL));
   }
-
 
   /* Filter out all hypothesis labels from the label key array.  We do not
      need them anymore, since they are stored locally in each statement
@@ -1875,7 +1844,6 @@ void parseStatements(void) {
   }
   g_numLabelKeys = g_numLabelKeys - j;
 /*E*/if(db5)print2(".  After: %ld\n",g_numLabelKeys);
-
 
   /* Deallocate temporary space */
   free(mathTokenSameAs);
@@ -1910,7 +1878,6 @@ void parseStatements(void) {
   free(symbolLenExists);
   free_vstring(tmpStr);
 }
-
 
 /* Parse proof of one statement in source file.  Uses g_WrkProof structure. */
 /* Returns 0 if OK; returns 1 if proof is incomplete (is empty or has '?'
@@ -2091,7 +2058,6 @@ char parseProof(long statemNum)
   qsort(g_WrkProof.hypAndLocLabel, (size_t)(g_WrkProof.numHypAndLoc),
       sizeof(struct sortHypAndLoc), hypAndLocSortCmp);
 
-
   /* Scan the parsed tokens for local label assignments */
   fbPtr = g_WrkProof.tokenSrcPtrPntr[0];
   if (fbPtr[0] == ':') {
@@ -2223,7 +2189,6 @@ char parseProof(long statemNum)
 
     g_WrkProof.numHypAndLoc++;
     g_WrkProof.localLabelPoolPtr = &g_WrkProof.localLabelPoolPtr[tokLength + 1];
-
   } /* Next i */
 
   /* Collect all target labels in /EXPLICIT format */
@@ -2313,7 +2278,6 @@ char parseProof(long statemNum)
         if (returnFlag < 2) returnFlag = 2;
       } /* End if duplicate label */
     } /* Next i */
-
   } /* End if there are local labels */
 
   /* Build the proof string and check the RPN stack */
@@ -2536,7 +2500,6 @@ char parseProof(long statemNum)
           m = g_WrkProof.RPNStackPtr - numReqHyp + k; /* Stack position of hyp */
           hypStepNum = g_WrkProof.RPNStack[m]; /* Step number of hypothesis k */
 
-
           /* Temporarily zap the token's end with a null for string comparisons */
           fbPtr = targetPntr[hypStepNum];
           zapSave = fbPtr[targetNmbr[hypStepNum]];
@@ -2611,7 +2574,6 @@ char parseProof(long statemNum)
     g_WrkProof.RPNStackPtr = g_WrkProof.RPNStackPtr - numReqHyp;
     g_WrkProof.RPNStack[g_WrkProof.RPNStackPtr] = step;
     g_WrkProof.RPNStackPtr++;
-
   } /* Next step */
 
   /* The stack should have one entry */
@@ -2749,7 +2711,6 @@ char parseProof(long statemNum)
               (g_WrkProof.proofString)[i] = wrkProofString[i];
             }
             break; /* Break out of the 'for (step...' loop */
-
           } /* if k>step */
         } /* if k<= -1000 */
       } /* next step */
@@ -2763,10 +2724,8 @@ char parseProof(long statemNum)
   } /* if (explicitTargets) */
 
   g_WrkProof.errorSeverity = returnFlag;
-  return (returnFlag);
-
+  return returnFlag;
 } /* parseProof() */
-
 
 /* Parse proof in compressed format */
 /* Parse proof of one statement in source file.  Uses wrkProof structure. */
@@ -2847,7 +2806,6 @@ char parseCompressedProof(long statemNum)
     chrType['$'] = 4; /* Dollar */
     chrType['?'] = 5; /* Question mark */
   }
-
 
   if (g_Statement[statemNum].type != p_) {
     bug(1724); /* should never get here */
@@ -2930,7 +2888,6 @@ char parseCompressedProof(long statemNum)
 
   fbPtr++;
   /* fbPtr points to the first token now. */
-
 
   /****** This part of the code is heavily borrowed from the regular
    ****** proof parsing, with local label and RPN handling removed,
@@ -3076,7 +3033,6 @@ char parseCompressedProof(long statemNum)
       g_WrkProof.errorCount++;
       if (returnFlag < 2) returnFlag = 2;
     }
-
   } /* Next step */
 
   /******* Create the starting label map (local labels will be
@@ -3214,7 +3170,6 @@ char parseCompressedProof(long statemNum)
           g_WrkProof.RPNStackPtr = g_WrkProof.RPNStackPtr - numReqHyp;
           g_WrkProof.RPNStack[g_WrkProof.RPNStackPtr] = g_WrkProof.numSteps;
           g_WrkProof.RPNStackPtr++;
-
         }
 
         g_WrkProof.numSteps++;
@@ -3355,7 +3310,6 @@ char parseCompressedProof(long statemNum)
 
     if (breakFlag) break;
     fbPtr++;
-
   } /* End while (1) */
 
   if (labelMapIndex) { /* In the middle of some digits */
@@ -3410,10 +3364,8 @@ char parseCompressedProof(long statemNum)
   }
 
   g_WrkProof.errorSeverity = returnFlag;
-  return (returnFlag);
-
+  return returnFlag;
 } /* parseCompressedProof */
-
 
 /* The caller must deallocate the returned nmbrString! */
 /* This function just gets the proof so the caller doesn't have to worry
@@ -3448,7 +3400,6 @@ nmbrString *getProof(long statemNum, flag printFlag) {
   /* cleanWrkProof(); */ /* Deallocate verifyProof() storage */
   return proof;
 } /* getProof */
-
 
 void rawSourceError(char *startFile, char *ptr, long tokLen, vstring errMsg) {
   char *startLine;
@@ -3586,7 +3537,6 @@ void sourceError(char *ptr, long tokLen, long stmtNum, vstring errMsg)
   free_vstring(fileName);
 } /* sourceError */
 
-
 void mathTokenError(long tokenNum /* 0 is 1st one */,
     nmbrString *tokenList, long stmtNum, vstring errMsg)
 {
@@ -3662,7 +3612,6 @@ long lookupLabel(const char *label)
   return statemNum;
 } /* lookupLabel */
 
-
 /* Label comparison for qsort */
 int labelSortCmp(const void *key1, const void *key2) {
   /* Returns -1 if key1 < key2, 0 if equal, 1 if key1 > key2 */
@@ -3670,13 +3619,11 @@ int labelSortCmp(const void *key1, const void *key2) {
       g_Statement[ *((long *)key2) ].labelName);
 } /* labelSortCmp */
 
-
 /* Label comparison for bsearch */
 int labelSrchCmp(const void *key, const void *data) {
   /* Returns -1 if key < data, 0 if equal, 1 if key > data */
   return strcmp(key, g_Statement[ *((long *)data) ].labelName);
 } /* labelSrchCmp */
-
 
 /* Math symbol comparison for qsort */
 int mathSortCmp(const void *key1, const void *key2) {
@@ -3685,14 +3632,12 @@ int mathSortCmp(const void *key1, const void *key2) {
       g_MathToken[ *((long *)key2) ].tokenName);
 }
 
-
 /* Math symbol comparison for bsearch */
 /* Here, key is pointer to a character string. */
 int mathSrchCmp(const void *key, const void *data) {
   /* Returns -1 if key < data, 0 if equal, 1 if key > data */
   return strcmp(key, g_MathToken[ *((long *)data) ].tokenName);
 }
-
 
 /* Hypotheses and local label comparison for qsort */
 int hypAndLocSortCmp(const void *key1, const void *key2) {
@@ -3702,14 +3647,12 @@ int hypAndLocSortCmp(const void *key1, const void *key2) {
     ((struct sortHypAndLoc *)key2)->labelName);
 }
 
-
 /* Hypotheses and local label comparison for bsearch */
 /* Here, key is pointer to a character string. */
 int hypAndLocSrchCmp(const void *key, const void *data) {
   /* Returns -1 if key < data, 0 if equal, 1 if key > data */
   return strcmp(key, ((struct sortHypAndLoc *)data)->labelName);
 }
-
 
 /* This function returns the length of the white space starting at ptr.
    Comments are considered white space.  ptr should point to the first character
@@ -3761,7 +3704,6 @@ long whiteSpaceLen(char *ptr) {
   return 0; /* Dummy return - never happens */
 } /* whiteSpaceLen */
 
-
 /* For .mm file splitting */
 /* This function is like whiteSpaceLen() except that comments are NOT
    considered white space.  ptr should point to the first character
@@ -3778,7 +3720,6 @@ long rawWhiteSpaceLen(char *ptr) {
   }
   return 0; /* Dummy return - never happens */
 } /* rawWhiteSpaceLen */
-
 
 /* This function returns the length of the token (non-white-space) starting at
    ptr.  Comments are considered white space.  ptr should point to the first
@@ -3815,7 +3756,6 @@ long tokenLen(char *ptr)
   return 0; /* Dummy return (never happens) */
 } /* tokenLen */
 
-
 /* This function returns the length of the token (non-white-space) starting at
    ptr.  Comments are considered white space.  ptr should point to the first
    character of the token.  If ptr points to a white space character, 0
@@ -3836,7 +3776,6 @@ long rawTokenLen(char *ptr)
   }
   return 0; /* Dummy return (never happens) */
 } /* rawTokenLen */
-
 
 /* This function returns the length of the proof token starting at
    ptr.  Comments are considered white space.  ptr should point to the first
@@ -3874,7 +3813,6 @@ long proofTokenLen(char *ptr)
   return 0; /* Dummy return - never happens */
 }
 
-
 /* Counts the number of \n between start for length chars.
    If length = -1, then use end-of-string 0 to stop.
    If length >= 0, then scan at most length chars, but stop
@@ -3897,7 +3835,6 @@ long countLines(const char *start, long length) {
   }
   return lines;
 } /* countLines */
-
 
 /* Return (for output) the complete contents of a statement, including all
    white space and comments, from first token through all white space and
@@ -3960,7 +3897,6 @@ vstring outputStatement(long stmt, flag reformatFlag) {
   let(&labelSectionSave, labelSection);
   let(&mathSectionSave, mathSection);
   let(&proofSectionSave, proofSection);
-
 
   /* Reformat statements to match the current set.mm convention */
   if (reformatFlag > 0) {  /* 1 = WRITE SOURCE / FORMAT or 2 = / REWRAP */
@@ -4291,7 +4227,6 @@ vstring outputStatement(long stmt, flag reformatFlag) {
       let(&output, cat(output, "$=", proofSection, NULL));
     }
     let(&output, cat(output, "$.", NULL));
-
   }
 
   /* Make sure the line has no carriage-returns */
@@ -4504,7 +4439,6 @@ vstring rewrapComment(const char *comment1) {
     }
   }
 
-
   /* Put two spaces after end of sentence and colon */
   ch = ""; /* Prevent compiler warning */
   for (i = 0; i < 4; i++) {
@@ -4629,10 +4563,8 @@ nmbrString *parseMathTokens(vstring userText, long statemNum)
   vstring_def(tmpStr);
   vstring_def(nlUserText);
 
-
   long *mathTokenSameAs; /* Flag that symbol is unique (for speed up) */
   long *reverseMathKey; /* Map from g_mathTokens to g_mathKey */
-
 
   /* Temporary working space */
   long wrkLen;
@@ -4717,9 +4649,7 @@ nmbrString *parseMathTokens(vstring userText, long statemNum)
     symbolLenExists[g_MathToken[i].length] = 1;
   }
 
-
   g_currentScope = g_Statement[statemNum].scope; /* Scope of the ref. statement */
-
 
   /* The code below is indented because it was borrowed from parseStatements().
      We will leave the indentation intact for easier future comparison
@@ -4822,7 +4752,6 @@ nmbrString *parseMathTokens(vstring userText, long statemNum)
             } /* End if fbPtr == '$' */
          } /* End if symbolLen == 0 */
 
-
           if (symbolLen == 0) { /* Symbol was not found */
             symbolLen = tokenLen(fbPtr);
             errCount++;
@@ -4850,7 +4779,6 @@ nmbrString *parseMathTokens(vstring userText, long statemNum)
           }
         } /* End while */
 
-
         /* Assign mathString */
         nmbrLet(&mathString, nmbrSpace(mathStringLen));
         for (i = 0; i < mathStringLen; i++) {
@@ -4873,7 +4801,6 @@ nmbrString *parseMathTokens(vstring userText, long statemNum)
 
   return nmbrMakeTempAlloc(mathString); /* Flag for dealloc */
 } /* parseMathTokens */
-
 
 /* For .mm file splitting */
 /* Get the next real $[...$] or virtual $( Begin $[... inclusion */
@@ -5105,7 +5032,6 @@ cmdType = 'S':
         break;
       }
       tmpPtr++;
-
     } /* while (1) */
 
     if (i == 0) {
@@ -5130,9 +5056,7 @@ cmdType = 'S':
     free_vstring(*fileName);
   }
   return;
-
 } /* getNextInclusion */
-
 
 /* This function transfers the content of the g_Statement[] array
    to a linear buffer in preparation for creating the output file.
@@ -5243,7 +5167,6 @@ vstring writeSourceToBuffer(void) {
   buf[size] = 0; /* End of string marker */
   return buf;
 } /* writeSourceToBuffer */
-
 
 /* This function creates split files containing $[ $] inclusions, from
    an unsplit source with $( Begin $[... etc. inclusions */
@@ -5390,7 +5313,6 @@ vstring writeSourceToBuffer(void) {
   free_vstring(fileNameWithPath);
 } /* writeSplitSource */
 
-
 /* When "write source" does not have the "/split" qualifier, by default
    (i.e. without "/no_delete") the included modules are "deleted" (renamed
    to ~1) since their content will be in the main output file. */
@@ -5461,7 +5383,6 @@ vstring writeSourceToBuffer(void) {
   return;
 } /* deleteSplits */
 
-
 /* Get file name and line number given a pointer into the read buffer */
 /* The user must deallocate the returned string (file name) */
 /* The global g_IncludeCall structure and g_includeCalls are used */
@@ -5501,7 +5422,6 @@ vstring getFileAndLineNum(const char *buffPtr /* start of read buffer */,
   return fileName;
 } /* getFileAndLineNo */
 
-
 /* g_Statement[stmtNum].fileName and .lineNum are initialized to "" and 0.
    To save CPU time, they aren't normally assigned until needed, but once
    assigned they can be reused without looking them up again.  This function
@@ -5517,7 +5437,6 @@ void assignStmtFileAndLineNum(long stmtNum) {
       g_Statement[stmtNum].statementPtr, &(g_Statement[stmtNum].lineNum));
   return;
 } /* assignStmtFileAndLineNum */
-
 
 /* This function returns a pointer to a buffer containing the contents of an
    input file and its 'include' calls.  'Size' returns the buffer's size.  */
@@ -5613,7 +5532,6 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
           - g_IncludeCall[g_includeCalls].current_offset);\
     */
 
-
     /* If we're here, cmdType is 'B', 'I', or 'S' */
 
     /* Create 2 new includeCall entries before recursive call, so that
@@ -5648,7 +5566,6 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
     g_IncludeCall[saveInclCalls].included_fn = "";
     let(&g_IncludeCall[saveInclCalls].included_fn,
         sourceFileName); /* Continuation of parent file after this include */
-
 
     /* See if includeFn file has already been included */
     alreadyInclBy = -1;
@@ -5977,7 +5894,6 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
     g_IncludeCall[saveInclCalls - 1].current_includeLength = inclSize; /* Length of the file
         to be included (0 if the file was previously included) */
 
-
     /* Initialize a new include call for the continuation of the parent. */
     /* This entry is identified by pushOrPop = 1 */
     g_IncludeCall[saveInclCalls].source_fn = "";  /* Name of the file to be
@@ -5992,7 +5908,6 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
         only if we may need it for a later Begin comparison */
     g_IncludeCall[saveInclCalls].current_includeLength = 0; /* Length of the file
         to be included (0 if the file was previously included) */
-
   } /* while (1) */
 
   /* Deallocate strings */
@@ -6007,7 +5922,6 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
 
   return newFileBuf;
 } /* readInclude */
-
 
 /* This function returns a pointer to a buffer containing the contents of an
    input file and its 'include' calls.  'Size' returns the buffer's size.  */
@@ -6115,6 +6029,5 @@ vstring readSourceAndIncludes(const char *inputFn /*input*/, long *size /*output
 /*D*//*g_IncludeCall[i].current_offset,g_IncludeCall[i].current_includeLength); */
     return newFileBuf;
   }
-
 } /* readSourceAndIncludes */
 

--- a/src/mmpars.h
+++ b/src/mmpars.h
@@ -92,7 +92,6 @@ long countLines(const char *start, long length);
 extern long *g_allLabelKeyBase;
 extern long g_numAllLabelKeys;
 
-
 extern long g_wrkProofMaxSize; /*!< Maximum size so far - it may grow */
 struct sortHypAndLoc {  /* Used for sorting hypAndLocLabel field */
   long labelTokenNum;

--- a/src/mmpfas.c
+++ b/src/mmpfas.c
@@ -121,7 +121,6 @@ void interactiveMatch(long step, long maxEssential)
       free_vstring(timeoutFlags);
       return;
     }
-
   }
 
   nmbrLet(&matchList, nmbrSpace(matchCount));
@@ -207,7 +206,6 @@ void interactiveMatch(long step, long maxEssential)
     print2("Step %ld was assigned statement %s.\n",
         (long)(step + 1),
         g_Statement[stmt].labelName);
-
   } /* End if matchCount == 1 */
 
   /* Add to statement to the proof */
@@ -222,9 +220,7 @@ void interactiveMatch(long step, long maxEssential)
   free_nmbrString(matchList);
   free_nmbrString(timeoutList);
   return;
-
 } /* interactiveMatch */
-
 
 /* Assign a statement to an unknown proof step */
 void assignStatement(long statemNum, long step)
@@ -246,7 +242,6 @@ void assignStatement(long statemNum, long step)
   free_nmbrString(hypList);
   return;
 } /* assignStatement */
-
 
 /* Find proof of formula by using the replaceStatement() algorithm i.e.
    see if any statement matches current step AND each of its hypotheses
@@ -327,7 +322,6 @@ nmbrString *proveByReplacement(long prfStmt,
   }
   return trialPrf;  /* Proof not found - return empty proof */
 }
-
 
 nmbrString *replaceStatement(long replStatemNum, long prfStep,
     long provStmtNum,
@@ -508,7 +502,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
   /* Initialize list of hypotheses after substitutions made */
   pntrLet(&hypMakeSubstList, pntrNSpace(schReqHyps));
 
-
   g_unifTrialCount = 1; /* Reset unification timeout */
   reEntryFlag = 0; /* For unifyH() */
 
@@ -574,7 +567,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
         if (g_Statement[g_Statement[replStatemNum].reqHypList[hypSortMap[hyp]]
              ].type != (char)f_) bug(1824);
       }
-
 
       /* Scan all known steps of existing subproof to find a hypothesis
          match */
@@ -752,7 +744,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
           } /* end if not reentry */
           /* (End speedup) */
 
-
           hypReEntryFlagList[hypSortMap[hyp]] = 2; /* For next unifyH() */
           hypStepList[hypSortMap[hyp]] = trialStep;
 
@@ -912,7 +903,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
         hyp = hyp - 2; /* Go back one iteration (subtract 2 to offset
                           end of loop increment) */
       } /* if (!foundTrialStepMatch) */
-
     } /* next hyp */
 
     if (noHypMatch) {
@@ -931,7 +921,6 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
                                                      /* Complete the proof */
 
     goto returnPoint;
-
   } /* End while (next unifyH() call for main replacement statement) */
 
   free_nmbrString(proof);  /* Proof not possible */
@@ -961,14 +950,12 @@ nmbrString *replaceStatement(long replStatemNum, long prfStep,
   free_vstring(hasFloatingProof);
   free_vstring(tryFloatingProofLater);
 
-
 /*E*/if(db8)print2("%s\n", cat("Returned: ",
 /*E*/   nmbrCvtRToVString(proof,
 /*E*/                0, /*explicitTargets*/
 /*E*/                0 /*statemNum, used only if explicitTargets*/), NULL));
   return proof; /* Caller must deallocate */
 } /* replaceStatement */
-
 
 /* This function identifies all steps in the proof in progress that (1) are
    independent of step refStep, (2) have no dummy variables, (3) are
@@ -1063,9 +1050,7 @@ vstring getIndepKnownSteps(long proofStmt, long refStep)
   free_vstring(unkSubPrfSteps); /* Deallocate */
 
   return indepSteps; /* Caller must deallocate */
-
 } /* getIndepKnownSteps */
-
 
 /* This function classifies each proof step in g_ProofInProgress.proof
    as known or unknown ('K' or 'U' in the returned string) depending
@@ -1119,9 +1104,7 @@ vstring getKnownSubProofs(void)
   if (stackPtr != 0) bug(1841);
   free_vstring(unkSubPrfStack); /* Deallocate */
   return unkSubPrfSteps; /* Caller must deallocate */
-
 } /* getKnownSubProofs */
-
 
 /* Add a subproof in place of an unknown step to g_ProofInProgress.  The
    .target, .source, and .user fields are initialized to empty (except
@@ -1294,7 +1277,6 @@ nmbrString *expandProof(
        process nested references to sourceStmt */
   } /* end while(1) */
 
-
  RETURN_POINT:
   if (nmbrEq(origTargetProof, expandedTargetProof)) {
     /*
@@ -1338,7 +1320,6 @@ nmbrString *expandProof(
   return expandedTargetProof;
 } /* expandProof */
 
-
 /* Delete a subproof starting (in reverse from) step.  The step is replaced
    with an unknown step, and its .target and .user fields are retained. */
 void deleteSubProof(long step) {
@@ -1371,7 +1352,6 @@ void deleteSubProof(long step) {
       step - sbPfLen + 1), pntrRight(g_ProofInProgress.user,
       step + 1), NULL));
 } /* deleteSubProof */
-
 
 /* Check to see if a statement will match the g_ProofInProgress.target (or .user)
    of an unknown step.  Returns 1 if match, 0 if not, 2 if unification
@@ -1507,8 +1487,7 @@ char checkStmtMatch(long statemNum, long step)
 
   if (!targetFlag || !userFlag) return (0);
   if (targetFlag == 1 && userFlag == 1) return (1);
-  return (2);
-
+  return 2;
 } /* checkStmtMatch */
 
 /* Check to see if a (user-specified) math string will match the
@@ -1532,10 +1511,8 @@ char checkMStringMatch(const nmbrString *mString, long step) {
 
   if (!targetFlag || !sourceFlag) return (0);
   if (targetFlag == 1 && sourceFlag == 1) return (1);
-  return (2);
-
+  return 2;
 } /* checkMStringMatch */
-
 
 /* Find proof of formula or simple theorem (no new vars in $e's) */
 /* maxEDepth is the maximum depth at which statements with $e hypotheses are
@@ -1614,7 +1591,6 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
     maxDepthExceeded = 1;  /* Flag to exit recursion */
     goto returnPoint;
   }
-
 
   /* First see if mString matches a required or optional hypothesis; if so,
      we're done; the proof is just the hypothesis. */
@@ -1750,7 +1726,6 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
     } /* Next hyp */
     if (breakFlag) continue; /* To next stmt */
 
-
     /* Change all variables in the statement to dummy vars for unification */
     nmbrLet(&scheme, stmtMathPtr);
     schemeVars = reqVars; /* S.b. same after eliminated new $e vars above */
@@ -1865,7 +1840,6 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
        hypOrdMap[0] = j;
 
        continue; /* Not possible; get next unification */
-
       } /* End if breakFlag */
 
       /* Proofs were found for all hypotheses */
@@ -1915,7 +1889,6 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
         free_nmbrString(*(nmbrString **)(&hypProofList[hyp]));
       }
       goto returnPoint;
-
     } /* End while (next unifyH() call) */
 
     /* Deallocate hypothesis schemes and proofs */
@@ -1923,7 +1896,6 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
       free_nmbrString(*(nmbrString **)(&hypList[hyp]));
       free_nmbrString(*(nmbrString **)(&hypProofList[hyp]));
     }
-
   } /* Next stmt */
 
   free_nmbrString(proof);  /* Proof not possible */
@@ -1944,7 +1916,6 @@ nmbrString *proveFloating(const nmbrString *mString, long statemNum, long maxEDe
 /*E*/if(db8){if(!depth)print2("Trials: %ld\n", trials);}
   return (proof); /* Caller must deallocate */
 } /* proveFloating */
-
 
 /* This function does quick check for some common conditions that prevent
    a trial statement (scheme) from being unified with a given instance.
@@ -1979,7 +1950,6 @@ INLINE flag quickMatchFilter(long trialStmt, const nmbrString *mString,
   lastSymbol = mString[mStringLen - 1];
   if (g_MathToken[lastSymbol].tokenType != (char)con_) lastSymbol = 0;
   /* (End of common section) */
-
 
   stmtMathPtr = g_Statement[trialStmt].mathString;
 
@@ -2040,9 +2010,7 @@ INLINE flag quickMatchFilter(long trialStmt, const nmbrString *mString,
   } /* if dummyVarFlag == 0 */
 
   return 1;
-
 } /* quickMatchFilter */
-
 
 /* Shorten proof by using specified statement. */
 void minimizeProof(long repStatemNum, long prvStatemNum,
@@ -2152,9 +2120,7 @@ void minimizeProof(long repStatemNum, long prvStatemNum,
     /* break; */  /* For special replacement with same label: always break
                       to prevent inf loop */
   } /* end while */
-
 } /* minimizeProof */
-
 
 /* Initialize g_ProofInProgress.source of the step, and .target of all
    hypotheses, to schemes using new dummy variables. */
@@ -2245,7 +2211,6 @@ void initStep(long step)
   return;
 } /* initStep */
 
-
 /* Look for completely known subproofs in g_ProofInProgress.proof and
    assign g_ProofInProgress.target and .source.  Calls assignKnownSteps(). */
 void assignKnownSubProofs(void)
@@ -2275,11 +2240,9 @@ void assignKnownSubProofs(void)
 
     /* Adjust pos for next pass through 'for' loop */
     pos = pos - subplen + 1;
-
   } /* Next pos */
   return;
 } /* assignKnownSubProofs */
-
 
 /* This function assigns math strings to all steps (g_ProofInProgress.target and
    .source fields) in a subproof with all known steps. */
@@ -2426,7 +2389,6 @@ void assignKnownSteps(long startStep, long sbProofLen)
       stackPtr = stackPtr - reqHyps;
       stack[stackPtr] = pos;
       stackPtr++;
-
     } /* End if (not) $e, $f */
   } /* Next pos */
 
@@ -2446,7 +2408,6 @@ void assignKnownSteps(long startStep, long sbProofLen)
   free_nmbrString(assertion);
   return;
 } /* assignKnownSteps */
-
 
 /* Interactively unify a step.  Calls interactiveUnify(). */
 /* If two unifications must take place (.target,.user and .source,.user),
@@ -2507,15 +2468,12 @@ void interactiveUnifyStep(long step, char messageFlag)
     g_proofChangedFlag = 1; /* Flag to push 'undo' stack */
 
     makeSubstAll(stateVector);
-
   } /* End if unifFlag = 1 */
 
   purgeStateVector(&stateVector);
 
   return;
-
 } /* interactiveUnifyStep */
-
 
 /* Interactively select one of several possible unifications */
 /* Returns:  0 = no unification possible
@@ -2577,7 +2535,6 @@ char interactiveUnify(const nmbrString *schemeA, const nmbrString *schemeB,
     if (!unifFlag) break;
     reEntryFlag = 1;
 
-
     /* Compute heuristic "weight" of resulting unification */
     /* The unification with the least "weight" is intended to be the
        most likely correct choice.  The heuristic was based on
@@ -2604,11 +2561,9 @@ char interactiveUnify(const nmbrString *schemeA, const nmbrString *schemeB,
       for (i = 0; i < nmbrLen(substResult); i++) {
         if (substResult[i] > g_mathTokens) unkCount++;
       }
-
     } /* Next var */
     thisUnifWeight = thisUnifWeight - onesCount;
     thisUnifWeight = thisUnifWeight + 7 * unkCount;
-
 
     /* Get new min and max weight for interactive scan ordering */
     if (thisUnifWeight > maxUnifWeight) maxUnifWeight = thisUnifWeight;
@@ -2715,9 +2670,7 @@ char interactiveUnify(const nmbrString *schemeA, const nmbrString *schemeB,
         }
         free_vstring(tmpStr);
       }
-
     } /* Next unifNum */
-
   } /* Next unifTrialWeight */
 
   /* (The user should reject everything to test for this bug) */
@@ -2732,9 +2685,7 @@ char interactiveUnify(const nmbrString *schemeA, const nmbrString *schemeB,
   free_nmbrString(unifWeight); /* Deallocate */
   free_nmbrString(substResult); /* Deallocate */
   return returnValue;
-
 } /* interactiveUnify */
-
 
 /* Automatically unify steps that have unique unification */
 /* Prints "congratulation" if congrats = 1 */
@@ -2829,9 +2780,7 @@ void autoUnify(flag congrats)
   }
 
   return;
-
 } /* autoUnify */
-
 
 /* Make stateVector substitutions in all steps.  The stateVector must
    contain the result of a valid unification. */
@@ -2862,7 +2811,6 @@ void makeSubstAll(pntrString *stateVector) {
         stateVector);
       free_nmbrString(nmbrTmpPtr);
     }
-
   } /* Next step */
   return;
 } /* makeSubstAll */
@@ -2955,7 +2903,6 @@ long subproofLen(const nmbrString *proof, long endStep) {
   }
   return (endStep - p + 1);
 } /* subproofLen */
-
 
 /* If testStep has no dummy variables, return 0;
    if testStep has isolated dummy variables (that don't affect rest of
@@ -3055,7 +3002,6 @@ char checkDummyVarIsolation(long testStep) { /* 0=1st step, 1=2nd, etc. */
   return dummyVarIndicator;
 } /* checkDummyVarIsolation */
 
-
 /* Given a starting step, find its parent (the step it is a hypothesis of) */
 /* If the starting step is the last proof step, just return it */
 long getParentStep(long startStep) /* 0=1st step, 1=2nd, etc. */
@@ -3085,7 +3031,6 @@ long getParentStep(long startStep) /* 0=1st step, 1=2nd, etc. */
   if (startStep != proofLen - 1) bug(1844); /* Didn't find parent... */
   return startStep; /* ...unless we started with the last proof step */
 } /* getParentStep */
-
 
 /* This function puts numNewVars dummy variables, named "$nnn", at the end
    of the g_MathToken array and modifies the global variable g_dummyVars. */
@@ -3125,15 +3070,12 @@ void declareDummyVars(long numNewVars)
     g_MathToken[g_mathTokens + g_dummyVars].active = 1;
     g_MathToken[g_mathTokens + g_dummyVars].tokenType = (char)var_;
     g_MathToken[g_mathTokens + g_dummyVars].tmp = 0;
-
   }
 
   g_startTempAllocStack = saveTempAllocStack;
 
   return;
-
 } /* declareDummyVars */
-
 
 /* Copy inProofStruct to outProofStruct.  A proof structure contains
    the state of the proof in the Proof Assistant MM-PA.  The one
@@ -3175,7 +3117,6 @@ void copyProofStruct(struct pip_struct *outProofStruct,
   return;
 } /* copyProofStruct */
 
-
 /* Create an initial proof structure needed for the Proof Assistant, given
    a starting proof.  Normally, proofStruct is the global g_ProofInProgress,
    although we've made it an argument to help modularize the function.  There
@@ -3215,7 +3156,6 @@ void initProofStruct(struct pip_struct *proofStruct, const nmbrString *proof,
   return;
 } /* initProofStruct */
 
-
 /* Deallocate memory used by a proof structure and set it to the initial
    state.  A proof structure contains the state of the proof in the Proof
    Assistant MM-PA.  It is assumed that proofStruct was declared with:
@@ -3238,8 +3178,7 @@ void deallocProofStruct(struct pip_struct *proofStruct)
   free_pntrString(proofStruct->source);
   free_pntrString(proofStruct->user);
   return;
-} /* deallocProofStruct */
-
+} // deallocProofStruct
 
 #define DEFAULT_UNDO_STACK_SIZE 20
 /* This function handles the UNDO/REDO commands.  It is called

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -99,5 +99,4 @@
   #define RUN_TESTS()
 #endif // TEST_ENABLE
 
-
-#endif /* include guard */
+#endif // METAMATH_MMTEST_H_

--- a/src/mmunif.c
+++ b/src/mmunif.c
@@ -134,7 +134,6 @@ void hentyAdd(nmbrString *hentyVars, nmbrString *hentyVarStart,
     nmbrString *hentyVarLen, nmbrString *hentySubstList,
     pntrString **stateVector);
 
-
 /* For heuristics */
 int maxNestingLevel = -1;
 int nestingLevel = 0;
@@ -143,7 +142,6 @@ int nestingLevel = 0;
 nmbrString_def(g_firstConst);
 nmbrString_def(g_lastConst);
 nmbrString_def(g_oneConst);
-
 
 /* Typical call:
      nmbrStringXxx = makeSubstUnif(&newVarFlag,trialScheme,
@@ -265,7 +263,6 @@ nmbrString *makeSubstUnif(flag *newVarFlag,
   return (result);
 } /* makeSubstUnif */
 
-
 char unify(
     const nmbrString *schemeA,
     const nmbrString *schemeB,
@@ -273,7 +270,6 @@ char unify(
     pntrString **stateVector,
     long reEntryFlag)
 {
-
 
 /* This function unifies two math token strings, schemeA and
    schemeB.  The result is contained in unifiedScheme.
@@ -338,7 +334,6 @@ char unify(
   /* static char g_bracketMatchInit = 0; */ /* Global so ERASE can init it */
   long bracketScanStart, bracketScanStop; /* For one-time $a scan */
   flag bracketMismatchFound;
-
 
 /*E*/long d;
 /*E*/vstring_def(tmpStr);
@@ -410,7 +405,6 @@ char unify(
       }
     } /* Next stmt */
   }
-
 
   if (!reEntryFlag) {
     /* First time called */
@@ -528,7 +522,6 @@ char unify(
     for (i = 0; i < unkVarsLen; i++) {
       g_MathToken[unkVars[i]].tmp = -1;
     }
-
   } else { /* reEntryFlag != 0 */
 
     /* We are re-entering to get the next possible assignment. */
@@ -561,8 +554,6 @@ char unify(
     goto backtrack;
    reEntry1: /* goto backtrack will come back here if reEntryFlag is set */
     reEntryFlag = 0;
-
-
   }
 
   /* Perform the unification */
@@ -723,7 +714,6 @@ char unify(
      failed, so backtrack */
 /*E*/if(db6)print2("Neither scheme has unknown variable\n");
   goto backtrack;
-
 
  substitute:
 /*E*/if(db6)print2("Entering substitute...\n");
@@ -1188,7 +1178,6 @@ char unify(
   return (0);
 } /* unify */
 
-
 /* oneDirUnif() is like unify(), except that when reEntryFlag is 1,
    a new unification is returned ONLY if the assignments to the
    variables in schemeA have changed.  This is used to speed up the
@@ -1250,7 +1239,6 @@ nmbrString *oldStackUnkVarLen; /* Pointer only - not allocated */
   }
   return(0); /* Dummy return value - never happens */
 } /* oneDirUnif */
-
 
 /* uniqueUnif() is like unify(), but there is no reEntryFlag, and 3 possible
    values are returned:
@@ -1372,9 +1360,7 @@ char uniqueUnif(
   }
 
   return (3); /* Return flag that unification is not unique */
-
 } /* uniqueUnif */
-
 
 /* Deallocates the contents of a stateVector */
 /* Note:  If unifyH() returns 0, there were no more unifications and
@@ -1416,9 +1402,7 @@ void purgeStateVector(pntrString **stateVector) {
   free_pntrString(*stateVector);
 
   return;
-
 } /* purgeStateVector */
-
 
 /* Prints the substitutions determined by unify for debugging purposes */
 void printSubst(pntrString *stateVector) {
@@ -1449,7 +1433,6 @@ void printSubst(pntrString *stateVector) {
   }
 } /* printSubst */
 
-
 /* unifyH() is like unify(), except that when reEntryFlag is 1, a new
    unification is returned ONLY if the normalized unification does not
    previously exist in the "Henty filter" part of the  stateVector.  This
@@ -1472,7 +1455,6 @@ char unifyH(
   if (!g_hentyFilter) return unify(schemeA, schemeB, stateVector, reEntryFlag);
 
   if (!reEntryFlag) {
-
     tmpFlag = unify(schemeA, schemeB, stateVector, 0);
     if (tmpFlag == 1) { /* Unification OK */
 
@@ -1483,12 +1465,9 @@ char unifyH(
       /* This is the first unification so add it to the filter then return 1 */
       hentyAdd(hentyVars, hentyVarStart, hentyVarLen,
           hentySubstList, stateVector);
-
     }
     return (tmpFlag);
-
   } else {
-
     while (1) {
       tmpFlag = unify(schemeA, schemeB, stateVector, 1);
       if (tmpFlag == 1) { /* 0 = not possible, 1 == OK, 2 = timed out */
@@ -1507,7 +1486,6 @@ char unifyH(
               hentySubstList, stateVector);
           return (1);
         }
-
       } else {
         /* No unification is possible, or it timed out */
         break;
@@ -1515,7 +1493,6 @@ char unifyH(
 
       /* If we get here this unification is in the Henty filter, so bypass it
          and get the next unification. */
-
     } /* End while (1) */
 
     /* Deallocate memory (when reEntryFlag is 1 and (not possible or timeout)).
@@ -1526,7 +1503,6 @@ char unifyH(
     free_nmbrString(hentyVarLen);
     free_nmbrString(hentySubstList);
     return (tmpFlag);
-
   }
 } /* unifyH */
 
@@ -1651,7 +1627,6 @@ void hentyNormalize(nmbrString **hentyVars, nmbrString **hentyVarStart,
   free_nmbrString(substList);
 
   return;
-
 } /* hentyNormalize */
 
 /* Check to see if an equivalent unification exists in the Henty filter */

--- a/src/mmunif.h
+++ b/src/mmunif.h
@@ -25,10 +25,8 @@ extern nmbrString *g_firstConst;
 extern nmbrString *g_lastConst;
 extern nmbrString *g_oneConst;
 
-
 nmbrString *makeSubstUnif(flag *newVarFlag,
     const nmbrString *trialScheme, pntrString *stateVector);
-
 
 /*! This function unifies two math token strings, schemeA and
    schemeB.  The result is contained in unifiedScheme.
@@ -59,7 +57,6 @@ char unify(
     pntrString **stateVector,
     long reEntryFlag);
 
-
 /*! oneDirUnif() is like unify(), except that when reEntryFlag is 1,
    a new unification is returned ONLY if the assignments to the
    variables in schemeA have changed.  This is used to speed up the
@@ -69,7 +66,6 @@ flag oneDirUnif(
     const nmbrString *schemeB,
     pntrString **stateVector,
     long reEntryFlag);
-
 
 /*! uniqueUnif() is like unify(), but there is no reEntryFlag, and 3 possible
    values are returned:

--- a/src/mmveri.c
+++ b/src/mmveri.c
@@ -349,7 +349,7 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
   v = -1; /* Position in bigSubstSchemeVars */
   p = 0; /* Position in bigSubstSchemeAss */
   q = 0; /* Position in bigSubstInstAss */
-  ambiguityCheck: /* Re-entry point to see if unification is unique */
+ambiguityCheck: /* Re-entry point to see if unification is unique */
   while (p != bigSubstSchemeLen-1 || q != bigSubstInstLen-1) {
 /*E*/if(db7&&v>=0)printLongLine(cat("p ", str((double)p), " q ", str((double)q), " VAR ",str((double)v),
 /*E*/    " ASSIGNED ", nmbrCvtMToVString(

--- a/src/mmveri.c
+++ b/src/mmveri.c
@@ -156,7 +156,6 @@ char verifyProof(long statemNum)
               g_WrkProof.RPNStack[i]));
         }
       } /* End of if (getStep.stepNum) */
-
     }
 
 /*E*/if(db7)printLongLine(cat("step ", str((double)step+1), " sch ",
@@ -184,12 +183,10 @@ char verifyProof(long statemNum)
       }
     }
 
-
     /* Pop the stack */
     g_WrkProof.RPNStackPtr = g_WrkProof.RPNStackPtr - numReqHyp;
     g_WrkProof.RPNStack[g_WrkProof.RPNStackPtr] = step;
     g_WrkProof.RPNStackPtr++;
-
   } /* Next step */
 
   /* If there was a stack error, the verifier should have never been
@@ -221,10 +218,8 @@ char verifyProof(long statemNum)
   free_nmbrString(bigSubstSchemeHyp);
   free_nmbrString(bigSubstInstHyp);
 
-  return (returnFlag);
-
-} /* verifyProof */
-
+  return returnFlag;
+} // verifyProof
 
 /* assignVar() finds an assignment to substScheme variables that match
    the assumptions specified in the reason string */
@@ -354,7 +349,7 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
   v = -1; /* Position in bigSubstSchemeVars */
   p = 0; /* Position in bigSubstSchemeAss */
   q = 0; /* Position in bigSubstInstAss */
- ambiguityCheck: /* Re-entry point to see if unification is unique */
+  ambiguityCheck: /* Re-entry point to see if unification is unique */
   while (p != bigSubstSchemeLen-1 || q != bigSubstInstLen-1) {
 /*E*/if(db7&&v>=0)printLongLine(cat("p ", str((double)p), " q ", str((double)q), " VAR ",str((double)v),
 /*E*/    " ASSIGNED ", nmbrCvtMToVString(
@@ -544,7 +539,6 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
     free_nmbrString(result);
   }
 
-
   /***** Get step information if requested *****/
   if (!ambiguityCheckFlag) { /* This is the real (first) unification */
     if (getStep.stepNum) {
@@ -588,7 +582,6 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
     } /* End if (getStep.stepNum) */
   } /* End if (!ambiguityCheckFlag) */
   /***** End of getting step information *****/
-
 
   /***** Check for $d violations *****/
   if (!ambiguityCheckFlag) { /* This is the real (first) unification */
@@ -839,7 +832,6 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
     goto ambiguityCheck;
   }
 
-
  returnPoint:
 
   /* Free up all allocated nmbrString space */
@@ -858,9 +850,7 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
 
   g_nmbrStartTempAllocStack = nmbrSaveTempAllocStack;
   return result;
-
-}
-
+} // assignVar
 
 /* Deallocate the math symbol strings assigned in wrkProof structure during
    proof verification.  This should be called after verifyProof() and after the
@@ -882,5 +872,4 @@ void cleanWrkProof(void) {
       }
     }
   }
-
-}
+} // cleanWrkProof

--- a/src/mmvstr.c
+++ b/src/mmvstr.c
@@ -164,7 +164,6 @@ static void* tempAlloc(long size)  /* String memory allocation/deallocation */
   return memptr;
 } /* tempAlloc */
 
-
 /* Put string in temporary allocation arena */
 temp_vstring makeTempAlloc(vstring s) {
   if (s[0]) { /* Don't do it if vstring is empty */
@@ -175,7 +174,6 @@ temp_vstring makeTempAlloc(vstring s) {
   }
   return s;
 } /* makeTempAlloc */
-
 
 /* String assignment */
 void let(vstring *target, const char *source) {
@@ -214,7 +212,6 @@ void let(vstring *target, const char *source) {
   }
 
   freeTempAlloc(); /* Free up temporary strings used in expression computation */
-
 } /* let */
 
 /* String concatenation */
@@ -252,7 +249,6 @@ temp_vstring cat(const char *string1, ...) {
     strcpy(result + argPos[i], arg[i]);
   return result;
 } /* cat */
-
 
 /* Input a line from the user or from a file */
 /* Returns 1 if a (possibly empty) line was successfully read, 0 if EOF */
@@ -303,19 +299,16 @@ int linput(FILE *stream, const char* ask, vstring *target) {
   return result;
 } /* linput */
 
-
 /* Find out the length of a string */
 long len(const char *s) {
   return (long)strlen(s);
 } /* len */
-
 
 /* Extract sin from character position start to stop into sout */
 temp_vstring seg(const char *sin, long start, long stop) {
   if (start < 1) start = 1;
   return mid(sin, start, stop - start + 1);
 } /* seg */
-
 
 /* Extract sin from character position start for length len */
 temp_vstring mid(const char *sin, long start, long length) {
@@ -328,18 +321,15 @@ temp_vstring mid(const char *sin, long start, long length) {
   return sout;
 } /* mid */
 
-
 /* Extract leftmost n characters */
 temp_vstring left(const char *sin, long n) {
   return mid(sin, 1, n);
 } /* left */
 
-
 /* Extract after character n */
 temp_vstring right(const char *sin, long n) {
   return seg(sin, n, (long)(strlen(sin)));
 } /* right */
-
 
 /* Emulate VMS BASIC edit$ command */
 temp_vstring edit(const char *sin, long control) {
@@ -634,7 +624,6 @@ temp_vstring edit(const char *sin, long control) {
   return sout;
 } /* edit */
 
-
 /* Return a string of the same character */
 temp_vstring string(long n, char c) {
   long j = 0;
@@ -645,12 +634,10 @@ temp_vstring string(long n, char c) {
   return (sout);
 } /* string */
 
-
 /* Return a string of spaces */
 temp_vstring space(long n) {
   return string(n, ' ');
 } /* space */
-
 
 /* Return a character given its ASCII value */
 temp_vstring chr(long n) {
@@ -659,7 +646,6 @@ temp_vstring chr(long n) {
   sout[1] = 0;
   return sout;
 } /* chr */
-
 
 long instr(long start, const char *string, const char *match) {
   const char *sp1, *sp2;
@@ -680,7 +666,6 @@ long instr(long start, const char *string, const char *match) {
   return found;
 } /* instr */
 
-
 /* Search for _last_ occurrence of string2 in string1 */
 /* 1 = 1st string character; 0 = not found */
 /* ??? Future - this could be made more efficient by searching directly,
@@ -696,7 +681,6 @@ long rinstr(const char *string1, const char *string2) {
   }
   return savePos;
 } /* rinstr */
-
 
 /* Translate string in sin to sout based on table.
    Table must be 256 characters long!! <- not true anymore? */
@@ -720,12 +704,10 @@ temp_vstring xlate(const char *sin, const char *table)
   return (sout);
 } /* xlate */
 
-
 /* Returns the ascii value of a character */
 long ascii_(const char *c) {
   return (unsigned char)c[0];
 } /* ascii_ */
-
 
 /* Returns the floating-point value of a numeric string */
 double val(const char *s) {
@@ -755,7 +737,6 @@ double val(const char *s) {
   return (atof(s));
   */
 } /* val */
-
 
 /* Returns current date as an ASCII string */
 temp_vstring date(void) {
@@ -789,7 +770,6 @@ temp_vstring date(void) {
       (int)((time_structure->tm_year) + 1900));
   return sout;
 } /* date */
-
 
 /* Return current time as an ASCII string */
 temp_vstring time_(void) {
@@ -827,7 +807,6 @@ temp_vstring time_(void) {
   return sout;
 } /* time */
 
-
 /* Return a number as an ASCII string */
 temp_vstring str(double f) {
   /* This function converts a floating point number to a string in the */
@@ -848,7 +827,6 @@ temp_vstring str(double f) {
   return s;
 } /* str */
 
-
 /* Return a number as an ASCII string */
 /* (This may have differed slightly from str() in BASIC but I forgot how.
    It should be considered deprecated.) */
@@ -856,13 +834,11 @@ temp_vstring num1(double f) {
   return str(f);
 } /* num1 */
 
-
 /* Return a number as an ASCII string surrounded by spaces */
 /* (This should be considered deprecated.) */
 temp_vstring num(double f) {
   return cat(" ", str(f), " ", NULL);
 } /* num */
-
 
 /* Emulate PROGRESS "entry" and related string functions */
 /* (PROGRESS is a 4-GL database language) */
@@ -940,7 +916,6 @@ long lookup(const char *expression, const char *list) {
   return 0;
 }
 
-
 /* Emulate PROGRESS num-entries function */
 /* Returns the number of items in a comma-separated list.  If the
    list is the empty string, return 0. */
@@ -991,7 +966,6 @@ long entryPosition(long element, const char *list) {
   if (list[lastComma + 1] == ',') return 0;
   return (lastComma + 2);
 }
-
 
 /* For debugging */
 /*

--- a/src/mmvstr.h
+++ b/src/mmvstr.h
@@ -231,7 +231,7 @@ typedef vstring temp_vstring;
  *
  * \param[in,out] x (not null) an initialized \ref vstring variable.  According to the
  * semantics of a \ref vstring, \p x is not deallocated, if it points to an
- * empty string. 
+ * empty string.
  * \pre
  *   \p x was declared and initialized before.
  * \post
@@ -566,7 +566,6 @@ long ascii_(const char *c);
 
 double val(const char *s);
 
-
 /* Emulation of Progress 4GL string functions */
 
 temp_vstring entry(long element, const char *list);
@@ -576,7 +575,6 @@ long lookup(const char *expression, const char *list);
 long numEntries(const char *list);
 
 long entryPosition(long element, const char *list);
-
 
 /* Routines may/may not be written (lowest priority):
 vstring place$(vstring sout);

--- a/src/mmword.c
+++ b/src/mmword.c
@@ -31,10 +31,8 @@
 /* Set to 79, 80, etc. - length of line after tag is added */
 #define LINE_LENGTH 80
 
-
    /* 7000 ! ***** "DIFF" Option ***** from DO LIST */
 /*  gosub_7000(f1_name, f2_name, f3_name, &f3_fp, m); */
-
 
 char strcmpe(vstring s1, vstring s2);
 vstring stripAndTag(vstring line, vstring tag, flag tagBlankLines);
@@ -60,7 +58,6 @@ flag printedAtLeastOne;
      vstring line2_[MAX_LINES];
      vstring reserve1_[MAX_BUF];
      vstring reserve2_[MAX_BUF];
-
 
 /* These two functions emulate 2 GOSUBs in BASIC, that are part of a
    translation of a very old BASIC program (by nm) that implemented a
@@ -88,7 +85,6 @@ void revise(FILE *f1_fp, FILE *f2_fp, FILE *f3_fp, vstring addTag, long m)
   let(&delStartTag_, "/******* Start of deleted section *******");
   let(&delEndTag_, "******* End of deleted section *******/");
 
-
   /* Initialize vstring arrays */
   for (i = 0; i < MAX_LINES; i++) {
     line1_[i] = "";
@@ -102,7 +98,6 @@ void revise(FILE *f1_fp, FILE *f2_fp, FILE *f3_fp, vstring addTag, long m)
   if (m < 1) m = 1;
 
   r0=r1=r2=i0=i1_=i2_=d=t=i=j=i9=0;
-
 
   let(&ctlz_,chr(26));  /* End-of-file character */
 
@@ -343,9 +338,7 @@ l7240: /* */
        let(&l1_,ctlz_);
        let(&l2_,ctlz_);
        goto l7100;
-
 }
-
 
 void gosub_7320(void) {
         /* Subroutine:  get next L1_ from original file */
@@ -442,9 +435,7 @@ void gosub_7330(void) {
   let(&l2_, cat(tmpLin, l2_, NULL)); /* Add any blank lines */
   free_vstring(tmpLin); /* Deallocate */
   return;
-
 }
-
 
 /* Return 0 if difference lines are the same, non-zero otherwise */
 char strcmpe(vstring s1, vstring s2)
@@ -496,7 +487,6 @@ char strcmpe(vstring s1, vstring s2)
   free_vstring(tmps2); /* Deallocate string */
   return (cmpflag);
 }
-
 
 /* Strip any old tag from line and put new tag on it */
 /* (Caller must deallocate returned string) */

--- a/src/mmword.h
+++ b/src/mmword.h
@@ -14,13 +14,11 @@
 /*! Tag file changes with revision number tags */
 void revise(FILE *f1_fp, FILE *f2_fp, FILE *f3_fp, vstring addTag, long m);
 
-
 /*! \brief Get the largest revision number tag in a file
 
    Tags are assumed to be of format nn or #nn in comment at end of line.
    Used to determine default argument for tag question. */
 long highestRevision(vstring fileName);
-
 
 /*! \brief Get numeric revision from the tag on a line (returns 0 if none)
 

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -106,7 +106,6 @@ vstring_def(sandboxTitle);
 vstring_def(g_htmlBibliographyTags);
 vstring_def(extHtmlBibliographyTags);
 
-
 void eraseTexDefs(void) {
   /* Deallocate the texdef/htmldef storage */
   long i;
@@ -121,7 +120,6 @@ void eraseTexDefs(void) {
   }
   return;
 } /* eraseTexDefs */
-
 
 /* Returns 2 if there were severe parsing errors, 1 if there were warnings but
    no errors, 0 if no errors or warnings */
@@ -225,7 +223,6 @@ flag readTexDefs(
   for (i = 0; i < j; i++) {
     if (fileBuf[i] == '\n') lineNumOffset--;
   }
-
 
 #define LATEXDEF 1
 #define HTMLDEF 2
@@ -503,11 +500,9 @@ flag readTexDefs(
 
           /* Combine the string part to the main token we're building */
           let(&token, cat(token, partialToken, NULL));
-
         } /* (parsePass == 2) */
 
         fbPtr = fbPtr + tokenLength;
-
 
         /* Get next token - "+" or ";" */
         fbPtr = fbPtr + texDefWhiteSpaceLen(fbPtr);
@@ -533,9 +528,7 @@ flag readTexDefs(
         fbPtr = fbPtr + tokenLength;
 
         if (fbPtr[-1] == ';') break;
-
       } /* End while */
-
 
       if (parsePass == 2) {
         if ((cmd == LATEXDEF && !g_htmlFlag)
@@ -599,7 +592,6 @@ flag readTexDefs(
           || (cmd == ALTHTMLDEF && g_htmlFlag && g_altHtmlFlag)) {
         numSymbs++;
       }
-
     } /* End while */
 
     if (fbPtr != fileBuf + charCount) bug(2305);
@@ -612,9 +604,7 @@ flag readTexDefs(
       g_TexDefs = malloc((size_t)numSymbs * sizeof(struct texDef_struct));
       if (!g_TexDefs) outOfMemory("#99 (TeX symbols)");
     }
-
   } /* next parsePass */
-
 
   /* Sort the tokens for later lookup */
   qsort(g_TexDefs, (size_t)numSymbs, sizeof(struct texDef_struct), texSortCmp);
@@ -702,7 +692,6 @@ flag readTexDefs(
     }
   }
 
-
   /* Look up the extended database start label */
   if (extHtmlLabel[0]) {
     for (i = 1; i <= g_statements; i++) {
@@ -754,7 +743,6 @@ flag readTexDefs(
   j = instr(i + 1, g_htmlHome, "\"");
   let(&g_htmlHomeIMG, seg(g_htmlHome, i + 1, j - 1));
 
-
   /* Compose abbreviated title from capital letters */
   j = (long)strlen(htmlTitle);
   let(&htmlTitleAbbr, "");
@@ -795,14 +783,12 @@ flag readTexDefs(
     let(&g_extHtmlTitleAbbr, cat(g_extHtmlTitleAbbr, " Home", NULL));
   }
 
-
   free_vstring(token); /* Deallocate */
   free_vstring(partialToken); /* Deallocate */
   free_vstring(fileBuf);
   g_texDefsRead = 1;  /* Set global flag that it's been read in */
   return warningFound; /* Return indicator that parsing passed (0) or
                            had warning(s) (1) */
-
 } /* readTexDefs */
 
 /* This function returns the length of the white space starting at ptr.
@@ -842,7 +828,6 @@ long texDefWhiteSpaceLen(char *ptr)
   bug(2307);
   return 0; /* Dummy return - never executed */
 } /* texDefWhiteSpaceLen */
-
 
 /* This function returns the length of the token (non-white-space) starting at
    ptr.  Comments are considered white space.  ptr should point to the first
@@ -895,7 +880,6 @@ int texSortCmp(const void *key1, const void *key2)
   return strcmp(((struct texDef_struct *)key1)->tokenName,
       ((struct texDef_struct *)key2)->tokenName);
 } /* texSortCmp */
-
 
 /* Token comparison for bsearch */
 int texSrchCmp(const void *key, const void *data)
@@ -994,7 +978,6 @@ vstring asciiToTt(vstring s)
   return ttstr;
 } /* asciiToTt */
 
-
 /* Convert ascii token to TeX equivalent */
 /* The "$" math delimiter is not placed around the returned arg. here */
 /* *** Note: The caller must deallocate the returned string */
@@ -1068,12 +1051,10 @@ vstring tokenToTex(vstring mtoken, long statemNum /*for error msgs*/)
     /* Make all letters Roman; put inside mbox */
     if (!g_htmlFlag)
       let(&tex, cat("\\mbox{\\rm ", tex, "}", NULL));
-
   } /* End if */
 
   return tex;
 } /* tokenToTex */
-
 
 /* Converts a comment section in math mode to TeX.  Each math token
    MUST be separated by white space.   TeX "$" does not surround the output. */
@@ -1139,7 +1120,6 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
 
   return texLine;
 } /* asciiMathToTex */
-
 
 /* Gets the next section of a comment that is in the current mode (text,
    label, or math).  If 1st char. is not "$" (DOLLAR_SUBST), text mode is
@@ -1214,7 +1194,6 @@ vstring getCommentModeSection(vstring *srcptr, char *mode)
   } /* End while */
   return NULL; /* Dummy return - never executes */
 } /* getCommentModeSection */
-
 
 /* The texHeaderFlag means this:
     If !g_htmlFlag (i.e. TeX mode), then 1 means print header
@@ -1358,7 +1337,6 @@ void printTexHeader(flag texHeaderFlag)
           left(g_texFileName, (long)strlen(g_texFileName) - 5),
           " - ", g_extHtmlTitle,
           "</TITLE>", NULL));
-
     } else {
       /* "Mathbox for <username>" */
       /* Scan from this statement backwards until a big header is found */
@@ -1397,7 +1375,6 @@ void printTexHeader(flag texHeaderFlag)
           left(g_texFileName, (long)strlen(g_texFileName) - 5),
           " - ", localSandboxTitle,
           "</TITLE>", NULL), "", "\"");
-
     }
     /* Icon for bookmark */
     print2("%s%s\n", "<LINK REL=\"shortcut icon\" HREF=\"favicon.ico\" ",
@@ -1574,18 +1551,14 @@ void printTexHeader(flag texHeaderFlag)
 
       /* Print the GIF/Unicode Font choice, if directories are specified */
       if (htmlDir[0]) {
-
         if (g_altHtmlFlag) {
           print2("      <A HREF=\"%s%s\">GIF version</A>\n",
                 htmlDir, g_texFileName);
-
         } else {
           print2("      <A HREF=\"%s%s\">Unicode version</A>\n",
                 altHtmlDir, g_texFileName);
-
         }
       }
-
     } else { /* texHeaderFlag=0 for HTML means not to put prev/next links */
       /* there is no table open (mmascii, mmdefinitions), so don't
          add </TD> which caused HTML validation failure */
@@ -1608,7 +1581,6 @@ void printTexHeader(flag texHeaderFlag)
       else {
         print2("&nbsp;\n");
       }
-
     }
 
     print2("      </FONT>\n");
@@ -1616,9 +1588,7 @@ void printTexHeader(flag texHeaderFlag)
     print2("  </TR>\n");
     print2("</TABLE>\n");
 
-
     print2("<HR NOSHADE SIZE=1>\n");
-
   } /* g_htmlFlag */
   fprintf(g_texFilePtr, "%s", g_printString);
   g_outputToString = 0;
@@ -1626,7 +1596,6 @@ void printTexHeader(flag texHeaderFlag)
 
   /* Deallocate strings */
   free_vstring(tmpStr);
-
 } /* printTexHeader */
 
 /* Prints an embedded comment in TeX or HTML.  The commentPtr must point to the first
@@ -1744,7 +1713,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
      math symbols are replaced with blanks in cmdMasked */
   let(&cmtMasked, cmt);
 
-
   /* This section is independent and can be removed without side effects */
   if (g_htmlFlag) {
     /* Convert special characters <, &, etc. to HTML entities */
@@ -1800,7 +1768,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     free_vstring(tmpStrMasked);
   }
 
-
   /* Add leading and trailing HTML markup to comment here
      (instead of in caller).  Also convert special characters. */
   if (g_htmlFlag) {
@@ -1813,7 +1780,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           cmtMasked, "</TD></TR></TABLE></CENTER>", NULL));
     }
   }
-
 
   /* Mask out _ (underscore) in labels so they won't become subscripts
      (reported by Benoit Jubin) */
@@ -1853,7 +1819,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       }  /* while (1) */
     } /* while (1) */
   } /* if g_htmlFlag */
-
 
   /* Handle dollar signs in comments converted to LaTeX */
   /* This section is independent and can be removed without side effects */
@@ -2002,7 +1967,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
               pos1 = pos2 + 4; /* Adjust for 5-1 extra chars in "let" above */
             }
             continue;
-
           } else {
             /* Found <nonwhitespace>_<whitespace> - not an opening "_" */
             /* Do nothing in this case */
@@ -2183,10 +2147,8 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           /*} else {*/
           } else if (g_showStatement < g_mathboxStmt) {
             let(&extHtmlBibliographyTags, bibTags);
-
           } else {
             let(&g_htmlBibliographyTags, bibTags);
-
           }
           /* Done reading in HTML file with bibliography */
         } /* end if (!bibTags[0]) */
@@ -2292,7 +2254,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           }
           free_vstring(tmp);
         }
-
       }
     }
     if (cmt[i] == '~' && mode != 'm') {
@@ -2346,7 +2307,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           clen = clen - 1;
         }
         free_vstring(tmp);
-
       }
     }
 
@@ -2374,7 +2334,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         clen = clen - 1;
       }
       free_vstring(tmp);
-
     }
     /* clen should always remain comment length - do a sanity check here */
     if ((signed)(strlen(cmt)) != clen) {
@@ -2382,7 +2341,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     }
   } /* Next i */
   /* End convert line to the old $m..$n and $l..$n */
-
 
   /* Put <HTML> and </HTML> at beginning of line so preformattedMode won't
      be switched on or off in the middle of processing a line */
@@ -2422,7 +2380,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
 
     let(&cmt, cat(left(cmt, pos1 - 1), "\n", right(cmt, pos1), NULL));
   }
-
 
   cmtptr = cmt; /* cmtptr is for scanning cmt */
 
@@ -2475,7 +2432,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     }
     free_vstring(tmpStr); /* Deallocate */
 
-
     /* Convert all sections of the line to text, math, or labels */
     let(&outputLine, "");
     srcptr = sourceLine;
@@ -2509,7 +2465,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                 NULL), "", " ");
             returnVal = 1; /* Error/warning printed */
             g_outputToString = 1;
-
           }
 
           if (!strcmp("http://", left(tmpStr, 7))
@@ -2535,7 +2490,6 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
               }
               let(&outputLine, cat(outputLine, "\\url{", tmpStr,
                   "}", tmp, NULL));
-
             }
           } else {
             /* Do binary search through just $a's and $p's (there
@@ -2756,9 +2710,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   free_vstring(bibTags);
 
   return returnVal; /* 1 if error/warning found */
-
 } /* printTexComment */
-
 
 void printTexLongMath(nmbrString *mathString,
     vstring startPrefix, /* Start prefix in "screen display" mode e.g.
@@ -3114,9 +3066,7 @@ void printTexTrailer(flag texTrailerFlag) {
     fprintf(g_texFilePtr, "%s", g_printString);
     free_vstring(g_printString);
   }
-
 } /* printTexTrailer */
-
 
 /* WRITE THEOREM_LIST command:  Write out theorem list
    into mmtheorems.html, mmtheorems1.html,... */
@@ -3269,14 +3219,12 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
         ")</B></FONT>",
         NULL), "", "\"");
 
-
     /* Put Previous/Next links into web page */
     print2("</TD><TD NOWRAP ALIGN=RIGHT VALIGN=TOP WIDTH=\"25%c\"><FONT\n", '%');
     print2(" SIZE=-1 FACE=sans-serif>\n");
 
     /* Output title with current page */
     /* Output previous and next */
-
 
     /* Assign prevNextLinks once here since it is used 3 times */
     let(&prevNextLinks, cat("<A HREF=\"mmtheorems",
@@ -3362,7 +3310,6 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
       print2("&nbsp;&gt;&nbsp;<A HREF=\"mmrecent.html\">\n");
       print2("Recent Proofs</A>\n");
     }
-
 
     print2("&nbsp; &nbsp; &nbsp; <B><FONT COLOR=%s>\n", GREEN_TITLE_COLOR);
     print2("This page:</FONT></B> \n");
@@ -3710,15 +3657,12 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
         } /* next stmt */
         /* 8-May-2015 nm Do we need the HR below? */
         fprintf(outputFilePtr, "<HR NOSHADE SIZE=1>\n");
-
       } /* next passNumber */
-
     } /* if page 0 */
     /* End table of contents */
 
     /* Just skip over instead of a big if indent */
     if (page == 0) goto SKIP_LIST;
-
 
     /* Put in color key */
     g_outputToString = 1;
@@ -3768,7 +3712,6 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
       print2("<TD WIDTH=10>&nbsp;</TD>\n");
       print2("\n");
 
-
       /* Mathbox stuff */
       print2("<TD BGCOLOR=%s NOWRAP><A\n", SANDBOX_COLOR);
       print2(" HREF=\"mathbox.html\"><IMG SRC=\"_sandbox.gif\"\n");
@@ -3786,7 +3729,6 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
       print2("<TD WIDTH=10>&nbsp;</TD>\n");
       print2("\n");
 
-
       print2("</TR></TABLE></CENTER>\n");
     } /* end if (g_extHtmlStmt < g_mathboxStmt) */
 
@@ -3794,7 +3736,6 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     fprintf(outputFilePtr, "%s", g_printString);
     g_outputToString = 0;
     let(&g_printString, "");
-
 
     /* Write the main table header */
     g_outputToString = 1;
@@ -4184,7 +4125,6 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
    SKIP_LIST: /* (skipped when page == 0) */
     g_outputToString = 1; /* To compensate for skipped assignment above */
 
-
     /* Put extra Prev/Next hyperlinks here for convenience */
     print2("<TABLE BORDER=0 WIDTH=\"100%c\">\n", '%');
     print2("  <TR>\n");
@@ -4201,20 +4141,16 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
     print2("  </TR>\n");
     print2("</TABLE>\n");
 
-
     print2("<HR NOSHADE SIZE=1>\n");
-
 
     g_outputToString = 0;
     fprintf(outputFilePtr, "%s", g_printString);
     free_vstring(g_printString);
 
-
     fprintf(outputFilePtr, "<A NAME=\"mmpglst\"></A>\n");
     fprintf(outputFilePtr, "<CENTER>\n");
     fprintf(outputFilePtr, "<B>Page List</B>\n");
     fprintf(outputFilePtr, "</CENTER>\n");
-
 
     /* Output links to the other pages */
     fprintf(outputFilePtr, "Jump to page: \n");
@@ -4250,7 +4186,6 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
       let(&str1, cat(str1, PINK_NBSP, str3, NULL));
       fprintf(outputFilePtr, "%s\n", str1);
     }
-
 
     g_outputToString = 1;
     print2("<HR NOSHADE SIZE=1>\n");
@@ -4301,9 +4236,7 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
   free_pntrString(pntrSmallHdr);
   for (i = 0; i <= g_statements; i++) free_vstring(*(vstring *)(&pntrTinyHdr[i]));
   free_pntrString(pntrTinyHdr);
-
 } /* writeTheoremList */
-
 
 /* This function extracts any section headers in the comment sections
    prior to the label of statement stmt.   If a huge (####...) header isn't
@@ -4629,7 +4562,6 @@ flag getSectionHeadings(long stmt,
   return errorFound;
 } /* getSectionHeadings */
 
-
 /* Returns HTML for the pink number to print after the statement labels
    in HTML output.  (Note that "pink" means "rainbow colored" number now.) */
 /* Warning: The caller must deallocate the returned vstring (i.e. this
@@ -4662,7 +4594,6 @@ vstring pinkHTML(long statemNum)
   return htmlCode;
 } /* pinkHTML */
 
-
 /* Returns HTML for a range of pink numbers separated by a "-". */
 /* Warning: The caller must deallocate the returned vstring (i.e. this
    function cannot be used in let statements but must be assigned to
@@ -4684,7 +4615,6 @@ vstring pinkRangeHTML(long statemNum1, long statemNum2) {
   free_vstring(str4); /* Deallocate */
   return htmlCode;
 } /* pinkRangeHTML */
-
 
 /* This function converts a "spectrum" color (1 to maxColor) to an
    RBG value in hex notation for HTML.  The caller must deallocate the
@@ -4811,7 +4741,6 @@ vstring spectrumToRGB(long color, long maxColor) {
   /*printf("<FONT COLOR='#%02X%02X%02X'>a </FONT>\n", red, green, blue);*/
   return str1;
 } /* spectrumToRGB */
-
 
 /* Returns the HTML code for GIFs (!g_altHtmlFlag) or Unicode (g_altHtmlFlag),
    or LaTeX when !g_htmlFlag, for the math string (hypothesis or conclusion) that
@@ -4992,7 +4921,6 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
   return texLine;
 } /* getTexLongMath */
 
-
 /* Returns the TeX, or HTML code for GIFs (!g_altHtmlFlag) or Unicode
    (g_altHtmlFlag), for a statement's hypotheses and assertion in the form
    hyp & ... & hyp => assertion */
@@ -5075,7 +5003,6 @@ vstring getTexOrHtmlHypAndAssertion(long statemNum) {
   free_vstring(str2);
   return texOrHtmlCode;
 }  /* getTexOrHtmlHypAndAssertion */
-
 
 /* Called by the WRITE BIBLIOGRAPHY command and also by VERIFY MARKUP
    for error checking */
@@ -5478,7 +5405,6 @@ flag writeBibliography(vstring bibFile,
     }
   }
 
-
   /* Discard the input file up to the special "<!-- #END# -->" comment */
   if (fileCheck) {
     while (1) {
@@ -5521,7 +5447,6 @@ flag writeBibliography(vstring bibFile,
     free_pntrString(pntrTmp);
   }
 
-
  BIB_ERROR:
   if (fileCheck) {
     fclose(list1_fp);
@@ -5541,7 +5466,6 @@ flag writeBibliography(vstring bibFile,
   if (errFlag == 2) warnFlag = 2;
   return warnFlag;
 }  /* writeBibliography */
-
 
 /* Returns 1 if stmt1 and stmt2 are in different mathboxes, 0 if
    they are in the same mathbox or if one of them is not in a mathbox. */
@@ -5578,7 +5502,6 @@ long getMathboxNum(long stmt) {
   return mbox;
 } /* getMathboxNum */
 
-
 /* Assign the global variable g_mathboxStmt, the statement number with the
    label "mathbox", as well as g_mathboxes, g_mathboxStart[], g_mathboxEnd[],
    and g_mathboxUser[].  For speed, we do the lookup only if it hasn't been
@@ -5600,7 +5523,6 @@ void assignMathboxInfo(void) {
   }
   return;
 } /* assignMathboxInfo */
-
 
 /* Returns the number of mathboxes, while assigning start statement, end
    statement, and mathbox name. */
@@ -5652,4 +5574,4 @@ long getMathboxLoc(nmbrString **mathboxStart, nmbrString **mathboxEnd,
   free_vstring(comment);
   free_vstring(user);
   return mathboxes;
-} /* getMathboxLoc */
+} // getMathboxLoc

--- a/src/mmwtex.h
+++ b/src/mmwtex.h
@@ -66,7 +66,6 @@ struct texDef_struct {
 };
 extern struct texDef_struct *g_TexDefs; /*!< for "erase" */
 
-
 long texDefWhiteSpaceLen(char *ptr);
 long texDefTokenLen(char *ptr);
 /*! Token comparison for qsort */

--- a/tests/anatomy-bad1.expected
+++ b/tests/anatomy-bad1.expected
@@ -1,13 +1,13 @@
 MM> READ "anatomy-bad1.mm"
-Reading source file "anatomy-bad1.mm"... 671 bytes
-671 bytes were read into the source buffer.
+Reading source file "anatomy-bad1.mm"... 669 bytes
+669 bytes were read into the source buffer.
 The source has 8 statements; 1 are $a and 1 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.
 MM> Continuous scrolling is now in effect.
 MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
 ..................................................
-?Error on line 29 of file "anatomy-bad1.mm" at statement 8, label "wnew", type
+?Error on line 27 of file "anatomy-bad1.mm" at statement 8, label "wnew", type
 "$p":
 wnew $p wff ( s -> ( r -> p ) ) $= ws wr wp w2 ws $.
                                                ^^

--- a/tests/anatomy-bad1.mm
+++ b/tests/anatomy-bad1.mm
@@ -7,9 +7,7 @@ This file is placed in the public domain per the Creative Commons Public
 Domain Dedication. http://creativecommons.org/licenses/publicdomain/
 
 Norman Megill
-
 $)
-
 
 $( This file is the introductory formal system example described
    in Chapter 4 of the Metamath book, "Anatomy of a proof". $)

--- a/tests/anatomy-bad2.expected
+++ b/tests/anatomy-bad2.expected
@@ -1,13 +1,13 @@
 MM> READ "anatomy-bad2.mm"
-Reading source file "anatomy-bad2.mm"... 668 bytes
-668 bytes were read into the source buffer.
+Reading source file "anatomy-bad2.mm"... 666 bytes
+666 bytes were read into the source buffer.
 The source has 8 statements; 1 are $a and 1 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.
 MM> Continuous scrolling is now in effect.
 MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
 ..................................................
-?Error on line 29 of file "anatomy-bad2.mm" at statement 8, label "wnew", type
+?Error on line 27 of file "anatomy-bad2.mm" at statement 8, label "wnew", type
 "$p":
 wnew $p wff ( s -> ( r -> p ) ) $= ws wr wp w2 $.
                                             ^^

--- a/tests/anatomy-bad2.mm
+++ b/tests/anatomy-bad2.mm
@@ -7,9 +7,7 @@ This file is placed in the public domain per the Creative Commons Public
 Domain Dedication. http://creativecommons.org/licenses/publicdomain/
 
 Norman Megill
-
 $)
-
 
 $( This file is the introductory formal system example described
    in Chapter 4 of the Metamath book, "Anatomy of a proof". $)

--- a/tests/anatomy-bad3.expected
+++ b/tests/anatomy-bad3.expected
@@ -1,13 +1,13 @@
 MM> READ "anatomy-bad3.mm"
-Reading source file "anatomy-bad3.mm"... 668 bytes
-668 bytes were read into the source buffer.
+Reading source file "anatomy-bad3.mm"... 666 bytes
+666 bytes were read into the source buffer.
 The source has 8 statements; 1 are $a and 1 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.
 MM> Continuous scrolling is now in effect.
 MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
 ..................................................
-?Error on line 29 of file "anatomy-bad3.mm" at statement 8, label "wnew", type
+?Error on line 27 of file "anatomy-bad3.mm" at statement 8, label "wnew", type
 "$p":
 wnew $p wff ( s -> ( r -> p ) ) $= wr wp w2 w2 $.
                                             ^^

--- a/tests/anatomy-bad3.mm
+++ b/tests/anatomy-bad3.mm
@@ -7,9 +7,7 @@ This file is placed in the public domain per the Creative Commons Public
 Domain Dedication. http://creativecommons.org/licenses/publicdomain/
 
 Norman Megill
-
 $)
-
 
 $( This file is the introductory formal system example described
    in Chapter 4 of the Metamath book, "Anatomy of a proof". $)

--- a/tests/anatomy.expected
+++ b/tests/anatomy.expected
@@ -1,6 +1,6 @@
 MM> READ "anatomy.mm"
-Reading source file "anatomy.mm"... 671 bytes
-671 bytes were read into the source buffer.
+Reading source file "anatomy.mm"... 669 bytes
+669 bytes were read into the source buffer.
 The source has 8 statements; 1 are $a and 1 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.

--- a/tests/anatomy.mm
+++ b/tests/anatomy.mm
@@ -7,9 +7,7 @@ This file is placed in the public domain per the Creative Commons Public
 Domain Dedication. http://creativecommons.org/licenses/publicdomain/
 
 Norman Megill
-
 $)
-
 
 $( This file is the introductory formal system example described
    in Chapter 4 of the Metamath book, "Anatomy of a proof". $)

--- a/tests/big-unifier-bad1.expected
+++ b/tests/big-unifier-bad1.expected
@@ -1,13 +1,13 @@
 MM> READ "big-unifier-bad1.mm"
-Reading source file "big-unifier-bad1.mm"... 3369 bytes
-3369 bytes were read into the source buffer.
+Reading source file "big-unifier-bad1.mm"... 3366 bytes
+3366 bytes were read into the source buffer.
 The source has 28 statements; 4 are $a and 1 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.
 MM> Continuous scrolling is now in effect.
 MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
 ..................................................
-?Error on line 68 of file "big-unifier-bad1.mm" at statement 28, label
+?Error on line 67 of file "big-unifier-bad1.mm" at statement 28, label
 "theorem1", type "$p":
    FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOARLIH $.
                                                   ^

--- a/tests/big-unifier-bad1.mm
+++ b/tests/big-unifier-bad1.mm
@@ -13,7 +13,6 @@ without any conditions, unless such conditions are required by law.
 Norman Megill - http://metamath.org $)
 
 $(
-
 This file (big-unifier.mm) is a unification and substitution test for
 Metamath verifiers, where small input expressions blow up to thousands
 of symbols.  It is a translation of William McCune's "big-unifier.in"
@@ -26,7 +25,6 @@ for the OTTER theorem prover:
         detachment.  These occur in Larry Wos's proofs that XCB is a single
         axiom for EC."
 $)
-
 
  $c wff |- e ( , ) $.
  $v x y z w v u v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 $.
@@ -68,7 +66,6 @@ $)
    FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOARLIH $.
 
 $(
-
 This comment holds a simple typesetting definition file so that HTML
 pages can be created with "show statement theorem1/html" in the
 metamath program.

--- a/tests/big-unifier-bad1.mm
+++ b/tests/big-unifier-bad1.mm
@@ -10,7 +10,8 @@ The public domain release applies worldwide.  In case this is not
 legally possible, the right is granted to use the work for any purpose,
 without any conditions, unless such conditions are required by law.
 
-Norman Megill - http://metamath.org $)
+Norman Megill - http://metamath.org
+$)
 
 $(
 This file (big-unifier.mm) is a unification and substitution test for

--- a/tests/big-unifier-bad2.expected
+++ b/tests/big-unifier-bad2.expected
@@ -1,13 +1,13 @@
 MM> READ "big-unifier-bad2.mm"
-Reading source file "big-unifier-bad2.mm"... 3366 bytes
-3366 bytes were read into the source buffer.
+Reading source file "big-unifier-bad2.mm"... 3363 bytes
+3363 bytes were read into the source buffer.
 The source has 28 statements; 4 are $a and 1 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.
 MM> Continuous scrolling is now in effect.
 MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
 ..................................................
-?Error on line 68 of file "big-unifier-bad2.mm" at statement 28, label
+?Error on line 67 of file "big-unifier-bad2.mm" at statement 28, label
 "theorem1", type "$p":
    FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOAR $.
                                                 ^

--- a/tests/big-unifier-bad2.mm
+++ b/tests/big-unifier-bad2.mm
@@ -13,7 +13,6 @@ without any conditions, unless such conditions are required by law.
 Norman Megill - http://metamath.org $)
 
 $(
-
 This file (big-unifier.mm) is a unification and substitution test for
 Metamath verifiers, where small input expressions blow up to thousands
 of symbols.  It is a translation of William McCune's "big-unifier.in"
@@ -26,7 +25,6 @@ for the OTTER theorem prover:
         detachment.  These occur in Larry Wos's proofs that XCB is a single
         axiom for EC."
 $)
-
 
  $c wff |- e ( , ) $.
  $v x y z w v u v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 $.
@@ -68,7 +66,6 @@ $)
    FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOAR $.
 
 $(
-
 This comment holds a simple typesetting definition file so that HTML
 pages can be created with "show statement theorem1/html" in the
 metamath program.

--- a/tests/big-unifier-bad2.mm
+++ b/tests/big-unifier-bad2.mm
@@ -10,7 +10,8 @@ The public domain release applies worldwide.  In case this is not
 legally possible, the right is granted to use the work for any purpose,
 without any conditions, unless such conditions are required by law.
 
-Norman Megill - http://metamath.org $)
+Norman Megill - http://metamath.org
+$)
 
 $(
 This file (big-unifier.mm) is a unification and substitution test for

--- a/tests/big-unifier-bad3.expected
+++ b/tests/big-unifier-bad3.expected
@@ -1,13 +1,13 @@
 MM> READ "big-unifier-bad3.mm"
-Reading source file "big-unifier-bad3.mm"... 3369 bytes
-3369 bytes were read into the source buffer.
+Reading source file "big-unifier-bad3.mm"... 3366 bytes
+3366 bytes were read into the source buffer.
 The source has 28 statements; 4 are $a and 1 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.
 MM> Continuous scrolling is now in effect.
 MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
 ..................................................
-?Error on line 68 of file "big-unifier-bad3.mm" at statement 28, label
+?Error on line 67 of file "big-unifier-bad3.mm" at statement 28, label
 "theorem1", type "$p":
    FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOARLAI $.
                                                    ^

--- a/tests/big-unifier-bad3.mm
+++ b/tests/big-unifier-bad3.mm
@@ -10,10 +10,10 @@ The public domain release applies worldwide.  In case this is not
 legally possible, the right is granted to use the work for any purpose,
 without any conditions, unless such conditions are required by law.
 
-Norman Megill - http://metamath.org $)
+Norman Megill - http://metamath.org
+$)
 
 $(
-
 This file (big-unifier.mm) is a unification and substitution test for
 Metamath verifiers, where small input expressions blow up to thousands
 of symbols.  It is a translation of William McCune's "big-unifier.in"
@@ -26,7 +26,6 @@ for the OTTER theorem prover:
         detachment.  These occur in Larry Wos's proofs that XCB is a single
         axiom for EC."
 $)
-
 
  $c wff |- e ( , ) $.
  $v x y z w v u v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 $.
@@ -68,7 +67,6 @@ $)
    FFZMPAFFZFPFQPFZFLRFFLNKMJAJNQPLAPGPMKBADCEOARLAI $.
 
 $(
-
 This comment holds a simple typesetting definition file so that HTML
 pages can be created with "show statement theorem1/html" in the
 metamath program.

--- a/tests/big-unifier.expected
+++ b/tests/big-unifier.expected
@@ -1,6 +1,6 @@
 MM> READ "big-unifier.mm"
-Reading source file "big-unifier.mm"... 21981 bytes
-21981 bytes were read into the source buffer.
+Reading source file "big-unifier.mm"... 21978 bytes
+21978 bytes were read into the source buffer.
 The source has 29 statements; 4 are $a and 2 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.

--- a/tests/big-unifier.mm
+++ b/tests/big-unifier.mm
@@ -10,10 +10,10 @@ The public domain release applies worldwide.  In case this is not
 legally possible, the right is granted to use the work for any purpose,
 without any conditions, unless such conditions are required by law.
 
-Norman Megill - http://metamath.org $)
+Norman Megill - http://metamath.org
+$)
 
 $(
-
 This file (big-unifier.mm) is a unification and substitution test for
 Metamath verifiers, where small input expressions blow up to thousands
 of symbols.  It is a translation of William McCune's "big-unifier.in"
@@ -26,7 +26,6 @@ for the OTTER theorem prover:
         detachment.  These occur in Larry Wos's proofs that XCB is a single
         axiom for EC."
 $)
-
 
  $c wff |- e ( , ) $.
  $v x y z w v u v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 $.
@@ -310,7 +309,6 @@ $)
    $.
 
 $(
-
 This comment holds a simple typesetting definition file so that HTML
 pages can be created with "show statement theorem1/html" in the
 metamath program.

--- a/tests/demo0-bad1.expected
+++ b/tests/demo0-bad1.expected
@@ -1,13 +1,13 @@
 MM> READ "demo0-bad1.mm"
-Reading source file "demo0-bad1.mm"... 1325 bytes
-1325 bytes were read into the source buffer.
+Reading source file "demo0-bad1.mm"... 1323 bytes
+1323 bytes were read into the source buffer.
 The source has 19 statements; 7 are $a and 1 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.
 MM> Continuous scrolling is now in effect.
 MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
 ..................................................
-?Error on line 50 of file "demo0-bad1.mm" at statement 19, label "th1", type
+?Error on line 48 of file "demo0-bad1.mm" at statement 19, label "th1", type
 "$p":
        tt tze tpl tt tt a1 mp mp
                               ^^

--- a/tests/demo0-bad1.mm
+++ b/tests/demo0-bad1.mm
@@ -7,9 +7,7 @@ This file is placed in the public domain per the Creative Commons Public
 Domain Dedication. http://creativecommons.org/licenses/publicdomain/
 
 Norman Megill
-
 $)
-
 
 $( This file is the introductory formal system example described
    in Chapter 2 of the Meamath book. $)

--- a/tests/demo0-includee.mm
+++ b/tests/demo0-includee.mm
@@ -7,9 +7,7 @@ This file is placed in the public domain per the Creative Commons Public
 Domain Dedication. http://creativecommons.org/licenses/publicdomain/
 
 Norman Megill
-
 $)
-
 
 $( This file is the introductory formal system example described
    in Chapter 2 of the Meamath book. $)

--- a/tests/demo0-includer.expected
+++ b/tests/demo0-includer.expected
@@ -1,7 +1,7 @@
 MM> READ "demo0-includer.mm"
-Reading source file "demo0-includer.mm"... 492 bytes
-Reading included file "demo0-includee.mm"... 1117 bytes
-1655 bytes were read into the source buffer.
+Reading source file "demo0-includer.mm"... 490 bytes
+Reading included file "demo0-includee.mm"... 1115 bytes
+1651 bytes were read into the source buffer.
 The source has 19 statements; 7 are $a and 1 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.

--- a/tests/demo0-includer.mm
+++ b/tests/demo0-includer.mm
@@ -7,9 +7,7 @@ This file is placed in the public domain per the Creative Commons Public
 Domain Dedication. http://creativecommons.org/licenses/publicdomain/
 
 Norman Megill
-
 $)
-
 
 $[ demo0-includee.mm $]
 

--- a/tests/demo0.expected
+++ b/tests/demo0.expected
@@ -1,6 +1,6 @@
 MM> READ "demo0.mm"
-Reading source file "demo0.mm"... 1325 bytes
-1325 bytes were read into the source buffer.
+Reading source file "demo0.mm"... 1323 bytes
+1323 bytes were read into the source buffer.
 The source has 19 statements; 7 are $a and 1 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.

--- a/tests/demo0.mm
+++ b/tests/demo0.mm
@@ -7,9 +7,7 @@ This file is placed in the public domain per the Creative Commons Public
 Domain Dedication. http://creativecommons.org/licenses/publicdomain/
 
 Norman Megill
-
 $)
-
 
 $( This file is the introductory formal system example described
    in Chapter 2 of the Meamath book. $)

--- a/tests/nuniq-gram.expected
+++ b/tests/nuniq-gram.expected
@@ -1,6 +1,6 @@
 MM> READ "nuniq-gram.mm"
-Reading source file "nuniq-gram.mm"... 449 bytes
-449 bytes were read into the source buffer.
+Reading source file "nuniq-gram.mm"... 448 bytes
+448 bytes were read into the source buffer.
 The source has 7 statements; 3 are $a and 0 are $p.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.

--- a/tests/nuniq-gram.mm
+++ b/tests/nuniq-gram.mm
@@ -1,4 +1,4 @@
-$( Here we have two variable typecodes A and B, and one logical 
+$( Here we have two variable typecodes A and B, and one logical
    typecode |-, and the question is whether |- connects to A or B.
    It parses either way. This is actually an unambiguous formal system,
    because we require only that there are no two ways to derive the proof

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -32,7 +32,7 @@ if [ "$1" = "--help" ]; then usage; exit; fi
 # Allow overriding the 'metamath' command using the METAMATH env variable
 cmd="${METAMATH:-metamath}"
 
-# Alternately, use the '-c metamath' argument which overrides the env variable
+# Alternatively, use the '-c metamath' argument which overrides the env variable
 if [ "$1" = "-c" ]; then shift; cmd=$1; shift; fi
 
 if [ "$1" = "--bless" ]; then bless=1; shift; fi

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 usage() {
-  cat >&2 << "HELP"
+  cat >&2 <<"HELP"
 Usage: run_test [-c CMD] [--bless] TESTS...
 Run tests from the test suite.
 
-Each TEST should be the name of a TEST.in file in the current directory.
-It calls 'metamath TEST.mm < TEST.in > TEST.produced' and compares
-TEST.produced with TEST.expected, printing a test failure report.
+Each TEST should be the name of a TEST.in file in the current directory.  It
+calls 'metamath TEST.mm < TEST.in > TEST.produced' and compares TEST.produced
+with TEST.expected, printing a test failure report.
 
 If TEST.mm does not exist, then it just calls metamath without arguments.
 
@@ -15,15 +15,15 @@ The 'metamath' command can be modified by setting the METAMATH environment
 variable, or via the '-c CMD' option (which takes priority).
 
 The --bless option can be used to update the TEST.expected file to match
-TEST.produced. Always review the changes after a call to run_test --bless.
+TEST.produced.  Always review the changes after a call to run_test --bless.
 
 TEST.in files have the syntax of metamath scripts, so leading ! can be used to
-write comments. This script contains some special directives in tests:
+write comments.  This script contains some special directives in tests:
 
 * '! run_test' means that the output will be ignored: TEST.produced will not be
   created and TEST.expected does not have to exist.
-* '! expect_fail' means that we expect metamath to return exit code 1
-  instead of 0 on this input.
+* '! expect_fail' means that we expect metamath to return exit code 1 instead
+  of 0 on this input.
 HELP
 }
 
@@ -32,7 +32,7 @@ if [ "$1" = "--help" ]; then usage; exit; fi
 # Allow overriding the 'metamath' command using the METAMATH env variable
 cmd="${METAMATH:-metamath}"
 
-# Alternatively, use the '-c metamath' argument which overrides the env variable
+# Alternately, use the '-c metamath' argument which overrides the env variable
 if [ "$1" = "-c" ]; then shift; cmd=$1; shift; fi
 
 if [ "$1" = "--bless" ]; then bless=1; shift; fi


### PR DESCRIPTION
rewrap README.TXT; all files: remove trailing spaces, remove double blank lines, remove blank lines before closing parentheses/braces/brackets