### PR TITLE
Line comments instead of block comments

### DIFF
--- a/src/mmword.c
+++ b/src/mmword.c
@@ -105,14 +105,13 @@ void revise(FILE *f1_fp, FILE *f2_fp, FILE *f3_fp, vstring addTag, long m)
   let(&l2_,ctlz_);
   eof1=eof2=0; // End-of-file flags
   d=0;
-
-l7100:  // Lines 7100 through 7300 are a modified version of the compare loop
-        // in DEC's FILCOM.BAS program.
-
+// Lines 7100 through 7300 are a modified version of the compare loop in DEC's
+// FILCOM.BAS program.
+l7100:  
         if (!strcmpe(l1_,l2_)) { // The lines are the same
                 if (strcmpe(l2_,ctlz_)) {
-                  fprintf(f3_fp_, "%s\n", l2_); // Use edited version
-                                                // of line when they are the same.
+                  // Use edited version of line when they are the same.
+                  fprintf(f3_fp_, "%s\n", l2_);
                 }
                 gosub_7320();
                 gosub_7330();
@@ -145,8 +144,8 @@ l7100:  // Lines 7100 through 7300 are a modified version of the compare loop
                         return;
                 }
         }
-        d=d+1; // Number of difference sections found so far
-               // (For user information only)
+        // Number of difference sections found so far (For user information only)
+        d=d+1; 
         i1_=i2_=m-1;
         let(&line1_[0],l1_);
         let(&line2_[0],l2_);
@@ -285,9 +284,9 @@ l7240:
                  addTag_, 0);
              fprintf(f3_fp_, "%s\n", tmpLine);
            }
+           // Output original deleted lines // freeTempAlloc();
+           // Clear vstring stack
            fprintf(f3_fp_, "%s\n", line1_[i]);
-                                     // Output original deleted lines
-           // freeTempAlloc(); // Clear vstring stack
          }
        }
        if (printedAtLeastOne) {
@@ -306,9 +305,9 @@ l7240:
                // Put tags on blank lines *inside* of new section
                tmpLine = stripAndTag(line2_[i], addTag_, 1);
              }
+             // Output tagged edited lines // freeTempAlloc();
+             // Clear vstring stack
              fprintf(f3_fp_, "%s\n", tmpLine);
-                                     // Output tagged edited lines
-             // freeTempAlloc(); // Clear vstring stack
            }
          }
        }
@@ -321,9 +320,9 @@ l7240:
              // Put tags on blank lines *inside* of new section
              tmpLine = stripAndTag(line2_[i], addTag_, 1);
            }
-           fprintf(f3_fp_, "%s\n", tmpLine);
-                                     // Print remaining edited lines
-           // freeTempAlloc(); // Clear vstring stack
+           // Print remaining edited lines // freeTempAlloc();
+           // Clear vstring stack
+           fprintf(f3_fp_, "%s\n", tmpLine);                  
          }
        }
        for (i=0; i<=m-1; i++) {
@@ -347,7 +346,7 @@ void gosub_7320(void) {
     for (i9=0; i9<=r1-1; i9++) {
       let(&reserve1_[i9],reserve1_[i9+1]);
     }
-  } else {              // Get next line from input file
+  } else { // Get next line from input file
     if (eof1) {
       let(&l1_,ctlz_);
     } else {
@@ -373,7 +372,7 @@ void gosub_7320(void) {
 }
 
 void gosub_7330(void) {
-        // Subroutine:  get next L2_ from edited file
+  // Subroutine: get next L2_ from edited file
   vstring_def(tmpLin);
   vstring tmpStrPtr; // pointer only
   flag stripDeletedSectionMode;
@@ -383,7 +382,7 @@ void gosub_7330(void) {
     for (i9 = 0; i9 < r2; i9++) {
       let(&reserve2_[i9],reserve2_[i9+1]);
     }
-  } else {              // Get next line from input file
+  } else { // Get next line from input file
     if (eof2) {
       let(&l2_,ctlz_);
     } else {

--- a/src/mmword.c
+++ b/src/mmword.c
@@ -4,22 +4,22 @@
 /*****************************************************************************/
 /*34567890123456 (79-character line to adjust editor window) 2345678901234567*/
 
-/* This file implements the UPDATE command of the TOOLS utility.  revise() is
-   the main external call; see the comments preceding it. */
+// This file implements the UPDATE command of the TOOLS utility.  revise() is
+// the main external call; see the comments preceding it.
 
-/* The UPDATE command of TOOLS (mmword.c) was custom-written in accordance
-   with the version control requirements of a company that used it.  It
-   documents the differences between two versions of a program as C-style
-   comments embedded in the newer version.  The best way to determine whether
-   it suits your similar needs is just to run it and look at its output. */
+// The UPDATE command of TOOLS (mmword.c) was custom-written in accordance
+// with the version control requirements of a company that used it.  It
+// documents the differences between two versions of a program as C-style
+// comments embedded in the newer version.  The best way to determine whether
+// it suits your similar needs is just to run it and look at its output.
 
-/* Very old history: this was called mmword.c because it was intended to
-   produce RTF output for Word, analogous to the existing LaTeX output.
-   Microsoft never responded to a request for the RTF specification, as they
-   promised in the circa 1990 manual accompanying Word.  Thus it remained an
-   empty shell.  When the need for UPDATE arose, the mmword.c shell was used in
-   order to avoid the nuisance of changing some compilation setups and scripts
-   existing at that time. */
+// Very old history: this was called mmword.c because it was intended to
+// produce RTF output for Word, analogous to the existing LaTeX output.
+// Microsoft never responded to a request for the RTF specification, as they
+// promised in the circa 1990 manual accompanying Word.  Thus it remained an
+// empty shell.  When the need for UPDATE arose, the mmword.c shell was used in
+// order to avoid the nuisance of changing some compilation setups and scripts
+// existing at that time.
 
 #include <string.h>
 #include <stdlib.h>
@@ -28,11 +28,11 @@
 #include "mminou.h"
 #include "mmword.h"
 
-/* Set to 79, 80, etc. - length of line after tag is added */
+// Set to 79, 80, etc. - length of line after tag is added
 #define LINE_LENGTH 80
 
-   /* 7000 ! ***** "DIFF" Option ***** from DO LIST */
-/*  gosub_7000(f1_name, f2_name, f3_name, &f3_fp, m); */
+// 7000 ! ***** "DIFF" Option ***** from DO LIST
+// gosub_7000(f1_name, f2_name, f3_name, &f3_fp, m);
 
 char strcmpe(vstring s1, vstring s2);
 vstring stripAndTag(vstring line, vstring tag, flag tagBlankLines);
@@ -51,7 +51,7 @@ vstring_def(addTag_);
 vstring_def(delStartTag_);
 vstring_def(delEndTag_);
 flag printedAtLeastOne;
-     /*  Declare input and save buffers */
+// Declare input and save buffers
 #define MAX_LINES 10000
 #define MAX_BUF 1000
      vstring line1_[MAX_LINES];
@@ -59,18 +59,18 @@ flag printedAtLeastOne;
      vstring reserve1_[MAX_BUF];
      vstring reserve2_[MAX_BUF];
 
-/* These two functions emulate 2 GOSUBs in BASIC, that are part of a
-   translation of a very old BASIC program (by nm) that implemented a
-   difference algorithm (like Unix diff). */
+// These two functions emulate 2 GOSUBs in BASIC, that are part of a
+// translation of a very old BASIC program (by nm) that implemented a
+// difference algorithm (like Unix diff).
 void gosub_7320(void);
 void gosub_7330(void);
 
-/* revise() is called by the UPDATE command of TOOLs.  The idea is to
-   keep all past history of a file in the file itself, in the form of
-   comments.  In mmcmds.c, see the parsing of the UPDATE command for a
-   partial explanation of its arguments.  UPDATE was written for a
-   proprietary language with C-style comments (where nested comments were
-   allowed) and it may not be generally useful without some modification. */
+// revise() is called by the UPDATE command of TOOLs.  The idea is to
+// keep all past history of a file in the file itself, in the form of
+// comments.  In mmcmds.c, see the parsing of the UPDATE command for a
+// partial explanation of its arguments.  UPDATE was written for a
+// proprietary language with C-style comments (where nested comments were
+// allowed) and it may not be generally useful without some modification.
 void revise(FILE *f1_fp, FILE *f2_fp, FILE *f3_fp, vstring addTag, long m)
 {
   /******** Figure out the differences (DO LIST subroutine) ******/
@@ -85,7 +85,7 @@ void revise(FILE *f1_fp, FILE *f2_fp, FILE *f3_fp, vstring addTag, long m)
   let(&delStartTag_, "/******* Start of deleted section *******");
   let(&delEndTag_, "******* End of deleted section *******/");
 
-  /* Initialize vstring arrays */
+  // Initialize vstring arrays
   for (i = 0; i < MAX_LINES; i++) {
     line1_[i] = "";
     line2_[i] = "";
@@ -99,22 +99,20 @@ void revise(FILE *f1_fp, FILE *f2_fp, FILE *f3_fp, vstring addTag, long m)
 
   r0=r1=r2=i0=i1_=i2_=d=t=i=j=i9=0;
 
-  let(&ctlz_,chr(26));  /* End-of-file character */
+  let(&ctlz_,chr(26)); // End-of-file character
 
   let(&l1_,ctlz_);
   let(&l2_,ctlz_);
-  eof1=eof2=0;  /* End-of-file flags */
+  eof1=eof2=0; // End-of-file flags
   d=0;
 
-l7100:  /*
-          Lines 7100 through 7300 are a modified version of the compare loop
-          In DEC's FILCOM.BAS program.
-        */
+l7100:  // Lines 7100 through 7300 are a modified version of the compare loop
+        // in DEC's FILCOM.BAS program.
 
-        if (!strcmpe(l1_,l2_)) { /* The lines are the same */
+        if (!strcmpe(l1_,l2_)) { // The lines are the same
                 if (strcmpe(l2_,ctlz_)) {
-                  fprintf(f3_fp_, "%s\n", l2_); /* Use edited version
-                                of line when they are the same */
+                  fprintf(f3_fp_, "%s\n", l2_); // Use edited version
+                                                // of line when they are the same.
                 }
                 gosub_7320();
                 gosub_7330();
@@ -125,7 +123,7 @@ l7100:  /*
                         fclose(f2_fp_);
                         fclose(f3_fp_);
 
-                      /* Deallocate string memory */
+                      // Deallocate string memory
                       for (i = 0; i < MAX_LINES; i++) {
                         free_vstring(line1_[i]);
                         free_vstring(line2_[i]);
@@ -147,8 +145,8 @@ l7100:  /*
                         return;
                 }
         }
-        d=d+1;  /* Number of difference sections found so far
-                         (For user information only) */
+        d=d+1; // Number of difference sections found so far
+               // (For user information only)
         i1_=i2_=m-1;
         let(&line1_[0],l1_);
         let(&line2_[0],l2_);
@@ -176,8 +174,8 @@ l7140:  if (strcmpe(line1_[i1_+t-m+1], line2_[i+t])) {
                 t=0;
         } else {
 
-                /* If lines "match", ensure we use the EDITED version for the
-                   final output */
+                // If lines "match", ensure we use the EDITED version for the
+                // final output.
                 let(&line1_[i1_+t-m+1], line2_[i+t]);
 
                 t=t+1;
@@ -209,8 +207,8 @@ l7170:
                 t=0;
         } else {
 
-                /* If lines "match", ensure we use the EDITED version for the
-                   final output */
+                // If lines "match", ensure we use the EDITED version for the
+                // final output.
                 let(&line1_[i+t], line2_[i2_+t-m+1]);
 
                 t=t+1;
@@ -264,7 +262,7 @@ l7220:  i=i+m-1;
         }
         i1_=i;
         goto l7240;
-l7240: /* */
+l7240:
 
        printedAtLeastOne = 0;
        for (i=0; i<=i1_-m; i++) {
@@ -272,13 +270,13 @@ l7240: /* */
            if (!printedAtLeastOne) {
              printedAtLeastOne = 1;
 
-             /* Put out any blank lines before delStartTag_ */
+             // Put out any blank lines before delStartTag_
              while (((vstring)(line1_[i]))[0] == '\n') {
                fprintf(f3_fp_, "\n");
                let(&(line1_[i]), right(line1_[i], 2));
              }
 
-             /* Find the beginning blank space */
+             // Find the beginning blank space
              tmpi = 0;
              while (((vstring)(line1_[i]))[tmpi] == ' ') tmpi++;
              let(&blanksPrefix, space(tmpi));
@@ -288,8 +286,8 @@ l7240: /* */
              fprintf(f3_fp_, "%s\n", tmpLine);
            }
            fprintf(f3_fp_, "%s\n", line1_[i]);
-                                     /* Output original deleted lines */
-           /*freeTempAlloc();*/ /* Clear vstring stack */
+                                     // Output original deleted lines
+           // freeTempAlloc(); // Clear vstring stack
          }
        }
        if (printedAtLeastOne) {
@@ -305,12 +303,12 @@ l7240: /* */
              if (i == 0) {
                tmpLine = stripAndTag(line2_[i], addTag_, 0);
              } else {
-               /* Put tags on blank lines *inside* of new section */
+               // Put tags on blank lines *inside* of new section
                tmpLine = stripAndTag(line2_[i], addTag_, 1);
              }
              fprintf(f3_fp_, "%s\n", tmpLine);
-                                     /* Output tagged edited lines */
-             /*freeTempAlloc();*/ /* Clear vstring stack */
+                                     // Output tagged edited lines
+             // freeTempAlloc(); // Clear vstring stack
            }
          }
        }
@@ -320,18 +318,18 @@ l7240: /* */
            if (i == 0) {
              tmpLine = stripAndTag(line2_[i], addTag_, 0);
            } else {
-             /* Put tags on blank lines *inside* of new section */
+             // Put tags on blank lines *inside* of new section
              tmpLine = stripAndTag(line2_[i], addTag_, 1);
            }
            fprintf(f3_fp_, "%s\n", tmpLine);
-                                     /* Print remaining edited lines */
-           /*freeTempAlloc();*/ /* Clear vstring stack */
+                                     // Print remaining edited lines
+           // freeTempAlloc(); // Clear vstring stack
          }
        }
        for (i=0; i<=m-1; i++) {
          let(&l1_,line1_[i1_-m+1+i]);
          if (strcmpe(l1_,ctlz_)) {
-           fprintf(f3_fp_,"%s\n",l1_);  /*  Print remaining matching lines */
+           fprintf(f3_fp_,"%s\n",l1_); // Print remaining matching lines
          }
        }
 
@@ -341,70 +339,70 @@ l7240: /* */
 }
 
 void gosub_7320(void) {
-        /* Subroutine:  get next L1_ from original file */
+  // Subroutine:  get next L1_ from original file
   vstring_def(tmpLin);
-  if (r1) {     /*  Get next line from save array */
+  if (r1) { // Get next line from save array
     let(&l1_,reserve1_[0]);
     r1=r1-1;
     for (i9=0; i9<=r1-1; i9++) {
       let(&reserve1_[i9],reserve1_[i9+1]);
     }
-  } else {              /* Get next line from input file */
+  } else {              // Get next line from input file
     if (eof1) {
       let(&l1_,ctlz_);
     } else {
      next_l1:
-      if (!linput(f1_fp_,NULL,&l1_)) { /*linput returns 0 if EOF */
+      if (!linput(f1_fp_,NULL,&l1_)) { // linput returns 0 if EOF
         eof1 = 1;
-        /* Note that we will discard any blank lines before EOF; this
-           should be OK though */
+        // Note that we will discard any blank lines before EOF; this
+        // should be OK though.
         let(&l1_,ctlz_);
-        free_vstring(tmpLin); /* Deallocate */
+        free_vstring(tmpLin); // Deallocate
         return;
       }
-      let(&l1_, edit(l1_, 4 + 128 + 2048)); /* Trim garb, trail space; untab */
-      if (!l1_[0]) { /* Ignore blank lines for comparison */
-        let(&tmpLin, cat(tmpLin, "\n", NULL)); /* Blank line */
+      let(&l1_, edit(l1_, 4 + 128 + 2048)); // Trim garb, trail space; untab
+      if (!l1_[0]) { // Ignore blank lines for comparison
+        let(&tmpLin, cat(tmpLin, "\n", NULL)); // Blank line
         goto next_l1;
       }
     }
   }
-  let(&l1_, cat(tmpLin, l1_, NULL)); /* Add any blank lines */
-  free_vstring(tmpLin); /* Deallocate */
+  let(&l1_, cat(tmpLin, l1_, NULL)); // Add any blank lines
+  free_vstring(tmpLin); // Deallocate
   return;
 }
 
 void gosub_7330(void) {
-        /*  Subroutine:  get next L2_ from edited file */
+        // Subroutine:  get next L2_ from edited file
   vstring_def(tmpLin);
-  vstring tmpStrPtr; /* pointer only */
+  vstring tmpStrPtr; // pointer only
   flag stripDeletedSectionMode;
-  if (r2) {     /*  Get next line from save array */
+  if (r2) { // Get next line from save array
     let(&l2_,reserve2_[0]);
     r2=r2-1;
     for (i9 = 0; i9 < r2; i9++) {
       let(&reserve2_[i9],reserve2_[i9+1]);
     }
-  } else {              /*  Get next line from input file */
+  } else {              // Get next line from input file
     if (eof2) {
       let(&l2_,ctlz_);
     } else {
      stripDeletedSectionMode = 0;
      next_l2:
-      if (!linput(f2_fp_,NULL,&l2_)) { /* linput returns 0 if EOF */
+      if (!linput(f2_fp_,NULL,&l2_)) { // linput returns 0 if EOF
         eof2 = 1;
-        /* Note that we will discard any blank lines before EOF; this
-           should be OK though */
+        // Note that we will discard any blank lines before EOF; this
+        // should be OK though.
         let(&l2_, ctlz_);
-        free_vstring(tmpLin); /* Deallocate */
+        free_vstring(tmpLin); // Deallocate
         return;
       }
-      let(&l2_, edit(l2_, 4 + 128 + 2048)); /* Trim garb, trail space; untab */
+      let(&l2_, edit(l2_, 4 + 128 + 2048)); // Trim garb, trail space; untab
       if (!strcmp(edit(delStartTag_, 2), left(edit(l2_, 2 + 4),
           (long)strlen(edit(delStartTag_, 2))))) {
         if (getRevision(l2_) == getRevision(addTag_)) {
-          /* We should strip out deleted section from previous run */
-          /* (The diff algorithm will put them back from orig. file) */
+          // We should strip out deleted section from previous run.
+          // (The diff algorithm will put them back from orig. file).
           stripDeletedSectionMode = 1;
           goto next_l2;
         }
@@ -418,31 +416,31 @@ void gosub_7330(void) {
         goto next_l2;
       }
 
-      /* Strip off tags that match *this* revision (so previous out-of-sync
-         runs will be corrected) */
+      // Strip off tags that match *this* revision (so previous out-of-sync
+      // runs will be corrected).
       if (getRevision(l2_) == getRevision(addTag_)) {
         tmpStrPtr = l2_;
         l2_ = stripAndTag(l2_, "", 0);
-        free_vstring(tmpStrPtr); /* deallocate old l2_ */
+        free_vstring(tmpStrPtr); // deallocate old l2_
       }
 
-      if (!l2_[0]) { /* Ignore blank lines for comparison */
-        let(&tmpLin, cat(tmpLin, "\n", NULL)); /* Blank line */
+      if (!l2_[0]) { // Ignore blank lines for comparison
+        let(&tmpLin, cat(tmpLin, "\n", NULL)); // Blank line
         goto next_l2;
       }
     }
   }
-  let(&l2_, cat(tmpLin, l2_, NULL)); /* Add any blank lines */
-  free_vstring(tmpLin); /* Deallocate */
+  let(&l2_, cat(tmpLin, l2_, NULL)); // Add any blank lines
+  free_vstring(tmpLin); // Deallocate
   return;
 }
 
-/* Return 0 if difference lines are the same, non-zero otherwise */
+// Return 0 if difference lines are the same, non-zero otherwise
 char strcmpe(vstring s1, vstring s2)
 {
   flag cmpflag;
 
-  /* Option flags - make global if we want to use them */
+  // Option flags - make global if we want to use them
   flag ignoreSpaces = 1;
   flag ignoreSameLineComments = 1;
 
@@ -466,8 +464,8 @@ char strcmpe(vstring s1, vstring s2)
       i2 = instr(i + 2, tmps1, "*/");
       if (i2 == 0) break;
       i3 = instr(i + 2, tmps1, "/*");
-      if (i3 != 0 && i3 < i2) break; /*i = i3;*/ /* Nested comment */
-      if (i2 - i > 7) break; /* only ignore short comments (tags) */
+      if (i3 != 0 && i3 < i2) break; // i = i3; // Nested comment
+      if (i2 - i > 7) break; // only ignore short comments (tags)
       let(&tmps1, cat(left(tmps1, i - 1), right(tmps1, i2 + 2), NULL));
     }
     while (1) {
@@ -476,20 +474,20 @@ char strcmpe(vstring s1, vstring s2)
       i2 = instr(i + 2, tmps2, "*/");
       if (i2 == 0) break;
       i3 = instr(i + 2, tmps2, "/*");
-      if (i3 != 0 && i3 < i2) break; /*i = i3;*/ /* Nested comment */
-      if (i2 - i > 7) break; /* only ignore short comments (tags) */
+      if (i3 != 0 && i3 < i2) break; // i = i3; // Nested comment
+      if (i2 - i > 7) break; // only ignore short comments (tags)
       let(&tmps2, cat(left(tmps2, i - 1), right(tmps2, i2 + 2), NULL));
     }
   }
 
   cmpflag = !!strcmp(tmps1, tmps2);
-  free_vstring(tmps1); /* Deallocate string */
-  free_vstring(tmps2); /* Deallocate string */
+  free_vstring(tmps1); // Deallocate string
+  free_vstring(tmps2); // Deallocate string
   return (cmpflag);
 }
 
-/* Strip any old tag from line and put new tag on it */
-/* (Caller must deallocate returned string) */
+// Strip any old tag from line and put new tag on it.
+// (Caller must deallocate returned string).
 vstring stripAndTag(vstring line, vstring tag, flag tagBlankLines)
 {
   long i, j, k, n;
@@ -498,8 +496,8 @@ vstring stripAndTag(vstring line, vstring tag, flag tagBlankLines)
   long lineLength = LINE_LENGTH;
   flag validTag;
   i = 0;
-  let(&line1, edit(line, 128 + 2048)); /* Trim trailing spaces and untab */
-  /* Get last comment on line */
+  let(&line1, edit(line, 128 + 2048)); // Trim trailing spaces and untab
+  // Get last comment on line
   while (1) {
     j = instr(i + 1, line1, "/*");
     if (j == 0) break;
@@ -510,21 +508,21 @@ vstring stripAndTag(vstring line, vstring tag, flag tagBlankLines)
     let(&comment, seg(line1, i + 2, j - 1));
     validTag = 1;
     for (k = 0; k < (signed)(strlen(comment)); k++) {
-      /* Check for valid characters that can appear in a tag */
+      // Check for valid characters that can appear in a tag
       if (instr(1, " 1234567890#", mid(comment, k + 1, 1))) continue;
       validTag = 0;
       break;
     }
     if (validTag) let(&line1, edit(left(line1, i - 1), 128));
-    free_vstring(comment); /* deallocate */
+    free_vstring(comment); // deallocate
   }
 
-  /* Count blank lines concatenated to the beginning of this line */
+  // Count blank lines concatenated to the beginning of this line
   n = 0;
   while (line1[n] == '\n') n++;
 
-  /* Add the tag */
-  if (tag[0]) { /* Non-blank tag */
+  // Add the tag
+  if (tag[0]) { // Non-blank tag
     if ((long)strlen(line1) - n < lineLength - 1 - (long)strlen(tag))
       let(&line1, cat(line1,
           space(lineLength - 1 - (long)strlen(tag) - (long)strlen(line1) + n),
@@ -538,8 +536,8 @@ vstring stripAndTag(vstring line, vstring tag, flag tagBlankLines)
     }
   }
 
-  /* Add tags to blank lines if tagBlankLines is set */
-  /* (Used for blank lines inside of new edited file sections) */
+  // Add tags to blank lines if tagBlankLines is set.
+  // (Used for blank lines inside of new edited file sections).
   if (tagBlankLines && n > 0) {
     let(&line1, right(line1, n + 1));
     for (i = 1; i <= n; i++) {
@@ -551,9 +549,9 @@ vstring stripAndTag(vstring line, vstring tag, flag tagBlankLines)
   return line1;
 }
 
-/* Get the largest revision number tag in a file */
-/* Tags are assumed to be of format nn or #nn in comment at end of line */
-/* Used to determine default argument for tag question */
+// Get the largest revision number tag in a file.
+// Tags are assumed to be of format nn or #nn in comment at end of line.
+// Used to determine default argument for tag question.
 long highestRevision(vstring fileName)
 {
   vstring_def(str1);
@@ -572,8 +570,8 @@ long highestRevision(vstring fileName)
   return largest;
 }
 
-/* Get numeric revision from the tag on a line (returns 0 if none) */
-/* Tags are assumed to be of format nn or #nn in comment at end of line */
+// Get numeric revision from the tag on a line (returns 0 if none).
+// Tags are assumed to be of format nn or #nn in comment at end of line.
 long getRevision(vstring line)
 {
   vstring_def(str1);
@@ -581,17 +579,17 @@ long getRevision(vstring line)
   vstring_def(tag);
   long revision;
 
-  if (instr(1, line, "/*") == 0) return 0; /* Speedup - no comment in line */
-  let(&str1, edit(line, 2)); /* This line has the tag not stripped */
+  if (instr(1, line, "/*") == 0) return 0; // Speedup - no comment in line
+  let(&str1, edit(line, 2)); // This line has the tag not stripped
   free_vstring(str2);
-  str2 = stripAndTag(str1, "", 0); /* Strip old tag & add dummy new one */
-  let(&str2, edit(str2, 2)); /* This line has the tag stripped */
+  str2 = stripAndTag(str1, "", 0); // Strip old tag & add dummy new one
+  let(&str2, edit(str2, 2)); // This line has the tag stripped
   if (!strcmp(str1, str2)) {
-    revision = 0;  /* No tag */
+    revision = 0; // No tag
   } else {
     let(&tag, edit(seg(str1, (long)strlen(str2) + 3,
         (long)strlen(str1) - 2), 2));
-    if (tag[0] == '#') let(&tag, right(tag, 2)); /* Remove any # */
+    if (tag[0] == '#') let(&tag, right(tag, 2)); // Remove any #
     revision = (long)(val(tag));
   }
   free_vstring(tag);

--- a/src/mmword.c
+++ b/src/mmword.c
@@ -284,9 +284,9 @@ l7240:
                  addTag_, 0);
              fprintf(f3_fp_, "%s\n", tmpLine);
            }
-           // Output original deleted lines // freeTempAlloc();
-           // Clear vstring stack
+           // Output original deleted lines 
            fprintf(f3_fp_, "%s\n", line1_[i]);
+           // freeTempAlloc(); // Clear vstring stack
          }
        }
        if (printedAtLeastOne) {
@@ -305,9 +305,9 @@ l7240:
                // Put tags on blank lines *inside* of new section
                tmpLine = stripAndTag(line2_[i], addTag_, 1);
              }
-             // Output tagged edited lines // freeTempAlloc();
-             // Clear vstring stack
+             // Output tagged edited lines 
              fprintf(f3_fp_, "%s\n", tmpLine);
+             // freeTempAlloc(); // Clear vstring stack
            }
          }
        }
@@ -320,9 +320,9 @@ l7240:
              // Put tags on blank lines *inside* of new section
              tmpLine = stripAndTag(line2_[i], addTag_, 1);
            }
-           // Print remaining edited lines // freeTempAlloc();
-           // Clear vstring stack
-           fprintf(f3_fp_, "%s\n", tmpLine);                  
+           // Print remaining edited lines
+           fprintf(f3_fp_, "%s\n", tmpLine); 
+           // freeTempAlloc(); // Clear vstring stack
          }
        }
        for (i=0; i<=m-1; i++) {

--- a/src/mmword.c
+++ b/src/mmword.c
@@ -336,9 +336,8 @@ l7240:
        let(&l2_,ctlz_);
        goto l7100;
 }
-
+// Subroutine:  get next L1_ from original file
 void gosub_7320(void) {
-  // Subroutine:  get next L1_ from original file
   vstring_def(tmpLin);
   if (r1) { // Get next line from save array
     let(&l1_,reserve1_[0]);
@@ -370,9 +369,8 @@ void gosub_7320(void) {
   free_vstring(tmpLin); // Deallocate
   return;
 }
-
+// Subroutine: get next L2_ from edited file
 void gosub_7330(void) {
-  // Subroutine: get next L2_ from edited file
   vstring_def(tmpLin);
   vstring tmpStrPtr; // pointer only
   flag stripDeletedSectionMode;


### PR DESCRIPTION
In https://github.com/metamath/metamath-exe/issues/17 I read:
> - [ ]  Use // comments instead of /* (or doc-comments where appropriate)

It doesn't seem a difficult task, so I thought I could give my contribution.

I might continue this if I did a good change.

