### PR TITLE
Fix a few UBs

### DIFF
--- a/src/mmcmdl.c
+++ b/src/mmcmdl.c
@@ -1772,11 +1772,12 @@ static flag getFullArg(long arg, const char *cmdList1) {
   if (!strcmp(left(possCmd[possCmds - 1],1), "<")) {
     // free_vstring(defaultCmd); // Not needed because defaultCmd is already empty
     // Get default argument, if any
-    defaultCmd = possCmd[possCmds - 1]; // re-use old allocation
-
-    if (!strcmp(defaultCmd, "<$>")) {
+    if (!strcmp(possCmd[possCmds - 1], "<$>")) {
       let(&defaultCmd, "<nothing>");
+    } else {
+      let(&defaultCmd, possCmd[possCmds - 1]);
     }
+    free_vstring(*(vstring *)(&possCmd[possCmds - 1]));
     pntrLet(&possCmd, pntrLeft(possCmd, possCmds - 1));
     possCmds--;
   }

--- a/src/mmdata.c
+++ b/src/mmdata.c
@@ -1224,14 +1224,14 @@ void nmbrCpy(nmbrString *s, const nmbrString *t) {
 // Like strncpy, only the 1st n characters are copied.
 // Dangerous for general purpose use.
 void nmbrNCpy(nmbrString *s, const nmbrString *t, long n) {
-  long i;
-  i = 0;
-  while (t[i] != -1) { // End of string -- nmbrSeg, nmbrMid depend on it!!
-    if (i >= n) break;
+  long i = 0;
+  // Check i < n before reading t[i] so we never access t[n]; all callers
+  // set sout[n] = NULL_NMBRSTRING afterwards, so that value is never used.
+  while (i < n && t[i] != -1) { // End of string -- nmbrSeg, nmbrMid depend on it!!
     s[i] = t[i];
     i++;
   }
-  s[i] = t[i]; // End of string
+  s[i] = *NULL_NMBRSTRING; // End of string (NULL-terminate at actual end)
 }
 
 // Compare two strings.

--- a/src/mmdata.c
+++ b/src/mmdata.c
@@ -1225,8 +1225,9 @@ void nmbrCpy(nmbrString *s, const nmbrString *t) {
 // Dangerous for general purpose use.
 void nmbrNCpy(nmbrString *s, const nmbrString *t, long n) {
   long i = 0;
-  // Check i < n before reading t[i] so we never access t[n]; all callers
-  // set sout[n] = NULL_NMBRSTRING afterwards, so that value is never used.
+  // Only t[0..n-1] are guaranteed to be valid elements, so check i < n before
+  // reading t[i]. The result is terminated below, so callers do not have to
+  // terminate it.
   while (i < n && t[i] != -1) { // End of string -- nmbrSeg, nmbrMid depend on it!!
     s[i] = t[i];
     i++;
@@ -2706,9 +2707,9 @@ void pntrCpy(pntrString *s, const pntrString *t) {
 // Dangerous for general purpose use
 void pntrNCpy(pntrString *s, const pntrString *t, long n) {
   long i = 0;
-  // Check i < n before reading t[i] so we never access t[n] (which may be
-  // a dangling pointer when callers free the element at position n before
-  // calling this function).  All callers set sout[n] = NULL afterwards.
+  // Only t[0..n-1] are guaranteed to be valid elements, so check i < n
+  // before reading t[i]. The result is terminated below, so callers do not
+  // have to terminate it.
   while (i < n && t[i] != NULL) { // End of string -- pntrSeg, pntrMid depend on it!!
     s[i] = t[i];
     i++;

--- a/src/mmdata.c
+++ b/src/mmdata.c
@@ -2708,14 +2708,15 @@ void pntrCpy(pntrString *s, const pntrString *t) {
 // Like strncpy, only the 1st n characters are copied.
 // Dangerous for general purpose use
 void pntrNCpy(pntrString *s, const pntrString *t, long n) {
-  long i;
-  i = 0;
-  while (t[i] != NULL) { // End of string -- pntrSeg, pntrMid depend on it!!
-    if (i >= n) break;
+  long i = 0;
+  // Check i < n before reading t[i] so we never access t[n] (which may be
+  // a dangling pointer when callers free the element at position n before
+  // calling this function).  All callers set sout[n] = NULL afterwards.
+  while (i < n && t[i] != NULL) { // End of string -- pntrSeg, pntrMid depend on it!!
     s[i] = t[i];
     i++;
   }
-  s[i] = t[i]; // End of string
+  s[i] = *NULL_PNTRSTRING; // End of string (NULL-terminate at actual end)
 }
 
 // Compare two strings.

--- a/src/mmdata.c
+++ b/src/mmdata.c
@@ -1256,7 +1256,6 @@ temp_nmbrString *nmbrSeg(const nmbrString *sin, long start, long stop) {
   if (length < 0) length = 0;
   temp_nmbrString *sout = nmbrTempAlloc(length + 1);
   nmbrNCpy(sout, sin + start - 1, length);
-  sout[length] = *NULL_NMBRSTRING;
   return sout;
 }
 
@@ -1266,7 +1265,6 @@ temp_nmbrString *nmbrMid(const nmbrString *sin, long start, long length) {
   if (length < 0) length = 0;
   temp_nmbrString *sout = nmbrTempAlloc(length + 1);
   nmbrNCpy(sout, sin + start - 1, length);
-  sout[length] = *NULL_NMBRSTRING;
   return sout;
 }
 
@@ -1275,7 +1273,6 @@ temp_nmbrString *nmbrLeft(const nmbrString *sin, long n) {
   if (n < 0) n = 0;
   temp_nmbrString *sout = nmbrTempAlloc(n + 1);
   nmbrNCpy(sout, sin, n);
-  sout[n] = *NULL_NMBRSTRING;
   return sout;
 }
 
@@ -2740,7 +2737,6 @@ temp_pntrString *pntrSeg(const pntrString *sin, long start, long stop) {
   if (length < 0) length = 0;
   temp_pntrString *sout = pntrTempAlloc(length + 1);
   pntrNCpy(sout, sin + start - 1, length);
-  sout[length] = *NULL_PNTRSTRING;
   return sout;
 }
 
@@ -2750,7 +2746,6 @@ temp_pntrString *pntrMid(const pntrString *sin, long start, long length) {
   if (length < 0) length = 0;
   temp_pntrString *sout = pntrTempAlloc(length + 1);
   pntrNCpy(sout, sin + start-1, length);
-  sout[length] = *NULL_PNTRSTRING;
   return sout;
 }
 
@@ -2759,7 +2754,6 @@ temp_pntrString *pntrLeft(const pntrString *sin, long n) {
   if (n < 0) n = 0;
   temp_pntrString *sout = pntrTempAlloc(n+1);
   pntrNCpy(sout,sin,n);
-  sout[n] = *NULL_PNTRSTRING;
   return sout;
 }
 

--- a/src/mmpars.c
+++ b/src/mmpars.c
@@ -5005,7 +5005,7 @@ void getNextInclusion(char *fileBuf, long startOffset, // inputs
         }
         continue; // We're past Begin; start search for End
       } // Begin, End, or Skip
-    } else if (i != i + 1) { // Suppress "unreachable code" warning for bug trap below
+    } else if (1) { // Suppress "unreachable code" warning for bug trap below
       // It's '$' not followed by '[' or '('; j is token length
       fbPtr = fbPtr + j;
       continue;

--- a/src/mmpars.c
+++ b/src/mmpars.c
@@ -5005,12 +5005,11 @@ void getNextInclusion(char *fileBuf, long startOffset, // inputs
         }
         continue; // We're past Begin; start search for End
       } // Begin, End, or Skip
-    } else if (1) { // Suppress "unreachable code" warning for bug trap below
+    } else {
       // It's '$' not followed by '[' or '('; j is token length
       fbPtr = fbPtr + j;
       continue;
     }
-    bug(1746); // Should never get here
    GET_PASSED_END_OF_COMMENT:
     // Note that fbPtr should be at beginning of last token found, which
     // may be "$)" (in which case i will be 1 from the instr).

--- a/src/mmvstr.c
+++ b/src/mmvstr.c
@@ -313,7 +313,10 @@ temp_vstring mid(const char *sin, long start, long length) {
   if (start < 1) start = 1;
   if (length < 0) length = 0;
   temp_vstring sout = tempAlloc(length + 1);
-  strncpy(sout, sin + start - 1, (size_t)length);
+  /* parentheses in next line ensure integer subtraction is evaluated before
+     pointer arithmetic to avoid 'pointer arithmetic out of object bounds' UB.
+  */
+  strncpy(sout, sin + (start - 1), (size_t)length);
 /*E*/ // ??? Should db be subtracted from if length > end of string?
   sout[length] = 0;
   return sout;
@@ -865,7 +868,11 @@ temp_vstring entry(long element, const char *list)
   length = i - lastComma - 1;
   if (length < 1) return ("");
   temp_vstring sout = tempAlloc(length + 1);
-  strncpy(sout, list + lastComma + 1, (size_t)length);
+  /* lastComma == -1 when element == 1 (no preceding comma);
+     parentheses in next line ensure integer addition is evaluated before
+     pointer arithmetic to avoid 'pointer arithmetic out of object bounds' UB.
+  */
+  strncpy(sout, list + (lastComma + 1), (size_t)length);
   sout[length] = 0;
   return sout;
 }


### PR DESCRIPTION
This PR fixes a few UBs (undefined behaviors): a class of particularly critical bugs. In the present case, the fixed UBs were pointer arithmetic out of a valid object bounds, uninitialized variable, dangling pointer, out-of-bound read. These bugs could actually occur (and I actually got segfaults over the years because of the getFullArg one).

These UBs were found with TrustInSoft Analyzer and I was assisted in the bugfixes by claude code.

Maybe @tirix and/or @wlammen can have a look?