### PR TITLE
Updated TeX packages

### DIFF
--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -1261,7 +1261,6 @@ void printTexHeader(flag texHeaderFlag)
     if (texHeaderFlag && !g_oldTexFlag) {
       /* LaTeX 2e */
       print2("\\documentclass{article}\n");
-      print2("\\usepackage{graphicx} %% for rotated iota\n"); // to be removed after latexdef of "iota" is changed to \riota (see next line)
       print2("\\usepackage{phonetic} %% for \\riota\n");
       // see https://www.ctan.org/pkg/phonetic
       // see https://www.ctan.org/pkg/comprehensive "Reflecting and rotating existing symbols"
@@ -1291,7 +1290,6 @@ void printTexHeader(flag texHeaderFlag)
     if (texHeaderFlag && g_oldTexFlag) {
       /* LaTeX 2e */
       print2("\\documentclass[leqno]{article}\n");
-      print2("\\usepackage{graphicx} %% for rotated iota\n"); // to be removed after latexdef of "iota" is changed to \riota (see next line)
       print2("\\usepackage{phonetic} %% for \\riota\n");
       // see https://www.ctan.org/pkg/phonetic
       // see https://www.ctan.org/pkg/comprehensive "Reflecting and rotating existing symbols"

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -1273,6 +1273,8 @@ void printTexHeader(flag texHeaderFlag)
       // see https://www.ctan.org/pkg/amsmath
       print2("\\usepackage{amsthm} %% amsthm must be loaded after amsmath\n");
       // see https://www.ctan.org/pkg/amsthm
+      print2("\\usepackage{accents} %% accents should be loaded after mathtools\n");
+      // see https://www.ctan.org/pkg/accents
       print2("\\theoremstyle{plain}\n");
       print2("\\newtheorem{theorem}{Theorem}[section]\n");
       print2("\\newtheorem{definition}[theorem]{Definition}\n");
@@ -1299,6 +1301,8 @@ void printTexHeader(flag texHeaderFlag)
       print2("\\usepackage{mathtools} %% loads package amsmath\n");
       // see https://www.ctan.org/pkg/mathtools
       // see https://www.ctan.org/pkg/amsmath
+      print2("\\usepackage{accents} %% accents should be loaded after mathtools\n");
+      // see https://www.ctan.org/pkg/accents
       print2("\\raggedbottom\n");
       print2("\\raggedright\n");
       print2("%%\\title{Your title here}\n");

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -1261,12 +1261,12 @@ void printTexHeader(flag texHeaderFlag)
     if (texHeaderFlag && !g_oldTexFlag) {
       /* LaTeX 2e */
       print2("\\documentclass{article}\n");
+      print2("\\usepackage{amssymb} %% amssymb must be loaded after phonetic\n");
       print2("\\usepackage{phonetic} %% for \\riota\n");
       // see https://www.ctan.org/pkg/phonetic
       // see https://www.ctan.org/pkg/comprehensive "Reflecting and rotating existing symbols"
       print2("\\usepackage{mathrsfs} %% for \\mathscr\n");
       // see https://www.ctan.org/pkg/mathrsfs
-      print2("\\usepackage{amssymb}\n");
       print2("\\usepackage{mathtools} %% loads package amsmath\n");
       // see https://www.ctan.org/pkg/mathtools
       // see https://www.ctan.org/pkg/amsmath
@@ -1290,12 +1290,12 @@ void printTexHeader(flag texHeaderFlag)
     if (texHeaderFlag && g_oldTexFlag) {
       /* LaTeX 2e */
       print2("\\documentclass[leqno]{article}\n");
+      print2("\\usepackage{amssymb} %% amssymb must be loaded after phonetic\n");
       print2("\\usepackage{phonetic} %% for \\riota\n");
       // see https://www.ctan.org/pkg/phonetic
       // see https://www.ctan.org/pkg/comprehensive "Reflecting and rotating existing symbols"
       print2("\\usepackage{mathrsfs} %% for \\mathscr\n");
       // see https://www.ctan.org/pkg/mathrsfs
-      print2("\\usepackage{amssymb}\n");
       print2("\\usepackage{mathtools} %% loads package amsmath\n");
       // see https://www.ctan.org/pkg/mathtools
       // see https://www.ctan.org/pkg/amsmath

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -1261,7 +1261,7 @@ void printTexHeader(flag texHeaderFlag)
     if (texHeaderFlag && !g_oldTexFlag) {
       /* LaTeX 2e */
       print2("\\documentclass{article}\n");
-      print2("\\usepackage{amssymb} %% amssymb must be loaded after phonetic\n");
+      print2("\\usepackage{amssymb} %% amssymb must be loaded before phonetic\n");
       print2("\\usepackage{phonetic} %% for \\riota\n");
       // see https://www.ctan.org/pkg/phonetic
       // see https://www.ctan.org/pkg/comprehensive "Reflecting and rotating existing symbols"
@@ -1290,7 +1290,7 @@ void printTexHeader(flag texHeaderFlag)
     if (texHeaderFlag && g_oldTexFlag) {
       /* LaTeX 2e */
       print2("\\documentclass[leqno]{article}\n");
-      print2("\\usepackage{amssymb} %% amssymb must be loaded after phonetic\n");
+      print2("\\usepackage{amssymb} %% amssymb must be loaded before phonetic\n");
       print2("\\usepackage{phonetic} %% for \\riota\n");
       // see https://www.ctan.org/pkg/phonetic
       // see https://www.ctan.org/pkg/comprehensive "Reflecting and rotating existing symbols"


### PR DESCRIPTION
This pull request does 3 things:

1. Fix checks 1, 9, 13 of  https://github.com/metamath/set.mm/issues/3091 by adding the `accents` package. There was a discussion about long term treatment of these packages, so this is to be considered a temporary solution to not obstruct the flow of https://github.com/metamath/set.mm/pull/3100 according to https://github.com/metamath/set.mm/issues/3091#issuecomment-1474327524 https://github.com/metamath/set.mm/pull/3099#issuecomment-1474323774
 
2. Fix issue related to relative position between the `amssymb` and `phonetic` packages https://github.com/metamath/set.mm/pull/3090#issuecomment-1465046048
 
3. Delete `graphicx` package since TeX substitutions with `\rotate` are now replaced with `\riota` in https://github.com/metamath/set.mm/pull/3099