### PR TITLE
Line comments instead of block comments 4

### DIFF
--- a/src/mmcmds.h
+++ b/src/mmcmds.h
@@ -70,14 +70,14 @@ void readInput(void);
 /*! WRITE SOURCE command */
 void writeSource(
   flag reformatFlag /* 1 = "/ FORMAT", 2 = "/REWRAP" */,
-  flag splitFlag,  /* /SPLIT - write out separate $[ $] includes */
-  flag noVersioningFlag, /* /NO_VERSIONING - no ~1 backup */
-  flag keepSplitsFlag, /* /KEEP_SPLITS - don't delete included files
-                        when /SPIT is not specified */
-  vstring extractLabels); /* "" means write everything */
+  flag splitFlag, // /SPLIT - write out separate $[ $] includes
+  flag noVersioningFlag, // /NO_VERSIONING - no ~1 backup
+  // /KEEP_SPLITS - don't delete included files when /SPIT is not specified
+  flag keepSplitsFlag, 
+  vstring extractLabels); // "" means write everything
 
 /*! Get info for WRITE SOURCE ... / EXTRACT */
-void writeExtractedSource(vstring extractLabels, /* EXTRACT argument provided by user */
+void writeExtractedSource(vstring extractLabels, // EXTRACT argument provided by user
   vstring fullOutput_fn, flag noVersioningFlag);
 
 void fixUndefinedLabels(vstring extractNeeded, vstring *buf);

--- a/src/mmdata.h
+++ b/src/mmdata.h
@@ -14,7 +14,7 @@
 
 #include "mmvstr.h"
 
-/* debugging flags & variables */
+// debugging flags & variables
 
 /*!
  * \var long db
@@ -105,7 +105,7 @@ typedef char flag;
  * \ref flag occasionally, but its value is in fact fixed to 0 in metamath,
  * meaning the LIST.EXE functionality is an integral part of metamath now.
  */
-extern flag g_listMode; /* 0 = metamath, 1 = list utility */
+extern flag g_listMode; // 0 = metamath, 1 = list utility
 
 /*!
  * \var g_toolsMode
@@ -115,9 +115,9 @@ extern flag g_listMode; /* 0 = metamath, 1 = list utility */
  * executing the 'tools' command.  In this mode text files are processed using
  * high level commands.  It is indicated by a 1 in \ref g_toolsMode.
  */
-extern flag g_toolsMode; /* In metamath mode:  0 = metamath, 1 = tools */
+extern flag g_toolsMode; // In metamath mode:  0 = metamath, 1 = tools
 
-typedef long nmbrString; /* String of numbers */
+typedef long nmbrString; // String of numbers
 
 /*!
  * \typedef pntrString
@@ -160,16 +160,16 @@ typedef long nmbrString; /* String of numbers */
  *   dedicated ownership and solving this problem more thoroughly, but Metamath
  *   is not up to that level (yet).
  */
-typedef void* pntrString; /* String of pointers */
+typedef void* pntrString; // String of pointers
 
-/* A nmbrString allocated in temporary storage. These strings will be deallocated
-   after the next call to `nmbrLet`.
-   See also `temp_vstring` for information on how temporaries are handled. */
+// A nmbrString allocated in temporary storage. These strings will be deallocated
+// after the next call to `nmbrLet`.
+// See also `temp_vstring` for information on how temporaries are handled.
 typedef nmbrString temp_nmbrString;
 
-/* A pntrString allocated in temporary storage. These strings will be deallocated
-   after the next call to `pntrLet`.
-   See also `temp_vstring` for information on how temporaries are handled. */
+// A pntrString allocated in temporary storage. These strings will be deallocated
+// after the next call to `pntrLet`.
+// See also `temp_vstring` for information on how temporaries are handled.
 
 /*!
  * \typedef temp_pntrString
@@ -184,23 +184,23 @@ typedef nmbrString temp_nmbrString;
 typedef pntrString temp_pntrString;
 
 enum mTokenType { var_, con_ };
-#define lb_ '{' /* ${ */
-#define rb_ '}' /* $} */
-#define v_  'v' /* $v */
-#define c_  'c' /* $c */
-#define a_  'a' /* $a */
-#define d_  'd' /* $d */
-#define e_  'e' /* $e */
-#define f_  'f' /* $f */
-#define p_  'p' /* $p */
-#define eq_ '=' /* $= */
-#define sc_ '.' /* $. (historically, used to be $; (semicolon) ) */
-#define illegal_ '?' /* anything else */
-/* Global variables related to current statement */
+#define lb_ '{' // ${
+#define rb_ '}' // $}
+#define v_  'v' // $v
+#define c_  'c' // $c
+#define a_  'a' // $a
+#define d_  'd' // $d
+#define e_  'e' // $e
+#define f_  'f' // $f
+#define p_  'p' // $p
+#define eq_ '=' // $=
+#define sc_ '.' // $. (historically, used to be $; (semicolon) )
+#define illegal_ '?' // anything else
+// Global variables related to current statement
 extern int g_currentScope;
 
 /*! The data associated with a statement in the file */
-struct statement_struct { /* Array index is statement number, starting at 1 */
+struct statement_struct { // Array index is statement number, starting at 1
   long lineNum; /*!< Line number in file; 0 means not yet determined */
   vstring fileName; /*!< File statement is in; "" means not yet determined */
   vstring labelName; /*!< Label of statement */
@@ -288,7 +288,7 @@ extern long *g_mathKey;
 extern long g_MAX_STATEMENTS;
 extern long g_MAX_MATHTOKENS;
 extern struct statement_struct *g_Statement;
-/*Obs*/ /*extern struct label_struct *label;*/
+// Obs // extern struct label_struct *label;
 
 /*! \warning `mathToken[i]` is 0-based, not 1-based! */
 extern struct mathToken_struct *g_MathToken;
@@ -301,14 +301,14 @@ extern long g_includeCalls;
 extern char *g_sourcePtr; /*!< Pointer to buffer in memory with input source */
 extern long g_sourceLen; /*!< Number of chars. in all inputs files combined (after includes)*/
 
-/* For use by getMarkupFlag() */
+// For use by getMarkupFlag()
 #define PROOF_DISCOURAGED_MARKUP "(Proof modification is discouraged.)"
 #define USAGE_DISCOURAGED_MARKUP "(New usage is discouraged.)"
-/* Mode argument for getMarkupFlag() */
+// Mode argument for getMarkupFlag()
 #define PROOF_DISCOURAGED 1
 #define USAGE_DISCOURAGED 2
 #define RESET 0
-/* Mode argument for getContrib() */
+// Mode argument for getContrib()
 #define GC_RESET 0
 #define GC_RESET_STMT 10
 #define CONTRIBUTOR 1
@@ -321,16 +321,16 @@ extern long g_sourceLen; /*!< Number of chars. in all inputs files combined (aft
 #define GC_ERROR_CHECK_SILENT 8
 #define GC_ERROR_CHECK_PRINT 9
 
-/* 14-May-2017 nm - TODO: someday we should create structures to
-   hold global vars, and clear their string components in eraseSource() */
+// 14-May-2017 nm - TODO: someday we should create structures to
+// hold global vars, and clear their string components in eraseSource().
 extern vstring g_contributorName;
 #define DEFAULT_CONTRIBUTOR "?who?"
 
 extern vstring g_proofDiscouragedMarkup;
 extern vstring g_usageDiscouragedMarkup;
-extern flag g_globalDiscouragement; /* SET DISCOURAGEMENT */
+extern flag g_globalDiscouragement; // SET DISCOURAGEMENT
 
-/* Allocation and deallocation in memory pool */
+// Allocation and deallocation in memory pool
 void *poolFixedMalloc(long size /* bytes */);
 
 /*!
@@ -402,7 +402,7 @@ void poolFree(void *ptr);
 void addToUsedPool(void *ptr);
 /*! Purges reset memory pool usage */
 void memFreePoolPurge(flag untilOK);
-/* Statistics */
+// Statistics
 
 /*!
  * \fn getPoolStats(long *freeAlloc, long *usedAlloc, long *usedActual)
@@ -580,10 +580,10 @@ flag matches(const char *testString, const char *pattern, char wildCard,
 /******* Special purpose routines for better
       memory allocation (use with caution) *******/
 
-extern long g_nmbrTempAllocStackTop;   /* Top of stack for nmbrTempAlloc function */
-extern long g_nmbrStartTempAllocStack; /* Where to start freeing temporary
-    allocation when nmbrLet() is called (normally 0, except for nested
-    nmbrString functions) */
+extern long g_nmbrTempAllocStackTop; // Top of stack for nmbrTempAlloc function
+ // Where to start freeing temporary allocation when nmbrLet() is called 
+ // (normally 0, except for nested nmbrString functions).
+extern long g_nmbrStartTempAllocStack;
 
 /*!
   When "size" is >0, "size" instances of nmbrString are allocated.
@@ -594,9 +594,8 @@ temp_nmbrString *nmbrTempAlloc(long size);
 /*! \brief Make string have temporary allocation to be released by next nmbrLet()
   \warning after nmbrMakeTempAlloc() is called, the nmbrString may NOT be
     assigned again with nmbrLet() */
+// Make string have temporary allocation to be released by next nmbrLet()
 temp_nmbrString *nmbrMakeTempAlloc(nmbrString *s);
-                                    /* Make string have temporary allocation to be
-                                    released by next nmbrLet() */
 
 /**************************************************/
 
@@ -727,7 +726,7 @@ long compressedProofSize(const nmbrString *proof, long statemNum);
  *
  * \invariant always refers the null pointer element behind the valid data.
  */
-extern long g_pntrTempAllocStackTop;   /* Top of stack for pntrTempAlloc function */
+extern long g_pntrTempAllocStackTop; // Top of stack for pntrTempAlloc function
 
 /*!
  * \var long g_pntrStartTempAllocStack
@@ -744,9 +743,9 @@ extern long g_pntrTempAllocStackTop;   /* Top of stack for pntrTempAlloc functio
  * local dependency chain.  On return the saved value is restored.
  * \invariant always less or equal to \ref g_pntrTempAllocStackTop.
  */
-extern long g_pntrStartTempAllocStack; /* Where to start freeing temporary
-    allocation when pntrLet() is called (normally 0, except for nested
-    pntrString functions) */
+// Where to start freeing temporary allocation when pntrLet() is called
+// (normally 0, except for nested pntrString functions).
+extern long g_pntrStartTempAllocStack;
 
 /*!
  * \brief Make string have temporary allocation to be released by next pntrLet()
@@ -806,7 +805,7 @@ void pntrLet(pntrString **target, const pntrString *source);
 /*! String concatenation - last argument MUST be NULL */
 temp_pntrString *pntrCat(const pntrString *string1,...);
 
-/* Emulation of pntrString functions similar to BASIC string functions */
+// Emulation of pntrString functions similar to BASIC string functions
 temp_pntrString *pntrSeg(const pntrString *sin, long p1, long p2);
 temp_pntrString *pntrMid(const pntrString *sin, long p, long length);
 temp_pntrString *pntrLeft(const pntrString *sin, long n);
@@ -889,7 +888,7 @@ temp_pntrString *pntrAddElement(const pntrString *g);
 /*! Add a single null pntrString element to a pntrString - faster than pntrCat */
 temp_pntrString *pntrAddGElement(const pntrString *g);
 
-/* Utility functions */
+// Utility functions
 
 /*! 0/1 knapsack algorithm */
 long knapsack01(long items, long *size, long *worth, long maxSize,
@@ -946,4 +945,4 @@ int qsortStringCmp(const void *p1, const void *p2);
 /*! Call on exit to free memory */
 void freeData(void);
 
-#endif /* METAMATH_MMDATA_H_ */
+#endif // METAMATH_MMDATA_H_

--- a/src/mmfatl.h
+++ b/src/mmfatl.h
@@ -120,7 +120,7 @@ enum {
  * in this particular case.
  */
 enum fatalErrorPlaceholderType {
-   //! escape character marking a placeholder, followed by a type character
+  //! escape character marking a placeholder, followed by a type character
   MMFATL_PH_PREFIX = '%',
   //! type character marking a placeholder for a string
   MMFATL_PH_STRING = 's',

--- a/src/mmhlpa.h
+++ b/src/mmhlpa.h
@@ -16,4 +16,4 @@ void help0(vstring helpCmd);
 /*! \note help1 should contain Metamath help */
 void help1(vstring helpCmd);
 
-#endif /* METAMATH_MMHLPA_H_ */
+#endif // METAMATH_MMHLPA_H_

--- a/src/mmhlpb.h
+++ b/src/mmhlpb.h
@@ -14,4 +14,4 @@
 void help2(vstring helpCmd);
 void help3(vstring helpCmd);
 
-#endif /* METAMATH_MMHLPB_H_ */
+#endif // METAMATH_MMHLPB_H_

--- a/src/mminou.h
+++ b/src/mminou.h
@@ -19,7 +19,7 @@
 
 extern int g_errorCount;     /*!< Total error count */
 
-/* Global variables used by print2() */
+// Global variables used by print2()
 
 /*!
  * \var flag g_logFileOpenFlag
@@ -52,7 +52,7 @@ extern flag g_outputToString;
  */
 extern vstring g_printString;
 
-/* Global variables used by cmdInput() */
+// Global variables used by cmdInput()
 
 /*!
  * \def MAX_COMMAND_FILE_NESTING
@@ -95,7 +95,7 @@ extern flag g_commandFileSilent[MAX_COMMAND_FILE_NESTING + 1];
  * If set to 1, suppresses prompts on input.  Activated through
  * SUBMIT ... /SILENT commands.  Initialized to 0 on program start.
  */
-extern flag g_commandFileSilentFlag; /* For SUBMIT ... /SILENT */
+extern flag g_commandFileSilentFlag; // For SUBMIT ... /SILENT
 
 extern FILE *g_input_fp;  /*!< File pointers */
 extern vstring g_input_fn, g_output_fn;  /*!< File names */
@@ -750,4 +750,4 @@ double getRunTime(double *timeSinceLastCall);
 /*! Call before exiting to free memory allocated by this module */
 void freeInOu(void);
 
-#endif /* METAMATH_MMINOU_H_*/
+#endif // METAMATH_MMINOU_H_

--- a/src/mmpars.h
+++ b/src/mmpars.h
@@ -51,7 +51,7 @@ int hypAndLocSrchCmp(const void *key, const void *data);
    is returned.  If ptr points to a null character, 0 is returned. */
 long whiteSpaceLen(char *ptr);
 
-/* For .mm file splitting */
+// For .mm file splitting
 /*! Like whiteSpaceLen except comments are not whitespace */
 long rawWhiteSpaceLen(char *ptr);
 
@@ -93,7 +93,7 @@ extern long *g_allLabelKeyBase;
 extern long g_numAllLabelKeys;
 
 extern long g_wrkProofMaxSize; /*!< Maximum size so far - it may grow */
-struct sortHypAndLoc {  /* Used for sorting hypAndLocLabel field */
+struct sortHypAndLoc { // Used for sorting hypAndLocLabel field
   long labelTokenNum;
   void *labelName;
 };
@@ -110,9 +110,9 @@ struct wrkProof_struct {
   flag errorSeverity; /*!< 0 = OK, 1 = unknown step, 2 = error, 3 = severe error,
                           4 = not a $p statement */
 
-  /* The following pointers will always be allocated with g_wrkProofMaxSize
-     entries.  If a function needs more than g_wrkProofMaxSize, it must
-     reallocate all of these and increase g_wrkProofMaxSize. */
+  // The following pointers will always be allocated with g_wrkProofMaxSize
+  // entries.  If a function needs more than g_wrkProofMaxSize, it must
+  // reallocate all of these and increase g_wrkProofMaxSize.
   nmbrString *tokenSrcPtrNmbr; /*!< Source parsed into tokens vs. token number
                                     - token size */
   pntrString *tokenSrcPtrPntr; /*!< Source parsed into tokens vs. token number
@@ -131,7 +131,7 @@ struct wrkProof_struct {
   pntrString *mathStringPtrs;
   nmbrString *RPNStack; /*!< Stack for RPN parsing */
 
-  /* For compressed proof parsing */
+  // For compressed proof parsing
   nmbrString *compressedPfLabelMap; /*!< Map from compressed label to actual */
   long compressedPfNumLabels; /*!< Number of compressed labels */
 };
@@ -141,7 +141,7 @@ extern struct wrkProof_struct g_WrkProof;
    provides the context for the parse (to get correct active symbols) */
 nmbrString *parseMathTokens(vstring userText, long statemNum);
 
-vstring outputStatement(long stmt, /*flag cleanFlag,*/ flag reformatFlag);
+vstring outputStatement(long stmt, /* flag cleanFlag, */ flag reformatFlag);
 /*! Caller must deallocate return string */
 vstring rewrapComment(const char *comment);
 
@@ -149,7 +149,7 @@ vstring rewrapComment(const char *comment);
    Return -1 if not found. */
 long lookupLabel(const char *label);
 
-/* For file splitting */
+// For file splitting
 
 /*! Get the next real $[...$] or virtual $( Begin $[... inclusion */
 void getNextInclusion(char *fileBuf, long startOffset, /*!< inputs */
@@ -184,9 +184,9 @@ void deleteSplits(vstring *fileBuf, flag noVersioningFlag);
  * \note The user must deallocate the returned string (file name)
  * \note The globals includeCall structure and includeCalls are used
  */
-vstring getFileAndLineNum(const char *buffPtr/*start of read buffer*/,
-    const char *currentPtr/*place at which to get file name and line no*/,
-    long *lineNum/*return argument*/);
+vstring getFileAndLineNum(const char *buffPtr /* start of read buffer */,
+    const char *currentPtr /* place at which to get file name and line no */,
+    long *lineNum /* return argument */);
 
 /*! statement[stmtNum].fileName and .lineNum are initialized to "" and 0.
    To save CPU time, they aren't normally assigned until needed, but once
@@ -201,7 +201,7 @@ vstring readSourceAndIncludes(const char *inputFn, long *size);
 
 /*! Recursively expand the source of an included file */
 vstring readInclude(const char *fileBuf, long fileBufOffset,
-    /*vstring inclFileName,*/ const char *sourceFileName,
+    /* vstring inclFileName, */ const char *sourceFileName,
     long *size, long parentLineNum, flag *errorFlag);
 
-#endif /* METAMATH_MMPARS_H_ */
+#endif // METAMATH_MMPARS_H_

--- a/src/mmpfas.h
+++ b/src/mmpfas.h
@@ -178,9 +178,8 @@ long subproofLen(const nmbrString *proof, long endStep);
 char checkDummyVarIsolation(long testStep /*!< 0=1st step, 1=2nd, etc. */);
 
 /*! Given a starting step, find its parent (the step it is a hypothesis of)
-
-  If the starting step is the last proof step, just return it */
-long getParentStep(long startStep /*!< 0=1st step, 1=2nd, etc. */);
+   If the starting step is the last proof step, just return it */
+long getParentStep(long startStep /*! < 0=1st step, 1=2nd, etc. */);
 
 /*! Adds a dummy variable to end of mathToken array
   \note it now grows forever, but purging it might worsen fragmentation */
@@ -197,7 +196,7 @@ void initProofStruct(struct pip_struct *proofStruct, const nmbrString *proof,
 /*! Clears the Proof Assistant proof state */
 void deallocProofStruct(struct pip_struct *proofStruct);
 
-/* Actions for processUndoStack() */
+// Actions for processUndoStack()
 #define PUS_INIT 1
 #define PUS_PUSH 2
 #define PUS_UNDO 3
@@ -212,4 +211,4 @@ long processUndoStack(struct pip_struct *proofStruct,
     vstring info, /*!< Info to print upon UNDO or REDO */
     long newStackSize /*!< Used only by NEW_SIZE */);
 
-#endif /* METAMATH_MMPFAS_H_ */
+#endif // METAMATH_MMPFAS_H_

--- a/src/mmunif.h
+++ b/src/mmunif.h
@@ -10,16 +10,18 @@
 /*! \file */
 
 #include "mmdata.h"
-
-extern long g_minSubstLen; /*!< User-settable value - 0 or 1 */
+/*!< User-settable value - 0 or 1 */
+extern long g_minSubstLen;
+/*!< User-defined upper limit (# backtracks) for unification trials */
 extern long g_userMaxUnifTrials;
-            /*!< User-defined upper limit (# backtracks) for unification trials */
+/*!< 0 means don't time out; 1 means start counting trials */
 extern long g_unifTrialCount;
-                     /*!< 0 means don't time out; 1 means start counting trials */
-extern long g_unifTimeouts; /*!< Number of timeouts so far for this command */
-extern flag g_hentyFilter; /*!< Turns Henty filter on or off */
+/*!< Number of timeouts so far for this command */
+extern long g_unifTimeouts;
+/*!< Turns Henty filter on or off */
+extern flag g_hentyFilter;
 
-/* Global so eraseSource() (mmcmds.c) can clear them */
+// Global so eraseSource() (mmcmds.c) can clear them
 extern flag g_bracketMatchInit;
 extern nmbrString *g_firstConst;
 extern nmbrString *g_lastConst;
@@ -53,7 +55,7 @@ nmbrString *makeSubstUnif(flag *newVarFlag,
 char unify(
     const nmbrString *schemeA,
     const nmbrString *schemeB,
-    /* nmbrString **unifiedScheme, */ /* stateVector[8] holds this */
+    // nmbrString **unifiedScheme, // stateVector[8] holds this
     pntrString **stateVector,
     long reEntryFlag);
 
@@ -96,4 +98,4 @@ void purgeStateVector(pntrString **stateVector);
 /*! Prints the substitutions determined by unify for debugging purposes */
 void printSubst(pntrString *stateVector);
 
-#endif /* METAMATH_MMUNIF_H_ */
+#endif // METAMATH_MMUNIF_H_

--- a/src/mmveri.h
+++ b/src/mmveri.h
@@ -16,9 +16,9 @@ char verifyProof(long statemNum);
 /*! assignVar() finds an assignment to substScheme variables that match
    the assumptions specified in the reason string */
 nmbrString *assignVar(nmbrString *bigSubstSchemeAss,
-  nmbrString *bigSubstInstAss, long substScheme,
-    /* For error messages: */
-  long statementNum, long step, flag unkHypFlag);
+nmbrString *bigSubstInstAss, long substScheme,
+// For error messages:
+long statementNum, long step, flag unkHypFlag);
 
 /*! Deallocate the math symbol strings assigned in g_WrkProof structure during
    proof verification.  This should be called after verifyProof() and after the
@@ -32,17 +32,17 @@ void cleanWrkProof(void);
   If getStep.stepNum is nonzero, we should get info about that step.
   \note This structure should be deallocated after use. */
 struct getStep_struct {
-  long stepNum; /* Step # to get info about */
-  long sourceStmt; /* Right side of = in proof display */
-  long targetStmt; /* Left side of = in proof display */
-  long targetParentStep; /* Step # of target's parent */
-  long targetParentStmt; /* Statement # of target's parent */
-  nmbrString *sourceHyps; /* List of step #'s */
-  nmbrString *sourceSubstsNmbr; /* List of vars w/ ptr to subst math tokens */
-  pntrString *sourceSubstsPntr; /* List of vars w/ ptr to subst math tokens */
-  nmbrString *targetSubstsNmbr; /* List of vars w/ ptr to subst math tokens */
-  pntrString *targetSubstsPntr; /* List of vars w/ ptr to subst math tokens */
+  long stepNum; // Step # to get info about
+  long sourceStmt; // Right side of = in proof display
+  long targetStmt; // Left side of = in proof display
+  long targetParentStep; // Step # of target's parent
+  long targetParentStmt; // Statement # of target's parent
+  nmbrString *sourceHyps; // List of step #'s
+  nmbrString *sourceSubstsNmbr; // List of vars w/ ptr to subst math tokens
+  pntrString *sourceSubstsPntr; // List of vars w/ ptr to subst math tokens
+  nmbrString *targetSubstsNmbr; // List of vars w/ ptr to subst math tokens
+  pntrString *targetSubstsPntr; // List of vars w/ ptr to subst math tokens
 };
 extern struct getStep_struct getStep;
 
-#endif /* METAMATH_MMVERI_H_ */
+#endif // METAMATH_MMVERI_H_

--- a/src/mmvstr.h
+++ b/src/mmvstr.h
@@ -348,8 +348,8 @@ temp_vstring cat(const char * string1, ...);
  */
 int linput(FILE *stream, const char *ask, vstring *target);
 
-/* Emulation of BASIC string functions */
-/* Indices are 1-based */
+// Emulation of BASIC string functions
+// Indices are 1-based
 
 /*!
  * \fn temp_vstring seg(const char *sin, long start, long stop)
@@ -566,7 +566,7 @@ long ascii_(const char *c);
 
 double val(const char *s);
 
-/* Emulation of Progress 4GL string functions */
+// Emulation of Progress 4GL string functions
 
 temp_vstring entry(long element, const char *list);
 
@@ -576,11 +576,10 @@ long numEntries(const char *list);
 
 long entryPosition(long element, const char *list);
 
-/* Routines may/may not be written (lowest priority):
-vstring place$(vstring sout);
-vstring prod$(vstring sout);
-vstring quo$(vstring sout);
-*/
+// Routines may/may not be written (lowest priority):
+// vstring place$(vstring sout);
+// vstring prod$(vstring sout);
+// vstring quo$(vstring sout);
 
 /******* Special purpose routines for better
       memory allocation (use with caution) *******/
@@ -600,7 +599,7 @@ vstring quo$(vstring sout);
  * end the called nested function saves administrative stack data.  Upon finish
  * it restores those values.
  */
-extern long g_tempAllocStackTop;   /* Top of stack for tempAlloc function */
+extern long g_tempAllocStackTop; // Top of stack for tempAlloc function
 
 /*!
  * \var g_startTempAllocStack
@@ -621,8 +620,9 @@ extern long g_tempAllocStackTop;   /* Top of stack for tempAlloc function */
  * \invariant
  *   \ref g_startTempAllocStack <= \ref g_tempAllocStackTop.
  */
-extern long g_startTempAllocStack; /* Where to start freeing temporary allocation
-    when let() is called (normally 0, except for nested vstring functions) */
+// Where to start freeing temporary allocation when let() is called 
+// (normally 0, except for nested vstring functions).
+extern long g_startTempAllocStack; 
 
 /*! \brief Make string have temporary allocation to be released by next let().
 
@@ -634,4 +634,4 @@ extern long g_startTempAllocStack; /* Where to start freeing temporary allocatio
   assigned again with let(). */
 temp_vstring makeTempAlloc(vstring s);
 
-#endif /* METAMATH_MMVSTR_H_ */
+#endif // METAMATH_MMVSTR_H_

--- a/src/mmword.h
+++ b/src/mmword.h
@@ -25,4 +25,4 @@ long highestRevision(vstring fileName);
    Tags are assumed to be of format nn or #nn in comment at end of line */
 long getRevision(vstring line);
 
-#endif /* METAMATH_MMWORD_H_ */
+#endif // METAMATH_MMWORD_H_

--- a/src/mmwtex.h
+++ b/src/mmwtex.h
@@ -12,18 +12,18 @@
 #include "mmvstr.h"
 #include "mmdata.h"
 
-/* Colors for HTML pages. */
+// Colors for HTML pages.
 #define GREEN_TITLE_COLOR "\"#006633\""
 #define MINT_BACKGROUND_COLOR "\"#EEFFFA\""
+// =salmon; was FF6666
 #define PINK_NUMBER_COLOR "\"#FA8072\""
-   /* =salmon; was FF6666 */
 #define PURPLISH_BIBLIO_COLOR "\"#FAEEFF\""
 #define SANDBOX_COLOR "\"#FFFFD9\""
 
-/* TeX flags */
+// TeX flags
 extern flag g_oldTexFlag; /*!< Use macros in output; obsolete; take out someday */
 
-/* HTML flags */
+// HTML flags
 extern flag g_htmlFlag;  /*!< HTML flag: 0 = TeX, 1 = HTML */
 extern flag g_altHtmlFlag;  /*!< Use "althtmldef" instead of "htmldef".  This is
     intended to allow the generation of pages with the old Symbol font
@@ -47,7 +47,7 @@ extern vstring g_htmlFont; /*!< Optional; set by g_htmlFont command */
 /*! Undo readTexDefs() */
 void eraseTexDefs(void);
 
-/* TeX/HTML/ALT_HTML word-processor-specific routines */
+// TeX/HTML/ALT_HTML word-processor-specific routines
 /*!
   \param gifCheck The GIF check ensures that for every 'htmldef' definition containing
    `IMG SRC="bla.gif"`, `bla.gif` must exist.
@@ -73,7 +73,6 @@ int texSortCmp(const void *key1, const void *key2);
 /*! Token comparison for bsearch */
 int texSrchCmp(const void *key, const void *data);
 /*! Convert ascii to a string of \tt tex
-
   (The caller must surround it by {\tt }) */
 vstring asciiToTt(vstring s);
 temp_vstring asciiToTt_temp(vstring s);
@@ -94,24 +93,24 @@ void printTexHeader(flag texHeaderFlag);
    allocation.  htmlCenterFlag, if 1, means to center the HTML and add a
    "Description:" prefix
   \returns 1 if error/warning */
-/* void printTexComment(vstring commentPtr, char htmlCenterFlag); */
+// void printTexComment(vstring commentPtr, char htmlCenterFlag);
 flag printTexComment(vstring commentPtr,    /*!< Sends result to g_texFilePtr */
     flag htmlCenterFlag, /*!< 1 = htmlCenterFlag */
     long actionBits, /*!< see indicators below */
     flag fileCheck /*!< 1 = fileCheck */);
 
-/* Indicators for actionBits */
+// Indicators for actionBits
 #define ERRORS_ONLY 1
 #define PROCESS_SYMBOLS 2
 #define PROCESS_LABELS 4
 #define ADD_COLORED_LABEL_NUMBER 8
 #define PROCESS_BIBREFS 16
 #define PROCESS_UNDERSCORES 32
-/* CONVERT_TO_HTML means '<' to '&lt;'; unless <HTML> in comment (and strip it) */
+// CONVERT_TO_HTML means '<' to '&lt;'; unless <HTML> in comment (and strip it)
 #define CONVERT_TO_HTML 64
-/* METAMATH_COMMENT means $) (as well as end-of-string) terminates string. */
+// METAMATH_COMMENT means $) (as well as end-of-string) terminates string.
 #define METAMATH_COMMENT 128
-/* PROCESS_ALL is for convenience */
+// PROCESS_ALL is for convenience
 #define PROCESS_EVERYTHING PROCESS_SYMBOLS + PROCESS_LABELS \
      + ADD_COLORED_LABEL_NUMBER + PROCESS_BIBREFS \
      + PROCESS_UNDERSCORES + CONVERT_TO_HTML + METAMATH_COMMENT
@@ -141,7 +140,7 @@ flag getSectionHeadings(long stmt, vstring *hugeHdrTitle,
     flag fullComment /*!< 1 = put $( + header + comment + $) into xxxHdrTitle */
     );
 
-/* TeX normal output */
+// TeX normal output
 extern flag g_texFileOpenFlag;
 extern FILE *g_texFilePtr;
 
@@ -152,9 +151,9 @@ vstring pinkHTML(long statemNum);
 /*! Pink statement number range HTML code for HTML pages, separated by a "-"
   \warning caller must deallocate returned string */
 vstring pinkRangeHTML(long statemNum1, long statemNum2);
-
-#define PINK_NBSP "&nbsp;" /* Either "" or "&nbsp;" depending on taste, it is
-                  the separator between a statement href and its pink number */
+// Either "" or "&nbsp;" depending on taste, it is the separator between
+// a statement href and its pink number.
+#define PINK_NBSP "&nbsp;"
 
 /*! This function converts a "spectrum" color (1 to maxColor) to an
    RBG value in hex notation for HTML.  The caller must deallocate the
@@ -191,10 +190,9 @@ flag writeBibliography(vstring bibFile,
 /*! Globals to hold mathbox information.  They should be re-initialized
    by the ERASE command (eraseSource()).  g_mathboxStmt = 0 indicates
    it and the other variables haven't been initialized. */
-extern long g_mathboxStmt; /* stmt# of "mathbox" label; statements+1 if none */
-extern long g_mathboxes; /* # of mathboxes */
-/* The following 3 "strings" are 0-based e.g. g_mathboxStart[0] is for
-   mathbox #1 */
+extern long g_mathboxStmt; // stmt# of "mathbox" label; statements+1 if none
+extern long g_mathboxes; // # of mathboxes
+// The following 3 "strings" are 0-based e.g. g_mathboxStart[0] is for mathbox #1
 extern nmbrString *g_mathboxStart; /*!< Start stmt vs. mathbox # */
 extern nmbrString *g_mathboxEnd; /*!< End stmt vs. mathbox # */
 extern pntrString *g_mathboxUser; /*!< User name vs. mathbox # */
@@ -215,4 +213,4 @@ void assignMathboxInfo(void);
 long getMathboxLoc(nmbrString **mathboxStart, nmbrString **mathboxEnd,
     pntrString **mathboxUser);
 
-#endif /* METAMATH_MMWTEX_H_ */
+#endif // METAMATH_MMWTEX_H_


### PR DESCRIPTION
Continuation of https://github.com/metamath/metamath-exe/pull/138.

This PR covers all (editable) h files. Same categories described in https://github.com/metamath/metamath-exe/pull/139 are applied. Comments that start with `/*!` are ignored.