### PR TITLE
Add tests for underscores in URLs

### DIFF
--- a/tests/underscores.expected
+++ b/tests/underscores.expected
@@ -1,6 +1,6 @@
 MM> READ "underscores.mm"
-Reading source file "underscores.mm"... 203 bytes
-203 bytes were read into the source buffer.
+Reading source file "underscores.mm"... 336 bytes
+336 bytes were read into the source buffer.
 The source has 2 statements; 1 are $a and 0 are $p.
 SET EMPTY_SUBSTITUTION was turned ON (allowed) for this database.
 No errors were found.  However, proofs were not checked.  Type VERIFY PROOF *
@@ -77,7 +77,11 @@ COLOR="#006633">underscores</FONT></FONT></B>&nbsp;<SPAN CLASS=r
 STYLE="color:#FB0000">1</SPAN></CENTER>
 <CENTER><TABLE><TR><TD ALIGN=LEFT><B>Description: </B>This is <I>italic</I> and
 the command &quot;MM-PA&gt; MINIMIZE_WITH *&quot; and a
-     sub<SUB><FONT SIZE="-1">script</FONT></SUB>.</TD></TR></TABLE></CENTER>
+     sub<SUB><FONT SIZE="-1">script</FONT></SUB>.
+<P STYLE="margin-bottom:0em">
+     In URLs underscores stand for themselves and a double underscore
+     is two underscores: <A
+HREF="https://example.com/one_two__three">https://example.com/one_two__three</A></TD></TR></TABLE></CENTER>
 
 <CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA"
 SUMMARY="Assertion">

--- a/tests/underscores.mm
+++ b/tests/underscores.mm
@@ -1,7 +1,10 @@
   $c a $.
 
   $( This is _italic_ and the command "MM-PA> MINIMIZE__WITH *" and a
-     sub_script. $)
+     sub_script.
+
+     In URLs underscores stand for themselves and a double underscore
+     is two underscores: ~ https://example.com/one_two__three $)
   underscores $a a $.
 
 $( $t


### PR DESCRIPTION
This is existing behavior but it would seem to make sense because the concept of italics or subscripts does not make sense within a URL.

This is the case also discussed in https://github.com/metamath/metamath-knife/issues/128