### PR TITLE
add handling of double underscores in generated html

### DIFF
--- a/src/mmhlpa.c
+++ b/src/mmhlpa.c
@@ -635,7 +635,9 @@ H("interpreted by / SYMBOLS, / LABELS, and / BIB_REFS respectively, escape");
 H("them with \"``\", \"~~\", and \"[[\" in the input file.  Literal \"`\"");
 H("must always be escaped even if / SYMBOLS is omitted, because the");
 H("algorithm will still use \"`...`\" to avoid interpreting special");
-H("characters in math symbols.");
+H("characters in math symbols.  Similarly, use a double underscore to");
+H("display one underscore \"_\" and not trigger an italic font or");
+H("subscripts.");
 H("");
 }
 

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -1972,17 +1972,19 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
               let(&cmt, cat(left(cmt, pos1 - 1),
                   "_",
                   seg(cmt, pos1 + 1, pos1 + 2), /* Skip (delete) "_" */
-                  "", right(cmt, pos1+2), NULL));
+                  "", right(cmt, pos1 + 2), NULL));
               let(&cmtMasked, cat(left(cmtMasked, pos1 - 1),
                   "_",
                   seg(cmtMasked, pos1 + 1, pos1 + 2), /* Skip (delete) "_" */
-                  "", right(cmtMasked, pos1+2), NULL));
+                  "", right(cmtMasked, pos1 + 2), NULL));
               pos1 ++; /* Adjust for 1 extra char '_' */
             } else {  /* LaTeX */
-              let(&cmt, cat(left(cmt, pos1 - 1), "\texttt{\_}",
+              let(&cmt, cat(left(cmt, pos1 - 1),
+                  "\texttt{\_}",
                   seg(cmt, pos1 + 1, pos1 + 2),  /* Skip (delete) "_" */
-                  "", right(cmt, pos2), NULL));
-              let(&cmtMasked, cat(left(cmtMasked, pos1 - 1), "$_{",
+                  "", right(cmt, pos1 + 2), NULL));
+              let(&cmtMasked, cat(left(cmtMasked, pos1 - 1),
+                  "\texttt{\_}",
                   seg(cmtMasked, pos1 + 1, pos1 + 2),  /* Skip (delete) "_" */
                   "", right(cmtMasked, pos1 + 2), NULL));
               pos1 = pos1 + 11; /* Adjust for 11 extra chars "\texttt{\_}" */

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -1964,6 +1964,32 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         continue;
       }
 
+      /* Double-underscore handling: double-underscores are "escaped
+      underscores", so replace a double-underscore with a single
+      underscore and do not modify italic or subscript. */
+      if (cmt[pos1 + 1] == '_') {
+            if (g_htmlFlag) {  /* HTML */
+              let(&cmt, cat(left(cmt, pos1 - 1),
+                  "_",
+                  seg(cmt, pos1 + 1, pos1 + 2), /* Skip (delete) "_" */
+                  "", right(cmt, pos1+2), NULL));
+              let(&cmtMasked, cat(left(cmtMasked, pos1 - 1),
+                  "_",
+                  seg(cmtMasked, pos1 + 1, pos1 + 2), /* Skip (delete) "_" */
+                  "", right(cmtMasked, pos1+2), NULL));
+              pos1 ++; /* Adjust for 1 extra char '_' */
+            } else {  /* LaTeX */
+              let(&cmt, cat(left(cmt, pos1 - 1), "\texttt{\_}",
+                  seg(cmt, pos1 + 1, pos1 + 2),  /* Skip (delete) "_" */
+                  "", right(cmt, pos2), NULL));
+              let(&cmtMasked, cat(left(cmtMasked, pos1 - 1), "$_{",
+                  seg(cmtMasked, pos1 + 1, pos1 + 2),  /* Skip (delete) "_" */
+                  "", right(cmtMasked, pos1 + 2), NULL));
+              pos1 = pos1 + 11; /* Adjust for 11 extra chars "\texttt{\_}" */
+            }
+        continue;
+      } /* End of double-underscore handling */
+
       // Opening "_" must be <whitespace>_<alphanum> for <I> tag
       if (pos1 > 1) {
         // Check for not whitespace and not opening punctuation

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -1963,34 +1963,27 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       if (!strcmp(mid(cmt, pos2 + 2, 2), "mm")) {
         continue;
       }
-
-      /* Double-underscore handling: double-underscores are "escaped
-      underscores", so replace a double-underscore with a single
-      underscore and do not modify italic or subscript. */
-      if (cmt[pos1 + 1] == '_') {
-            if (g_htmlFlag) {  /* HTML */
-              let(&cmt, cat(left(cmt, pos1),
-                  "",
-                  seg(cmt, pos1 + 1, pos1 + 2), /* Skip (delete) "_" */
-                  "", right(cmt, pos1 + 2), NULL));
-              let(&cmtMasked, cat(left(cmtMasked, pos1),
-                  "",
-                  seg(cmtMasked, pos1 + 1, pos1 + 2), /* Skip (delete) "_" */
-                  "", right(cmtMasked, pos1 + 2), NULL));
-              pos1 ++; /* Adjust for 1 extra char '_' */
-            } else {  /* LaTeX */
-              let(&cmt, cat(left(cmt, pos1 - 1),
-                  "\texttt{\_}",
-                  seg(cmt, pos1 + 1, pos1 + 2),  /* Skip (delete) "_" */
-                  "", right(cmt, pos1 + 2), NULL));
-              let(&cmtMasked, cat(left(cmtMasked, pos1 - 1),
-                  "\texttt{\_}",
-                  seg(cmtMasked, pos1 + 1, pos1 + 2),  /* Skip (delete) "_" */
-                  "", right(cmtMasked, pos1 + 2), NULL));
-              pos1 = pos1 + 11; /* Adjust for 11 extra chars "\texttt{\_}" */
+      // Double-underscore handling: double-underscores are "escaped
+      // underscores", so replace a double-underscore with a single
+      // underscore and do not modify italic or subscript.
+      if (cmt[pos1] == '_') {
+            if (g_htmlFlag) {  // HTML
+              let(&cmt, cat(left(cmt, pos1), // Skip (delete) "_"
+                  right(cmt, pos1 + 2), NULL));
+              let(&cmtMasked, cat(left(cmtMasked, pos1), // Skip (delete) "_"
+                  right(cmtMasked, pos1 + 2), NULL));
+              pos1 ++; // Adjust for 1 extra char '_'
+            } else {  // LaTeX
+              let(&cmt, cat(left(cmt, pos1 - 1),  // Skip (delete) "_"
+                  "\\texttt{\\_}",
+                  right(cmt, pos1 + 2), NULL));
+              let(&cmtMasked, cat(left(cmtMasked, pos1 - 1),  // Skip (delete) "_"
+                  "\\texttt{\\_}",
+                  right(cmtMasked, pos1 + 2), NULL));
+              pos1 = pos1 + 11; // Adjust for 11 extra chars "\texttt{\_}"
             }
         continue;
-      } /* End of double-underscore handling */
+      } // End of double-underscore handling
 
       // Opening "_" must be <whitespace>_<alphanum> for <I> tag
       if (pos1 > 1) {

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -16,24 +16,21 @@
 #include "mmwtex.h"
 #include "mmcmdl.h" // For g_texFileName
 
-// All LaTeX and HTML definitions are taken from the source file (read in by
-// the READ command).  In the source file, there should be a single comment
-// $( ... $) containing the keyword $t.  The definitions start after the $t and
-// end at the $).  Between $t and $), the definition source should exist.  See
-// the file set.mm for an example.
+// All LaTeX and HTML definitions are taken from the source
+// file (read in the by READ... command).  In the source file, there should
+// be a single comment $( ... $) containing the keyword $t.  The definitions
+// start after the $t and end at the $).  Between $t and $), the definition
+// source should exist.  See the file set.mm for an example.
 
 flag g_oldTexFlag = 0; // Use TeX macros in output (obsolete)
 
 flag g_htmlFlag = 0; // HTML flag: 0 = TeX, 1 = HTML
-
 // Use "althtmldef" instead of "htmldef".  This is intended to allow the
 // generation of pages with the Unicode font instead of the individual GIF files.
 flag g_altHtmlFlag = 0;
-
 // Output statement lists only, for statement display in other HTML pages,
 // such as the Proof Explorer home page.
-flag g_briefHtmlFlag = 0; // TODO: unused
-
+flag g_briefHtmlFlag = 0;
 // At this statement and above, use the exthtmlxxx
 // variables for title, links, etc.  This was put in to allow proper
 // generation of the Hilbert Space Explorer extension to the set.mm
@@ -48,12 +45,12 @@ long g_extHtmlStmt = 0;
 // 0 means it hasn't been looked up yet; g_statements + 1 means there is
 // no mathbox.
 long g_mathboxStmt = 0;
-long g_mathboxes = 0; // number of mathboxes
+long g_mathboxes = 0; // # of mathboxes
 // The following 3 strings are 0-based e.g. g_mathboxStart[0] is for
-// mathbox number 1.
-nmbrString_def(g_mathboxStart); // Start stmt vs. mathbox number
-nmbrString_def(g_mathboxEnd); // End stmt vs. mathbox number
-pntrString_def(g_mathboxUser); // User name vs. mathbox number
+// mathbox #1.
+nmbrString_def(g_mathboxStart); // Start stmt vs. mathbox #
+nmbrString_def(g_mathboxEnd); // End stmt vs. mathbox #
+pntrString_def(g_mathboxUser); // User name vs. mathbox #
 
 // This is the list of characters causing the space before the opening "`"
 // in a math string in a comment to be removed for HTML output.
@@ -191,7 +188,7 @@ flag readTexDefs(
     eraseTexDefs();
     saveHtmlFlag = g_htmlFlag; // Save for next call to readTexDefs()
     saveAltHtmlFlag = g_altHtmlFlag; // Save for next call to readTexDefs()
-    if (!g_htmlFlag /* Tex */ && g_altHtmlFlag) {
+    if (g_htmlFlag == 0 /* Tex */ && g_altHtmlFlag == 1) {
       bug(2301); // Nonsensical combination
     }
   } else {
@@ -1068,9 +1065,8 @@ vstring tokenToTex(vstring mtoken, long statemNum /* for error msgs */)
     for (i = 0; i < j; i++) {
       if (ispunct((unsigned char)(tex[i]))) {
         tmpStr = asciiToTt(chr(tex[i]));
-        if (!g_htmlFlag) {  // LaTeX
+        if (!g_htmlFlag)
           let(&tmpStr, cat("{\\tt ", tmpStr, "}", NULL));
-        }
         k = (long)strlen(tmpStr);
         let(&tex,
             cat(left(tex, i), tmpStr, right(tex, i + 2), NULL));
@@ -1081,10 +1077,9 @@ vstring tokenToTex(vstring mtoken, long statemNum /* for error msgs */)
     } // Next i
 
     // Make all letters Roman in math mode
-    if (!g_htmlFlag) {  // LaTeX
+    if (!g_htmlFlag)
       let(&tex, cat("\\mathrm{", tex, "}", NULL));
-    }
-  } // End if (texDefsPtr)
+  } // End if
 
   return tex;
 } // tokenToTex
@@ -1118,7 +1113,7 @@ vstring asciiMathToTex(vstring mathComment, long statemNum)
     // tokenToTex allocates tex; we must deallocate it
     tex = tokenToTex(token, statemNum);
 
-    if (!g_htmlFlag) {  // LaTeX
+    if (!g_htmlFlag) {
       // If this token and previous token begin with letter, add a thin
       // space between them.
       // Also, anything not in table will have space added.
@@ -1226,14 +1221,13 @@ vstring getCommentModeSection(vstring *srcptr, char *mode)
     }
     ptr++;
   } // End while
-  assert(0);
   return NULL; // Dummy return - never executes
 } // getCommentModeSection
 
 // The texHeaderFlag means this:
-// if !g_htmlFlag (i.e., TeX mode), then 1 means print header;
-// if g_htmlFlag (i.e., HTML mode), then 1 means include "Previous Next" links
-// on page, based on the global g_showStatement variable.
+// If !g_htmlFlag (i.e. TeX mode), then 1 means print header
+// If g_htmlFlag, then 1 means include "Previous Next" links on page,
+// based on the global g_showStatement variable.
 void printTexHeader(flag texHeaderFlag)
 {
 
@@ -1259,7 +1253,7 @@ void printTexHeader(flag texHeaderFlag)
   // }
 
   g_outputToString = 1; // Redirect print2 and printLongLine to g_printString
-  if (!g_htmlFlag) {  // LaTeX
+  if (!g_htmlFlag) {
     print2("%s This LaTeX file was created by Metamath on %s %s.\n",
        "%", date(), time_());
 
@@ -1332,7 +1326,7 @@ void printTexHeader(flag texHeaderFlag)
       print2("  \\box\\mlinebox\n");
       print2("}\n");
     }
-  } else { // g_htmlFlag  // HTML
+  } else { // g_htmlFlag
 
     print2("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n");
     print2(     "    \"http://www.w3.org/TR/html4/loose.dtd\">\n");
@@ -1751,7 +1745,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   // Convert line to the old $m..$n and $l..$n formats (using DOLLAR_SUBST
   // instead of "$") - the old syntax is obsolete but we do this conversion
   // to re-use some old code.
-  if (metamathComment) {
+  if (metamathComment != 0) {
     i = instr(1, cmtptr, "$)"); // If it points to source buffer
     if (!i) i = (long)strlen(cmtptr) + 1; // If it's a stand-alone string
   } else {
@@ -1764,12 +1758,12 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   let(&cmtMasked, cmt);
 
   // This section is independent and can be removed without side effects
-  if (g_htmlFlag) {  // HTML
+  if (g_htmlFlag) {
     // Convert special characters <, &, etc. to HTML entities.
     // But skip converting math symbols inside ` `.
     // Detect preformatted HTML (this is crude, since it
     // will apply to whole comment - perhaps fine-tune this later).
-    if (convertToHtml) {
+    if (convertToHtml != 0) {
       if (instr(1, cmt, "<HTML>") != 0) preformattedMode = 1;
     } else {
       preformattedMode = 1; // For MARKUP command - don't convert HTML
@@ -1816,9 +1810,11 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
     let(&cmtMasked, tmpMasked);
     free_vstring(tmpStr); // Deallocate
     free_vstring(tmpStrMasked);
+  }
 
-    // Add leading and trailing HTML markup to comment here
-    // (instead of in caller).  Also convert special characters.
+  // Add leading and trailing HTML markup to comment here
+  // (instead of in caller).  Also convert special characters.
+  if (g_htmlFlag) {
     // This used to be done in mmcmds.c
     if (htmlCenterFlag) { // Note:  this should be 0 in MARKUP command
       let(&cmt, cat("<CENTER><TABLE><TR><TD ALIGN=LEFT><B>Description: </B>",
@@ -1827,9 +1823,12 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
           cat("<CENTER><TABLE><TR><TD ALIGN=LEFT><B>Description: </B>",
           cmtMasked, "</TD></TR></TABLE></CENTER>", NULL));
     }
+  }
 
-    // Mask out _ (underscore) in labels so they won't become subscripts.
-    // This section is independent and can be removed without side effects.
+  // Mask out _ (underscore) in labels so they won't become subscripts
+  // (reported by Benoit Jubin).
+  // This section is independent and can be removed without side effects.
+  if (g_htmlFlag != 0) {
     pos1 = 0;
     while (1) { // Look for label start
       pos1 = instr(pos1 + 1, cmtMasked, "~");
@@ -1889,7 +1888,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   // below, so that "{\em...}" won't be converted to "\}\em...\}".
   // Convert any remaining special characters for LaTeX.
   // This section is independent and can be removed without side effects.
-  if (!g_htmlFlag) { // LaTeX
+  if (!g_htmlFlag) { // i.e. LaTeX mode.
     // At this point, the comment begins e.g "\begin{lemma}\label{lem:abc}".
     pos1 = instr(1, cmt, "} ");
     if (pos1) {
@@ -1939,7 +1938,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   // to <I>abc</I> for book titles, etc.; convert a_n to a<SUB>n</SUB> for
   // subscripts.
   // This section is independent and can be removed without side effects
-  if (g_htmlFlag && processUnderscores) {
+  if (g_htmlFlag != 0 && processUnderscores != 0) {
     pos1 = 0;
     while (1) {
       // Only look at non-math part of comment
@@ -1968,13 +1967,13 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       // underscores", so replace a double-underscore with a single
       // underscore and do not modify italic or subscript.
       if (cmt[pos1] == '_') {
-            if (g_htmlFlag) {  // HTML; TODO: extraneous since in a "if (g_htmlFlag && processUnderscores)"
+            if (g_htmlFlag) {  // HTML
               let(&cmt, cat(left(cmt, pos1), // Skip (delete) "_"
                   right(cmt, pos1 + 2), NULL));
               let(&cmtMasked, cat(left(cmtMasked, pos1), // Skip (delete) "_"
                   right(cmtMasked, pos1 + 2), NULL));
               pos1 ++; // Adjust for 1 extra char '_'
-            } else {  // LaTeX; TODO: unreachable since in a "if (g_htmlFlag && processUnderscores)"
+            } else {  // LaTeX
               let(&cmt, cat(left(cmt, pos1 - 1),  // Skip (delete) "_"
                   "\\texttt{\\_}",
                   right(cmt, pos1 + 2), NULL));
@@ -2011,7 +2010,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
               pos2++; // Move forward through subscript
             }
             pos2++; // Adjust for left, seg, etc. that start at 1 not 0
-            if (g_htmlFlag) { // HTML; TODO: extraneous since in a "if (g_htmlFlag && processUnderscores)"
+            if (g_htmlFlag) { // HTML
               // Put <SUB>...</SUB> around subscript
               let(&cmt, cat(left(cmt, pos1 - 1),
                   "<SUB><FONT SIZE=\"-1\">",
@@ -2022,7 +2021,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
                   seg(cmtMasked, pos1 + 1, pos2 - 1), // Skip (delete) "_"
                   "</FONT></SUB>", right(cmtMasked, pos2), NULL));
               pos1 = pos2 + 33; // Adjust for 34-1 extra chars in "let" above
-            } else { // LaTeX; TODO: unreachable since in a "if (g_htmlFlag && processUnderscores)"
+            } else { // LaTeX
               // Put _{...} around subscript
               let(&cmt, cat(left(cmt, pos1 - 1), "$_{",
                   seg(cmt, pos1 + 1, pos2 - 1), // Skip (delete) "_"
@@ -2047,7 +2046,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       // Closing "_" must be <alphanum>_<nonalphanum>
       if (!isalnum((unsigned char)(cmt[pos2 - 2]))) continue;
       if (isalnum((unsigned char)(cmt[pos2]))) continue;
-      if (g_htmlFlag) { // HTML; TODO: extraneous since in a "if (g_htmlFlag && processUnderscores)"
+      if (g_htmlFlag) { // HTML
         let(&cmt, cat(left(cmt, pos1 - 1), "<I>",
             seg(cmt, pos1 + 1, pos2 - 1),
             "</I>", right(cmt, pos2 + 1), NULL));
@@ -2055,7 +2054,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
             seg(cmtMasked, pos1 + 1, pos2 - 1),
             "</I>", right(cmtMasked, pos2 + 1), NULL));
         pos1 = pos2 + 5; // Adjust for 7-2 extra chars in "let" above
-      } else { // LaTeX; TODO: unreachable since in a "if (g_htmlFlag && processUnderscores)"
+      } else { // LaTeX
         let(&cmt, cat(left(cmt, pos1 - 1), "{\\em ",
             seg(cmt, pos1 + 1, pos2 - 1),
             "}", right(cmt, pos2 + 1), NULL));
@@ -2065,11 +2064,11 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         pos1 = pos2 + 4; // Adjust for 6-2 extra chars in "let" above
       }
     }
-  }  // End if (g_htmlFlag && processUnderscores)
+  }
 
   // Convert opening double quote to `` for LaTeX.
   // This section is independent and can be removed without side effects
-  if (!g_htmlFlag) {  // LaTeX
+  if (!g_htmlFlag) { // If LaTeX mode
     i = 1; // Even/odd counter: 1 = left quote, 0 = right quote
     pos1 = 0;
     while (1) {
@@ -2092,7 +2091,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
   // Put bibliography hyperlinks in comments converted to HTML:
   // [Monk2] becomes <A HREF="mmset.html#monk2>[Monk2]</A> etc.
   // This section is independent and can be removed without side effects
-  if (g_htmlFlag && processBibrefs) {
+  if (g_htmlFlag && processBibrefs != 0) {
     // Assign local tag list and local HTML file name
     if (g_showStatement < g_extHtmlStmt) {
       let(&bibTags, g_htmlBibliographyTags);
@@ -2245,7 +2244,7 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
         pos1 = pos1 + (long)strlen(tmp) - (long)strlen(bibTag); // Adjust comment position
       } // end while(1)
     } // end if (bibFileName[0])
-  } // end if (g_htmlFlag)
+  } // end of if (g_htmlFlag)
 
   // All actions on cmt should be mirrored on cmdMasked, except that
   // math symbols are replaced with blanks in cmdMasked.
@@ -4803,7 +4802,7 @@ vstring spectrumToRGB(long color, long maxColor) {
   return str1;
 } // spectrumToRGB
 
-// Return the HTML code for GIFs (!g_altHtmlFlag) or Unicode (g_altHtmlFlag),
+// Returns the HTML code for GIFs (!g_altHtmlFlag) or Unicode (g_altHtmlFlag),
 // or LaTeX when !g_htmlFlag, for the math string (hypothesis or conclusion) that
 // is passed in.
 // Warning: The caller must deallocate the returned vstring.

--- a/src/mmwtex.c
+++ b/src/mmwtex.c
@@ -1969,12 +1969,12 @@ flag printTexComment(vstring commentPtr, flag htmlCenterFlag,
       underscore and do not modify italic or subscript. */
       if (cmt[pos1 + 1] == '_') {
             if (g_htmlFlag) {  /* HTML */
-              let(&cmt, cat(left(cmt, pos1 - 1),
-                  "_",
+              let(&cmt, cat(left(cmt, pos1),
+                  "",
                   seg(cmt, pos1 + 1, pos1 + 2), /* Skip (delete) "_" */
                   "", right(cmt, pos1 + 2), NULL));
-              let(&cmtMasked, cat(left(cmtMasked, pos1 - 1),
-                  "_",
+              let(&cmtMasked, cat(left(cmtMasked, pos1),
+                  "",
                   seg(cmtMasked, pos1 + 1, pos1 + 2), /* Skip (delete) "_" */
                   "", right(cmtMasked, pos1 + 2), NULL));
               pos1 ++; /* Adjust for 1 extra char '_' */

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
 issue134.tex
+underscores.html

--- a/tests/underscores.expected
+++ b/tests/underscores.expected
@@ -1,12 +1,12 @@
 MM> READ "underscores.mm"
-Reading source file "underscores.mm"... 193 bytes
-193 bytes were read into the source buffer.
+Reading source file "underscores.mm"... 203 bytes
+203 bytes were read into the source buffer.
 The source has 2 statements; 1 are $a and 0 are $p.
 SET EMPTY_SUBSTITUTION was turned ON (allowed) for this database.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
 if you want to check them.
 MM> Continuous scrolling is now in effect.
-MM> Creating HTML file "b.html"...
+MM> Creating HTML file "underscores.html"...
 Reading definitions from $t statement of underscores.mm...
 1 typesetting statements were read from "underscores.mm".
 MM> <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
@@ -28,7 +28,7 @@ img { margin-bottom: -4px }
 -->
 </STYLE>
 
-<TITLE>b - Metamath Test Page</TITLE>
+<TITLE>underscores - Metamath Test Page</TITLE>
 <LINK REL="shortcut icon" HREF="favicon.ico" TYPE="image/x-icon">
 </HEAD>
 <BODY BGCOLOR="#FFFFFF">
@@ -46,11 +46,11 @@ Metamath Test Page
       </B></FONT></TD>
     <TD ALIGN=RIGHT VALIGN=TOP WIDTH="25%">
       <FONT SIZE=-1 FACE=sans-serif>
-      <A HREF="b.html">
+      <A HREF="underscores.html">
       &lt; Wrap</A>&nbsp;&nbsp;
-      <A HREF="b.html">Wrap &gt;</A>
+      <A HREF="underscores.html">Wrap &gt;</A>
       </FONT><FONT FACE=sans-serif SIZE=-2>
-      <BR><A HREF="mmtheorems1.html#b">Nearby theorems</A>
+      <BR><A HREF="mmtheorems1.html#underscores">Nearby theorems</A>
       </FONT>
     </TD>
   </TR>
@@ -61,7 +61,7 @@ Metamath Test Page
       &nbsp;<A HREF="../index.html">Home</A>&nbsp; &gt;
       &nbsp;<A HREF="mmset.html">MTP Home</A>&nbsp; &gt;
       &nbsp;<A HREF="mmtheorems.html">Th. List</A>&nbsp; &gt;
-      &nbsp;b
+      &nbsp;underscores
       </FONT>
     </TD>
     <TD COLSPAN=2 ALIGN=RIGHT VALIGN=TOP>
@@ -73,7 +73,7 @@ Metamath Test Page
 </TABLE>
 <HR NOSHADE SIZE=1>
 <CENTER><B><FONT SIZE="+1">Syntax Definition <FONT
-COLOR="#006633">b</FONT></FONT></B>&nbsp;<SPAN CLASS=r
+COLOR="#006633">underscores</FONT></FONT></B>&nbsp;<SPAN CLASS=r
 STYLE="color:#FB0000">1</SPAN></CENTER>
 <CENTER><TABLE><TR><TD ALIGN=LEFT><B>Description: </B>This is <I>italic</I> and
 the command &quot;MM-PA&gt; MINIMIZE_WITH *&quot; and a
@@ -84,7 +84,7 @@ SUMMARY="Assertion">
 <CAPTION><B>Assertion</B></CAPTION>
 <TR><TH>Ref
 </TH><TH>Expression</TH></TR>
-<TR ALIGN=LEFT><TD><FONT COLOR="#006633"><B>b</B></FONT></TD><TD>
+<TR ALIGN=LEFT><TD><FONT COLOR="#006633"><B>underscores</B></FONT></TD><TD>
 <SPAN >a</SPAN></TD></TR>
 </TABLE></CENTER>
 

--- a/tests/underscores.expected
+++ b/tests/underscores.expected
@@ -1,6 +1,6 @@
 MM> READ "underscores.mm"
-Reading source file "underscores.mm"... 171 bytes
-171 bytes were read into the source buffer.
+Reading source file "underscores.mm"... 193 bytes
+193 bytes were read into the source buffer.
 The source has 2 statements; 1 are $a and 0 are $p.
 SET EMPTY_SUBSTITUTION was turned ON (allowed) for this database.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
@@ -76,7 +76,8 @@ Metamath Test Page
 COLOR="#006633">b</FONT></FONT></B>&nbsp;<SPAN CLASS=r
 STYLE="color:#FB0000">1</SPAN></CENTER>
 <CENTER><TABLE><TR><TD ALIGN=LEFT><B>Description: </B>This is <I>italic</I> and
-the command &quot;MM-PA&gt; MINIMIZE_WITH *&quot;.</TD></TR></TABLE></CENTER>
+the command &quot;MM-PA&gt; MINIMIZE_WITH *&quot; and a
+     sub<SUB><FONT SIZE="-1">script</FONT></SUB>.</TD></TR></TABLE></CENTER>
 
 <CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA"
 SUMMARY="Assertion">

--- a/tests/underscores.expected
+++ b/tests/underscores.expected
@@ -1,0 +1,104 @@
+MM> READ "underscores.mm"
+Reading source file "underscores.mm"... 171 bytes
+171 bytes were read into the source buffer.
+The source has 2 statements; 1 are $a and 0 are $p.
+SET EMPTY_SUBSTITUTION was turned ON (allowed) for this database.
+No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
+if you want to check them.
+MM> Continuous scrolling is now in effect.
+MM> Creating HTML file "b.html"...
+Reading definitions from $t statement of underscores.mm...
+1 typesetting statements were read from "underscores.mm".
+MM> <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+    "http://www.w3.org/TR/html4/loose.dtd">
+<HTML LANG="EN-US">
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
+<META NAME="viewport" CONTENT="width=device-width, initial-scale=1.0">
+<STYLE TYPE="text/css">
+<!--
+img { margin-bottom: -4px }
+.r { font-family: "Arial Narrow";
+     font-size: x-small;
+   }
+.i { font-family: "Arial Narrow";
+     font-size: x-small;
+     color: gray;
+   }
+-->
+</STYLE>
+
+<TITLE>b - Metamath Test Page</TITLE>
+<LINK REL="shortcut icon" HREF="favicon.ico" TYPE="image/x-icon">
+</HEAD>
+<BODY BGCOLOR="#FFFFFF">
+<TABLE BORDER=0 CELLSPACING=0 CELLPADDING=0 WIDTH="100%">
+  <TR>
+    <TD ALIGN=LEFT VALIGN=TOP WIDTH="25%"><A HREF=
+    "mmset.html"><IMG SRC="mm.gif"
+      BORDER=0
+      ALT="MTP Home"
+      TITLE="MTP Home"
+      HEIGHT=32 WIDTH=32 ALIGN=TOP STYLE="margin-bottom:0px"></A>
+    </TD>
+    <TD ALIGN=CENTER COLSPAN=2 VALIGN=TOP><FONT SIZE="+3" COLOR="#006633"><B>
+Metamath Test Page
+      </B></FONT></TD>
+    <TD ALIGN=RIGHT VALIGN=TOP WIDTH="25%">
+      <FONT SIZE=-1 FACE=sans-serif>
+      <A HREF="b.html">
+      &lt; Wrap</A>&nbsp;&nbsp;
+      <A HREF="b.html">Wrap &gt;</A>
+      </FONT><FONT FACE=sans-serif SIZE=-2>
+      <BR><A HREF="mmtheorems1.html#b">Nearby theorems</A>
+      </FONT>
+    </TD>
+  </TR>
+  <TR>
+    <TD COLSPAN=2 ALIGN=LEFT VALIGN=TOP><FONT SIZE=-2
+      FACE=sans-serif>
+      <A HREF="../mm.html">Mirrors</A>&nbsp; &gt;
+      &nbsp;<A HREF="../index.html">Home</A>&nbsp; &gt;
+      &nbsp;<A HREF="mmset.html">MTP Home</A>&nbsp; &gt;
+      &nbsp;<A HREF="mmtheorems.html">Th. List</A>&nbsp; &gt;
+      &nbsp;b
+      </FONT>
+    </TD>
+    <TD COLSPAN=2 ALIGN=RIGHT VALIGN=TOP>
+      <FONT SIZE=-2 FACE=sans-serif>
+
+      </FONT>
+    </TD>
+  </TR>
+</TABLE>
+<HR NOSHADE SIZE=1>
+<CENTER><B><FONT SIZE="+1">Syntax Definition <FONT
+COLOR="#006633">b</FONT></FONT></B>&nbsp;<SPAN CLASS=r
+STYLE="color:#FB0000">1</SPAN></CENTER>
+<CENTER><TABLE><TR><TD ALIGN=LEFT><B>Description: </B>This is <I>italic</I> and
+the command &quot;MM-PA&gt; MINIMIZE_WITH *&quot;.</TD></TR></TABLE></CENTER>
+
+<CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA"
+SUMMARY="Assertion">
+<CAPTION><B>Assertion</B></CAPTION>
+<TR><TH>Ref
+</TH><TH>Expression</TH></TR>
+<TR ALIGN=LEFT><TD><FONT COLOR="#006633"><B>b</B></FONT></TD><TD>
+<SPAN >a</SPAN></TD></TR>
+</TABLE></CENTER>
+
+
+<HR NOSHADE SIZE=1>
+</TABLE></CENTER>
+<TABLE BORDER=0 WIDTH="100%">
+<TR><TD WIDTH="25%">&nbsp;</TD>
+<TD ALIGN=CENTER VALIGN=BOTTOM>
+<FONT SIZE=-2 FACE=sans-serif>
+Copyright terms:
+<A HREF="../copyright.html#pd">Public domain</A>
+</FONT></TD><TD ALIGN=RIGHT VALIGN=BOTTOM WIDTH="25%">
+<FONT SIZE=-2 FACE=sans-serif>
+<A HREF="http://validator.w3.org/check?uri=referer">
+W3C validator</A>
+</FONT></TD></TR></TABLE>
+</BODY></HTML>

--- a/tests/underscores.in
+++ b/tests/underscores.in
@@ -1,0 +1,2 @@
+show statement b/alt_html
+"cat b.html"

--- a/tests/underscores.in
+++ b/tests/underscores.in
@@ -1,2 +1,2 @@
-show statement b/alt_html
-"cat b.html"
+show statement underscores/alt_html
+"cat underscores.html"

--- a/tests/underscores.mm
+++ b/tests/underscores.mm
@@ -1,0 +1,9 @@
+  $c a $.
+
+  $( This is _italic_ and the command "MM-PA> MINIMIZE__WITH *". $)
+  b $a a $.
+
+$( $t
+ htmldef "a" as "a";
+  althtmldef "a" as "a";
+   latexdef "a" as "a"; $)

--- a/tests/underscores.mm
+++ b/tests/underscores.mm
@@ -1,6 +1,7 @@
   $c a $.
 
-  $( This is _italic_ and the command "MM-PA> MINIMIZE__WITH *". $)
+  $( This is _italic_ and the command "MM-PA> MINIMIZE__WITH *" and a
+     sub_script. $)
   b $a a $.
 
 $( $t

--- a/tests/underscores.mm
+++ b/tests/underscores.mm
@@ -2,7 +2,7 @@
 
   $( This is _italic_ and the command "MM-PA> MINIMIZE__WITH *" and a
      sub_script. $)
-  b $a a $.
+  underscores $a a $.
 
 $( $t
  htmldef "a" as "a";


### PR DESCRIPTION
Almost certainly buggy since I don't know the codebase nor the language. Also, probably inefficient since I copied code from a more complex case than just replacing `__` with `_`. This is more like pseudocode than anything else, actually, but I wanted to get the ball rolling since the need for this feature was emphasized in https://github.com/metamath/set.mm/pull/3389#discussion_r1298845431 by @avekens (i.e., we want to display command names like `MINIMIZE_WITH` and `TRACE_BACK` without triggering italics or subscripts in the generated html).

Help would be appreciated (it may be simpler to start another PR). Maybe from @digama0 or @wlammen or @tirix ?
