### PR TITLE
run unification check even when there are no variables to unify

### DIFF
--- a/src/mmveri.c
+++ b/src/mmveri.c
@@ -229,18 +229,13 @@ nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
   nmbrLet(&bigSubstSchemeVars,nmbrExtractVars(bigSubstSchemeAss));
   long bigSubstSchemeVarLen = nmbrLen(bigSubstSchemeVars);
 
-  /* If there are no variables in the hypotheses, there won't be any in the
-     assertion (unless there was a previously detected error).  In this case,
-     the unification is just the assertion itself. */
-  if (!bigSubstSchemeVarLen) {
-    if (!nmbrLen(g_Statement[substScheme].reqVarList)) {
-      nmbrLet(&result,g_Statement[substScheme].mathString);
-    } else {
-      /* There must have been a previous error; let result remain empty */
-      if (!unkHypFlag) bug(2109);
-    }
-    goto returnPoint;
-  }
+  // If there are no variables in the hypotheses (bigSubstSchemeVarLen == 0),
+  // there won't be any in the assertion (unless there was a previously
+  // detected error). In this case, the unification is just the assertion itself.
+  //
+  // However, we still have to go through the motions of creating the
+  // substitution because we may need to report a unification failure error
+  // (see #107).
 
   /* Allocate nmbrStrings used only to hold extra data for bigSubstSchemeAss;
      don't use further nmbrString functions on them! */
@@ -428,7 +423,7 @@ ambiguityCheck: /* Re-entry point to see if unification is unique */
 /*E*/"p=%ld,bigSubstSchemeLen=%ld;q=%ld,bigSubstInstLen=%ld;v=%ld,bigSubstSchemeVarLen=%ld\n",
 /*E*/  p,bigSubstSchemeLen,q,bigSubstInstLen,v,bigSubstSchemeVarLen);
   /* See if the assignment completed normally */
-  if (v == -1) {
+  if (breakFlag) {
     if (ambiguityCheckFlag) {
       /* This is what we wanted to see -- no further unification possible */
       goto returnPoint;

--- a/tests/issue107.expected
+++ b/tests/issue107.expected
@@ -1,0 +1,17 @@
+MM> READ "issue107.mm"
+Reading source file "issue107.mm"... 122 bytes
+122 bytes were read into the source buffer.
+The source has 7 statements; 2 are $a and 1 are $p.
+SET EMPTY_SUBSTITUTION was turned ON (allowed) for this database.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> Continuous scrolling is now in effect.
+MM> 0 10%  20%  30%  40%  50%  60%  70%  80%  90% 100%
+..................................................
+?Error on line 10 of file "issue107.mm" at statement 7, label "th", type "$p":
+th $p thesis $= ax mp $.
+                   ^^
+The hypotheses of statement "mp" at proof step 2 cannot be unified.
+  Hypothesis 1:  hypothesis
+  Step 1:  axiom
+

--- a/tests/issue107.in
+++ b/tests/issue107.in
@@ -1,0 +1,1 @@
+verify proof *

--- a/tests/issue107.mm
+++ b/tests/issue107.mm
@@ -1,0 +1,10 @@
+$c axiom hypothesis thesis $.
+
+ax $a axiom $.
+
+${
+   hyp $e hypothesis $.
+   mp $a thesis $.
+$}
+
+th $p thesis $= ax mp $.


### PR DESCRIPTION
* [x] depends on #126

fixes #107