### PR TITLE
tex generation: avoid '\rm', load mathtools and phonetic

### DIFF
--- a/src/mmdata.h
+++ b/src/mmdata.h
@@ -946,4 +946,4 @@ int qsortStringCmp(const void *p1, const void *p2);
 /*! Call on exit to free memory */
 void freeData(void);
 
-#endif /* METAMATH_MMDATA_H_ */
+#endif // METAMATH_MMDATA_H_

--- a/src/mmhlpa.h
+++ b/src/mmhlpa.h
@@ -16,4 +16,4 @@ void help0(vstring helpCmd);
 /*! \note help1 should contain Metamath help */
 void help1(vstring helpCmd);
 
-#endif /* METAMATH_MMHLPA_H_ */
+#endif // METAMATH_MMHLPA_H_

--- a/src/mmhlpb.h
+++ b/src/mmhlpb.h
@@ -14,4 +14,4 @@
 void help2(vstring helpCmd);
 void help3(vstring helpCmd);
 
-#endif /* METAMATH_MMHLPB_H_ */
+#endif // METAMATH_MMHLPB_H_

--- a/src/mminou.h
+++ b/src/mminou.h
@@ -750,4 +750,4 @@ double getRunTime(double *timeSinceLastCall);
 /*! Call before exiting to free memory allocated by this module */
 void freeInOu(void);
 
-#endif /* METAMATH_MMINOU_H_*/
+#endif // METAMATH_MMINOU_H_

--- a/src/mmpars.h
+++ b/src/mmpars.h
@@ -204,4 +204,4 @@ vstring readInclude(const char *fileBuf, long fileBufOffset,
     /*vstring inclFileName,*/ const char *sourceFileName,
     long *size, long parentLineNum, flag *errorFlag);
 
-#endif /* METAMATH_MMPARS_H_ */
+#endif // METAMATH_MMPARS_H_

--- a/src/mmpfas.h
+++ b/src/mmpfas.h
@@ -212,4 +212,4 @@ long processUndoStack(struct pip_struct *proofStruct,
     vstring info, /*!< Info to print upon UNDO or REDO */
     long newStackSize /*!< Used only by NEW_SIZE */);
 
-#endif /* METAMATH_MMPFAS_H_ */
+#endif // METAMATH_MMPFAS_H_

--- a/src/mmunif.h
+++ b/src/mmunif.h
@@ -96,4 +96,4 @@ void purgeStateVector(pntrString **stateVector);
 /*! Prints the substitutions determined by unify for debugging purposes */
 void printSubst(pntrString *stateVector);
 
-#endif /* METAMATH_MMUNIF_H_ */
+#endif // METAMATH_MMUNIF_H_

--- a/src/mmveri.h
+++ b/src/mmveri.h
@@ -45,4 +45,4 @@ struct getStep_struct {
 };
 extern struct getStep_struct getStep;
 
-#endif /* METAMATH_MMVERI_H_ */
+#endif // METAMATH_MMVERI_H_

--- a/src/mmvstr.h
+++ b/src/mmvstr.h
@@ -207,7 +207,7 @@ typedef vstring temp_vstring;
  * \def vstring_def
  * \brief creates a new \ref vstring variable.
  *
- * declares a \ref vstring variable and initiates it with empty text ("").
+ * Declares a \ref vstring variable and initiates it with empty text ("").
  * If it remains unmodified, freeing of __x__ is possible, but not required.
  *
  * \param[in] x plain C variable name without quote characters.
@@ -634,4 +634,4 @@ extern long g_startTempAllocStack; /* Where to start freeing temporary allocatio
   assigned again with let(). */
 temp_vstring makeTempAlloc(vstring s);
 
-#endif /* METAMATH_MMVSTR_H_ */
+#endif // METAMATH_MMVSTR_H_

--- a/src/mmword.h
+++ b/src/mmword.h
@@ -25,4 +25,4 @@ long highestRevision(vstring fileName);
    Tags are assumed to be of format nn or #nn in comment at end of line */
 long getRevision(vstring line);
 
-#endif /* METAMATH_MMWORD_H_ */
+#endif // METAMATH_MMWORD_H_

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -1234,7 +1234,7 @@ void printTexHeader(flag texHeaderFlag)
   long i, j, k;
   vstring_def(tmpStr);
 
-  /* "Mathbox for <username>" mod */
+  // "Mathbox for <username>" mod
   vstring_def(localSandboxTitle);
   vstring_def(hugeHdr);
   vstring_def(bigHdr);
@@ -1250,19 +1250,20 @@ void printTexHeader(flag texHeaderFlag)
        "?There was an error in the $t comment's LaTeX/HTML definitions.\n");
     return;
   }
-  /*}*/
 
-  g_outputToString = 1;  /* Redirect print2 and printLongLine to g_printString */
+  g_outputToString = 1;  // redirect print2 and printLongLine to g_printString
   if (!g_htmlFlag) {
     print2("%s This LaTeX file was created by Metamath on %s %s.\n",
        "%", date(), time_());
-
     if (texHeaderFlag && !g_oldTexFlag) {
+      // LaTeX 2e
       print2("\\documentclass{article}\n");
-      print2("\\usepackage{graphicx} %% For rotated iota\n");// to be removed after latexdef of "iota" is changed to \riota (see next line)
+      print2("\\usepackage{graphicx} %% for rotated iota\n"); // to be removed after latexdef of "iota" is changed to \riota (see next line)
       print2("\\usepackage{phonetic} %% for \\riota\n");
       // see https://www.ctan.org/pkg/phonetic
       // see https://www.ctan.org/pkg/comprehensive "Reflecting and rotating existing symbols"
+      print2("\\usepackage{mathrsfs} %% for \\mathscr\n");
+      // see https://www.ctan.org/pkg/mathrsfs
       print2("\\usepackage{amssymb}\n");
       print2("\\usepackage{mathtools} %% loads package amsmath\n");
       // see https://www.ctan.org/pkg/mathtools
@@ -1281,15 +1282,19 @@ void printTexHeader(flag texHeaderFlag)
       print2("\\begin{document}\n");
       print2("\n");
     }
-
     if (texHeaderFlag && g_oldTexFlag) {
       // LaTeX 2e
       print2("\\documentclass[leqno]{article}\n");
-      print2("\\usepackage{graphicx} %% For rotated iota\n");// to be removed after latexdef of "iota" is changed to \riota (see next line)
+      print2("\\usepackage{graphicx} %% for rotated iota\n"); // to be removed after latexdef of "iota" is changed to \riota (see next line)
       print2("\\usepackage{phonetic} %% for \\riota\n");
       // see https://www.ctan.org/pkg/phonetic
       // see https://www.ctan.org/pkg/comprehensive "Reflecting and rotating existing symbols"
+      print2("\\usepackage{mathrsfs} %% for \\mathscr\n");
+      // see https://www.ctan.org/pkg/mathrsfs
       print2("\\usepackage{amssymb}\n");
+      print2("\\usepackage{mathtools} %% loads package amsmath\n");
+      // see https://www.ctan.org/pkg/mathtools
+      // see https://www.ctan.org/pkg/amsmath
       print2("\\raggedbottom\n");
       print2("\\raggedright\n");
       print2("%%\\title{Your title here}\n");
@@ -1316,7 +1321,7 @@ void printTexHeader(flag texHeaderFlag)
       print2("  \\box\\mlinebox\n");
       print2("}\n");
     }
-  } else { /* g_htmlFlag */
+  } else { // g_htmlFlag
 
     print2("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n");
     print2(     "    \"http://www.w3.org/TR/html4/loose.dtd\">\n");
@@ -1557,7 +1562,7 @@ void printTexHeader(flag texHeaderFlag)
         print2("      Mathboxes</A>&nbsp; &gt;\n");
       }
       print2("      &nbsp;%s\n",
-          /* Strip off ".html" */
+          // Strip off ".html"
           left(g_texFileName, (long)strlen(g_texFileName) - 5));
       print2("      </FONT>\n");
       print2("    </TD>\n");
@@ -1626,14 +1631,14 @@ void printTexHeader(flag texHeaderFlag)
     print2("</TABLE>\n");
 
     print2("<HR NOSHADE SIZE=1>\n");
-  } /* g_htmlFlag */
+  } // g_htmlFlag
   fprintf(g_texFilePtr, "%s", g_printString);
   g_outputToString = 0;
   free_vstring(g_printString);
 
-  /* Deallocate strings */
+  // deallocate strings
   free_vstring(tmpStr);
-} /* printTexHeader */
+} // printTexHeader
 
 /* Prints an embedded comment in TeX or HTML.  The commentPtr must point to the first
    character after the "$(" in the comment.  The printout ends when the first
@@ -3074,14 +3079,14 @@ void printTexLongMath(nmbrString *mathString,
   free_vstring(tmp); /* Deallocate */
   free_vstring(texLine); /* Deallocate */
   free_vstring(tex); /* Deallocate */
-} /* printTexLongMath */
+} // printTexLongMath
 
 void printTexTrailer(flag texTrailerFlag) {
 
   if (texTrailerFlag) {
-    g_outputToString = 1; /* Redirect print2 and printLongLine to g_printString */
+    g_outputToString = 1; // redirect print2 and printLongLine to g_printString
     if (!g_htmlFlag) let(&g_printString, "");
-        /* May have stuff to be printed */
+        // may have stuff to be printed
     if (!g_htmlFlag) {
       print2("\\end{document}\n");
     } else {
@@ -3099,11 +3104,11 @@ void printTexTrailer(flag texTrailerFlag) {
       print2("</FONT></TD></TR></TABLE>\n");
       print2("</BODY></HTML>\n");
     }
-    g_outputToString = 0; /* Restore normal output */
+    g_outputToString = 0; // restore normal output
     fprintf(g_texFilePtr, "%s", g_printString);
     free_vstring(g_printString);
   }
-} /* printTexTrailer */
+} // printTexTrailer
 
 /* WRITE THEOREM_LIST command:  Write out theorem list
    into mmtheorems.html, mmtheorems1.html,... */
@@ -3116,15 +3121,15 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
   vstring_def(str3);
   vstring_def(str4);
   vstring_def(prevNextLinks);
-  long partCntr;        /* Counter for hugeHdr */
-  long sectionCntr;     /* Counter for bigHdr */
-  long subsectionCntr;  /* Counter for smallHdr */
-  long subsubsectionCntr;  /* Counter for tinyHdr */
+  long partCntr;        // Counter for hugeHdr
+  long sectionCntr;     // Counter for bigHdr
+  long subsectionCntr;  // Counter for smallHdr
+  long subsubsectionCntr;  // Counter for tinyHdr
   vstring_def(outputFileName);
   FILE *outputFilePtr;
-  long passNumber; /* for summary/detailed table of contents */
+  long passNumber; // for summary/detailed table of contents
 
-  /* for table of contents */
+  // for table of contents
   vstring_def(hugeHdr);
   vstring_def(bigHdr);
   vstring_def(smallHdr);
@@ -3146,20 +3151,20 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
   vstring_def(hdrCommentAnchor);
   flag hdrCommentAnchorDone = 0;
 
-  /* Populate the statement map */
-  /* ? ? ? Future:  is assertions same as g_Statement[g_statements].pinkNumber? */
+  // Populate the statement map
+  // ? ? ? Future:  is assertions same as g_Statement[g_statements].pinkNumber?
   nmbrLet(&nmbrStmtNmbr, nmbrSpace(g_statements + 1));
-  assertions = 0; /* Number of $p's + $a's */
+  assertions = 0; // Number of $p's + $a's
   for (s = 1; s <= g_statements; s++) {
     if (g_Statement[s].type == a_ || g_Statement[s].type == p_) {
-      assertions++; /* Corresponds to pink number */
+      assertions++; // Corresponds to pink number
       nmbrStmtNmbr[assertions] = s;
     }
   }
   if (assertions != g_Statement[g_statements].pinkNumber) bug(2328);
 
-  /* Table of contents */
-  /* Allocate array for section headers found */
+  // Table of contents
+  // Allocate array for section headers found
   pntrLet(&pntrHugeHdr, pntrSpace(g_statements + 1));
   pntrLet(&pntrBigHdr, pntrSpace(g_statements + 1));
   pntrLet(&pntrSmallHdr, pntrSpace(g_statements + 1));
@@ -3171,15 +3176,15 @@ void writeTheoremList(long theoremsPerPage, flag showLemmas, flag noVersioning)
 
   pages = ((assertions - 1) / theoremsPerPage) + 1;
   for (page = 0; page <= pages; page++) {
-    /* Open file */
+    // Open file
     let(&outputFileName,
         cat("mmtheorems", (page > 0) ? str((double)page) : "", ".html", NULL));
     print2("Creating %s\n", outputFileName);
     outputFilePtr = fSafeOpen(outputFileName, "w", noVersioning);
-    if (!outputFilePtr) goto TL_ABORT; /* Couldn't open it (error msg was provided)*/
+    if (!outputFilePtr) goto TL_ABORT; // Could not open it (error msg was provided)
 
-    /* Output header */
-    /* TODO 14-Jan-2016: why aren't we using printTexHeader? */
+    // Output header
+    // TODO 14-Jan-2016: why aren't we using printTexHeader?
 
     g_outputToString = 1;
     print2("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n");

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -924,15 +924,15 @@ vstring asciiToTt(vstring s) {
   vstring_def(tmp);
   long i, j, k;
 
-  let(&ttstr, s); /* In case the input s is temporarily allocated */
+  let(&ttstr, s); // In case the input s is temporarily allocated
   j = (long)strlen(ttstr);
 
-  /* Put special \tt font characters in a form that TeX can understand */
+  // Put special \tt font characters in a form that TeX can understand
   for (i = 0; i < j; i++) {
     k = 1;
     if (!g_htmlFlag) {
       switch (ttstr[i]) {
-        /* For all unspecified cases, TeX will accept the character 'as is' */
+        // For all unspecified cases, TeX will accept the character 'as is'
         case ' ':
         case '$':
         case '%':
@@ -959,23 +959,23 @@ vstring asciiToTt(vstring s) {
           let(&ttstr,cat(left(ttstr,i),"\\char`\\",right(ttstr,i+1),NULL));
           k = 8;
           break;
-      } /* End switch mtoken[i] */
+      } // end switch mtoken[i]
     } else {
       switch (ttstr[i]) {
-        /* For all unspecified cases, HTML will accept the character 'as is' */
+        // For all unspecified cases, HTML will accept the character 'as is'
         /* Don't convert to &amp; but leave as is.  This
            will allow the user to insert HTML entities for Unicode etc.
            directly in the database source. */
-        /* case '&': ... */
+        // case '&': ...
         case '<':
-          /* Leave in HTML tags (case must match) */
+          // Leave in HTML tags (case must match)
           if (!strcmp(mid(ttstr, i + 1, 6), "<HTML>")) {
-            let(&ttstr, ttstr); /* Purge stack to prevent overflow by 'mid' */
+            let(&ttstr, ttstr); // purge stack to prevent overflow by 'mid'
             i = i + 6;
             break;
           }
           if (!strcmp(mid(ttstr, i + 1, 7), "</HTML>")) {
-            let(&ttstr, ttstr); /* Purge stack to prevent overflow by 'mid' */
+            let(&ttstr, ttstr); // purge stack to prevent overflow by 'mid'
             i = i + 7;
             break;
           }
@@ -990,18 +990,18 @@ vstring asciiToTt(vstring s) {
           let(&ttstr,cat(left(ttstr,i),"&quot;",right(ttstr,i+2),NULL));
           k = 6;
           break;
-      } /* End switch mtoken[i] */
+      } // end switch mtoken[i]
     }
 
-    if (k > 1) { /* Adjust iteration and length */
+    if (k > 1) { // adjust iteration and length
       i = i + k - 1;
       j = j + k - 1;
     }
-  } /* Next i */
+  } // next i
 
-  free_vstring(tmp);  /* Deallocate */
+  free_vstring(tmp);  // deallocate
   return ttstr;
-} /* asciiToTt */
+} // asciiToTt
 
 temp_vstring asciiToTt_temp(vstring s) {
   return makeTempAlloc(asciiToTt(s));
@@ -1015,19 +1015,19 @@ vstring tokenToTex(vstring mtoken, long statemNum /*for error msgs*/)
   vstring_def(tex);
   vstring tmpStr;
   long i, j, k;
-  void *texDefsPtr; /* For binary search */
+  void *texDefsPtr; // for binary search
   flag saveOutputToString;
 
   if (!g_texDefsRead) {
-    bug(2320); /* This shouldn't be called if definitions weren't read */
+    bug(2320); // this should not be called if definitions were not read
   }
 
   texDefsPtr = (void *)bsearch(mtoken, g_TexDefs, (size_t)numSymbs,
       sizeof(struct texDef_struct), texSrchCmp);
-  if (texDefsPtr) { /* Found it */
+  if (texDefsPtr) { // found
     let(&tex, ((struct texDef_struct *)texDefsPtr)->texEquiv);
   } else {
-    /* If it wasn't found, give user a warning... */
+    // if it was not found, give user a warning
     saveOutputToString = g_outputToString;
     g_outputToString = 0;
     /* It is possible for statemNum to be 0 when
@@ -1035,33 +1035,33 @@ vstring tokenToTex(vstring mtoken, long statemNum /*for error msgs*/)
        printTexLongMath(), when its hypStmt argument is 0 (= not associated
        with a statement).  (Reported by Wolf Lammen.) */
     if (statemNum < 0 || statemNum > g_statements) bug(2331);
-    if (statemNum > 0) {   /* Include statement label in error message */
+    if (statemNum > 0) {   // Include statement label in error message
       printLongLine(cat("?Warning: In the comment for statement \"",
           g_Statement[statemNum].labelName,
           "\", math symbol token \"", mtoken,
           "\" does not have a LaTeX and/or an HTML definition.", NULL),
           "", " ");
-    } else { /* There is no statement associated with the error message */
+    } else { // There is no statement associated with the error message
       printLongLine(cat("?Warning: Math symbol token \"", mtoken,
           "\" does not have a LaTeX and/or an HTML definition.", NULL),
           "", " ");
     }
     g_outputToString = saveOutputToString;
-    /* ... but we'll still leave in the old default conversion anyway: */
+    // ... but we will still leave in the old default conversion anyway:
 
-    /* If it wasn't found, use built-in conversion rules */
+    // if it was not found, use built-in conversion rules
     let(&tex, mtoken);
 
-    /* First, see if it's a tilde followed by a letter */
-    /* If so, remove the tilde.  (This is actually obsolete.) */
-    /* (The tilde was an escape in the obsolete syntax.) */
+    // First, see if it is a tilde followed by a letter.
+    // If so, remove the tilde.  (This is actually obsolete.)
+    // (The tilde was an escape in the obsolete syntax.)
     if (tex[0] == '~') {
       if (isalpha((unsigned char)(tex[1]))) {
-        let(&tex, right(tex, 2)); /* Remove tilde */
+        let(&tex, right(tex, 2)); // remove tilde
       }
     }
 
-    /* Next, convert punctuation characters to tt font */
+    // Next, convert punctuation characters to tt font
     j = (long)strlen(tex);
     for (i = 0; i < j; i++) {
       if (ispunct((unsigned char)(tex[i]))) {
@@ -1071,25 +1071,24 @@ vstring tokenToTex(vstring mtoken, long statemNum /*for error msgs*/)
         k = (long)strlen(tmpStr);
         let(&tex,
             cat(left(tex, i), tmpStr, right(tex, i + 2), NULL));
-        i = i + k - 1; /* Adjust iteration */
-        j = j + k - 1; /* Adjust length */
-        free_vstring(tmpStr); /* Deallocate */
+        i = i + k - 1; // adjust iteration
+        j = j + k - 1; // adjust length
+        free_vstring(tmpStr); // deallocate
       }
-    } /* Next i */
+    } // next i
 
-    /* Make all letters Roman; put inside mbox */
+    // make all letters Roman in math mode
     if (!g_htmlFlag)
-      let(&tex, cat("\\mbox{\\rm ", tex, "}", NULL));
-  } /* End if */
+      let(&tex, cat("\\mathrm{", tex, "}", NULL));
+  } // end if
 
   return tex;
-} /* tokenToTex */
+} // tokenToTex
 
 /* Converts a comment section in math mode to TeX.  Each math token
-   MUST be separated by white space.   TeX "$" does not surround the output. */
+   MUST be separated by white space.  TeX "$" does not surround the output. */
 vstring asciiMathToTex(vstring mathComment, long statemNum)
 {
-
   vstring tex;
   vstring_def(texLine);
   vstring_def(lastTex);
@@ -1122,17 +1121,17 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
         converted to char.  Thanks to Wolf Lammen for pointing this out. */
       alphnew = !!isalpha((unsigned char)(tex[0]));
       unknownnew = 0;
-      if (!strcmp(left(tex, 10), "\\mbox{\\rm ")) { /* Token not in table */
+      if (!strcmp(left(tex, 8), "\\mathrm{")) { // token not in table
         unknownnew = 1;
       }
       alphold = !!isalpha((unsigned char)(lastTex[0]));
       unknownold = 0;
-      if (!strcmp(left(lastTex, 10), "\\mbox{\\rm ")) { /* Token not in table*/
+      if (!strcmp(left(lastTex, 8), "\\mathrm{")) { // token not in table
         unknownold = 1;
       }
-      /* Put thin space only between letters and/or unknowns */
+      // put thin space only between letters and/or unknowns
       if ((alphold || unknownold) && (alphnew || unknownnew)) {
-        /* Put additional thin space between two letters */
+        // put additional thin space between two letters
         let(&texLine, cat(texLine, "\\,", tex, " ", NULL));
       } else {
         let(&texLine, cat(texLine, tex, " ", NULL));
@@ -1140,15 +1139,15 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
     } else {
       let(&texLine, cat(texLine, tex, NULL));
     }
-    free_vstring(lastTex); /* Deallocate */
-    lastTex = tex; /* Pass deallocation responsibility for tex to lastTex */
-  } /* End while (1) */
+    free_vstring(lastTex); // deallocate
+    lastTex = tex; // pass deallocation responsibility for tex to lastTex
+  } // end while(1)
 
-  free_vstring(lastTex); /* Deallocate */
-  free_vstring(token); /* Deallocate */
+  free_vstring(lastTex); // deallocate
+  free_vstring(token); // deallocate
 
   return texLine;
-} /* asciiMathToTex */
+} // asciiMathToTex
 
 /* Gets the next section of a comment that is in the current mode (text,
    label, or math).  If 1st char. is not "$" (DOLLAR_SUBST), text mode is
@@ -1157,16 +1156,16 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
 vstring getCommentModeSection(vstring *srcptr, char *mode)
 {
   vstring_def(modeSection);
-  vstring ptr; /* Not allocated */
+  vstring ptr; // not allocated
   flag addMode = 0;
   if (!g_outputToString) bug(2319);
 
   if ((*srcptr)[0] != DOLLAR_SUBST /*'$'*/) {
-    if ((*srcptr)[0] == 0) { /* End of string */
-      *mode = 0; /* End of comment */
+    if ((*srcptr)[0] == 0) { // end of string
+      *mode = 0; // end of comment
       return "";
     } else {
-      *mode = 'n'; /* Normal text */
+      *mode = 'n'; // normal text
       addMode = 1;
     }
   } else {
@@ -1176,10 +1175,10 @@ vstring getCommentModeSection(vstring *srcptr, char *mode)
       case 'n':
         *mode = (*srcptr)[1];
         break;
-      case ')':  /* Obsolete */
+      case ')':  // obsolete
         bug(2317);
-        /* Leave old code in case user continues through the bug */
-        *mode = 0; /* End of comment */
+        // Leave old code in case user continues through the bug
+        *mode = 0; // end of comment
         return "";
         break;
       default:
@@ -1195,7 +1194,7 @@ vstring getCommentModeSection(vstring *srcptr, char *mode)
         case 'l':
         case 'm':
         case 'n':
-        case ')':  /* Obsolete (will never happen) */
+        case ')':  // obsolete (will never happen)
           if (ptr[1] == ')') bug(2318);
           let(&modeSection, space(ptr - (*srcptr)));
           memcpy(modeSection, *srcptr, (size_t)(ptr - (*srcptr)));
@@ -1220,9 +1219,9 @@ vstring getCommentModeSection(vstring *srcptr, char *mode)
       }
     }
     ptr++;
-  } /* End while */
-  return NULL; /* Dummy return - never executes */
-} /* getCommentModeSection */
+  } // end while
+  return NULL; // dummy return - never executes
+} // getCommentModeSection
 
 /* The texHeaderFlag means this:
     If !g_htmlFlag (i.e. TeX mode), then 1 means print header
@@ -1260,10 +1259,16 @@ void printTexHeader(flag texHeaderFlag)
 
     if (texHeaderFlag && !g_oldTexFlag) {
       print2("\\documentclass{article}\n");
-      print2("\\usepackage{graphicx} %% For rotated iota\n");
+      print2("\\usepackage{graphicx} %% For rotated iota\n");// to be removed after latexdef of "iota" is changed to \riota (see next line)
+      print2("\\usepackage{phonetic} %% for \\riota\n");
+      // see https://www.ctan.org/pkg/phonetic
+      // see https://www.ctan.org/pkg/comprehensive "Reflecting and rotating existing symbols"
       print2("\\usepackage{amssymb}\n");
-      print2("\\usepackage{amsmath} %% For \\begin{align}...\n");
-      print2("\\usepackage{amsthm}\n");
+      print2("\\usepackage{mathtools} %% loads package amsmath\n");
+      // see https://www.ctan.org/pkg/mathtools
+      // see https://www.ctan.org/pkg/amsmath
+      print2("\\usepackage{amsthm} %% amsthm must be loaded after amsmath\n");
+      // see https://www.ctan.org/pkg/amsthm
       print2("\\theoremstyle{plain}\n");
       print2("\\newtheorem{theorem}{Theorem}[section]\n");
       print2("\\newtheorem{definition}[theorem]{Definition}\n");
@@ -1271,16 +1276,19 @@ void printTexHeader(flag texHeaderFlag)
       print2("\\newtheorem{axiom}{Axiom}\n");
       print2("\\allowdisplaybreaks[1] %% Allow page breaks in {align}\n");
       print2("\\usepackage[plainpages=false,pdfpagelabels]{hyperref}\n");
+      // see https://www.ctan.org/pkg/hyperref
       print2("\\hypersetup{colorlinks} %% Get rid of boxes around links\n");
       print2("\\begin{document}\n");
       print2("\n");
     }
 
     if (texHeaderFlag && g_oldTexFlag) {
-      /* LaTeX 2e */
+      // LaTeX 2e
       print2("\\documentclass[leqno]{article}\n");
-      /* LaTeX 2e */
-      print2("\\usepackage{graphicx}\n"); /* For rotated iota */
+      print2("\\usepackage{graphicx} %% For rotated iota\n");// to be removed after latexdef of "iota" is changed to \riota (see next line)
+      print2("\\usepackage{phonetic} %% for \\riota\n");
+      // see https://www.ctan.org/pkg/phonetic
+      // see https://www.ctan.org/pkg/comprehensive "Reflecting and rotating existing symbols"
       print2("\\usepackage{amssymb}\n");
       print2("\\raggedbottom\n");
       print2("\\raggedright\n");
@@ -4797,12 +4805,12 @@ vstring getTexLongMath(nmbrString *mathString, long statemNum)
       /* Also, anything not in table will have space added */
       alphnew = !!isalpha((unsigned char)(tex[0]));
       unknownnew = 0;
-      if (!strcmp(left(tex, 10), "\\mbox{\\rm ")) { /* Token not in table */
+      if (!strcmp(left(tex, 8), "\\mathrm{")) { // token not in table
         unknownnew = 1;
       }
       alphold = !!isalpha((unsigned char)(lastTex[0]));
       unknownold = 0;
-      if (!strcmp(left(lastTex, 10), "\\mbox{\\rm ")) { /* Token not in table*/
+      if (!strcmp(left(lastTex, 8), "\\mathrm{")) { // token not in table
         unknownold = 1;
       }
       /* Put thin space only between letters and/or unknowns */
@@ -5562,14 +5570,14 @@ long getMathboxLoc(nmbrString **mathboxStart, nmbrString **mathboxEnd,
   long mathboxes = 0;
   vstring_def(comment);
   vstring_def(user);
-  assignMathboxInfo(); /* Assign g_mathboxStmt */
+  assignMathboxInfo(); // assign g_mathboxStmt
   tagLen = (long)strlen(MB_TAG);
-  /* Ensure lists are initialized */
+  // ensure lists are initialized
   if (pntrLen((pntrString *)(*mathboxUser)) != 0) bug(2347);
   if (nmbrLen((nmbrString *)(*mathboxStart)) != 0) bug(2348);
   if (nmbrLen((nmbrString *)(*mathboxEnd)) != 0) bug(2349);
   for (stmt = g_mathboxStmt + 1; stmt <= g_statements; stmt++) {
-    /* Heuristic to match beginning of mathbox */
+    // heuristic to match beginning of mathbox
     let(&comment, left(g_Statement[stmt].labelSectionPtr,
         g_Statement[stmt].labelSectionLen));
     p = 0;
@@ -5578,27 +5586,27 @@ long getMathboxLoc(nmbrString **mathboxStart, nmbrString **mathboxEnd,
     while (1) {
       q = instr(p + 1, comment, MB_TAG);
       if (q == 0) break;
-      p = q; /* Save last "Mathbox for " */
+      p = q; // save last "Mathbox for "
     }
-    if (p == 0) continue; /* No "Mathbox for " in this statement's comment */
+    if (p == 0) continue; // no "Mathbox for " in this statement's comment
 
-    /* Found a mathbox; assign user and start statement */
+    // Found a mathbox; assign user and start statement
     mathboxes++;
     q = instr(p, comment, "\n");
-    if (q == 0) bug(2350); /* No end of line */
+    if (q == 0) bug(2350); // no end of line
     let(&user, seg(comment, p + tagLen, q - 1));
     pntrLet(&(*mathboxUser), pntrAddElement(*mathboxUser));
     (*mathboxUser)[mathboxes - 1] = "";
     let((vstring *)(&((*mathboxUser)[mathboxes - 1])), user);
     nmbrLet(&(*mathboxStart), nmbrAddElement(*mathboxStart, stmt));
-  } /* next stmt */
+  } // next stmt
   if (mathboxes == 0) goto RETURN_POINT;
-  /* Assign end statements */
-  nmbrLet(&(*mathboxEnd), nmbrSpace(mathboxes)); /* Pre-allocate */
+  // assign end statements
+  nmbrLet(&(*mathboxEnd), nmbrSpace(mathboxes)); // preallocate
   for (m = 0; m < mathboxes - 1; m++) {
     (*mathboxEnd)[m] = (*mathboxStart)[m + 1] - 1;
   }
-  (*mathboxEnd)[mathboxes - 1] = g_statements; /* Assumed end of last mathbox */
+  (*mathboxEnd)[mathboxes - 1] = g_statements; // assumed end of last mathbox
  RETURN_POINT:
   free_vstring(comment);
   free_vstring(user);

--- a/src/mmwtex.h
+++ b/src/mmwtex.h
@@ -215,4 +215,4 @@ void assignMathboxInfo(void);
 long getMathboxLoc(nmbrString **mathboxStart, nmbrString **mathboxEnd,
     pntrString **mathboxUser);
 
-#endif /* METAMATH_MMWTEX_H_ */
+#endif // METAMATH_MMWTEX_H_


### PR DESCRIPTION
* tex generation: avoid '\rm', load mathtools and phonetic
* comment formating

There remain some `\tt` that should be replaced by either `texttt{` or `\mathtt{` depending on whether we are in text or math mode (was not obvious at first in the C code).

Also, I added the `phonetic` package, so that we can replace the latexdef's using \rotate with \riota, and then one can remove the `graphicx` package.