### PR TITLE
describe invocation of regression tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,9 @@ may need to be checked manually.
 We expect all code merged to compile and not break existing
 functionality.
 
+We also expect the regression tests to pass.  See `src/mmtest.h` for how to
+run them and for more details.
+
 To be merged, a pull request must be approved by a different existing
 contributor (someone who's already had some previous contributions accepted).
 You can approve a change by viewing the pull request, selecting

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -735,7 +735,6 @@ int main(int argc, char *argv[]) {
 
   // see mmtest.h for how to run the regression tests
   RUN_TESTS_AND_EXIT_IF_ENABLED();
-  // The following code is not reached if tests are enabled.
 
   // ******** If g_listMode is set to 1 here, the startup will be Text
   //          Tools utilities, and Metamath will be disabled *********

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -731,12 +731,11 @@ void command(int argc, char *argv[]);
  */
 int main(int argc, char *argv[]) {
 
-// argc is the number of arguments; argv points to an array containing them
+  // argc is the number of arguments; argv points to an array containing them
 
-#ifdef TEST_ENABLE // enable this in mmtest.h or via './build.sh -t'
-  RUN_TESTS();
-  // you never get here
-#endif
+  // enable this in mmtest.h or via './build.sh -t'
+  RUN_TESTS_IF_ENABLED();
+  // The following code is not reached if tests are enabled.
 
   // ******** If g_listMode is set to 1 here, the startup will be Text
   //          Tools utilities, and Metamath will be disabled *********

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -734,7 +734,7 @@ int main(int argc, char *argv[]) {
   // argc is the number of arguments; argv points to an array containing them
 
   // see mmtest.h for how to run the regression tests
-  RUN_TESTS_IF_ENABLED();
+  RUN_TESTS_AND_EXIT_IF_ENABLED();
   // The following code is not reached if tests are enabled.
 
   // ******** If g_listMode is set to 1 here, the startup will be Text

--- a/src/metamath.c
+++ b/src/metamath.c
@@ -733,7 +733,7 @@ int main(int argc, char *argv[]) {
 
   // argc is the number of arguments; argv points to an array containing them
 
-  // enable this in mmtest.h or via './build.sh -t'
+  // see mmtest.h for how to run the regression tests
   RUN_TESTS_IF_ENABLED();
   // The following code is not reached if tests are enabled.
 

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -29,15 +29,15 @@
    ./metamath_test
    \endverbatim
  *
- * 4. The macro \ref TEST_SILENT can suppress progress and success information.
- * When left in its default state, messages of the following kind are issued:
+ * 4. The test program reports its progress to \c stdout:
  * \verbatim
    running test_mmfatl:test_fatalErrorInit... ok
    \endverbatim
  *
  * If every displayed test ends with \c ok, all regression tests have passed.
- * Otherwise, failing tests always display diagnostic information identifying
- * the test and the kind of failure.
+ * Progress and success messages can be suppressed, see \ref TEST_SILENT.
+ * Failing tests always display diagnostic information identifying the failing
+ * assertion and its source location.
  *
  * \subsection test_details Details and implementation
  * If the macro \c TEST_ENABLE is defined by the \c -t option of \c build.sh,
@@ -55,11 +55,9 @@
  * executable does not increase in size. Thus, a disabled test suite incurs
  * neither a linking nor a runtime penalty.
  *
- * If testing is enabled, the progress of tests is reported to \c stdout,
- * subject to \ref TEST_SILENT. The first failed assertion aborts the test
- * suite to which it belongs, and a diagnostic message identifying the failing
- * assertion and its source location is always written. Remaining test suites
- * still run, and the program exits with a nonzero status if any test failed.
+ * A failed assertion skips the rest of the function in which it occurs. The
+ * other functions registered with \c RUN_TEST are still executed. The program
+ * exits with status 0 if all tests passed, and nonzero otherwise.
  *
  * We recommend running the regression tests whenever the code is modified
  * to ensure that it continues to behave as intended. The tests are also

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -43,7 +43,7 @@
  * the macro is defined matters. Defining the macro directly in this file does
  * not affect the executable's name.
  *
- * If testing is enableded or disablrd without modifying any source files in
+ * If testing is enableded or disabled without modifying any source files in
  * between, also pass the \c -c (clean) option to \c build.sh to remove
  * intermediate build artifacts.
  *

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -38,12 +38,12 @@
  * If every test ends with \c ok, all regression tests have passed.
  * Otherwise, diagnostic information identifies the failed test.
  *
- * If the macro \c TEST_ENABLE is defined (the \c -t option of
- * \c build.sh), the regression tests are compiled into a separate
- * executable named \c metamath_test. The value of \c TEST_ENABLE can
- * also be overridden in this file. If testing is switched on or off
- * without modifying any source files in between, also pass the \c -c
- * (clean) option to \c build.sh to remove intermediate build artifacts.
+ * If the macro \c TEST_ENABLE is defined (the \c -t option of \c build.sh),
+ * the regression tests are compiled into a separate executable named
+ * \c metamath_test. The macro may also be defined directly in this file; its
+ * value is irrelevant. If testing is switched on or off without modifying any
+ * source files in between, also pass the \c -c (clean) option to \c build.sh
+ * to remove intermediate build artifacts.
  *
  * If testing is disabled, the \c RUN_TESTS_IF_ENABLED macro expands to
  * nothing. The compiler also excludes all test code, so the resulting

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -43,9 +43,9 @@
  * the macro is defined matters. Defining the macro directly in this file does
  * not affect the executable's name.
  *
- * If testing is enableded or disabled without modifying any source files in
- * between, also pass the \c -c (clean) option to \c build.sh to remove
- * intermediate build artifacts.
+ * After enabling or disabling testing, even without modifying any source
+ * files, also pass the \c -c (clean) option to \c build.sh to rebuild all
+ * intermediate artifacts.
  *
  * If testing is disabled, the \c RUN_TESTS_IF_ENABLED macro expands to
  * nothing. The compiler also excludes all test code, so the resulting

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -7,7 +7,6 @@
 #ifndef METAMATH_MMTEST_H_
 #define METAMATH_MMTEST_H_
 
-
 /*!
  * \file mmtest.h
  * \brief Framework for regression tests.
@@ -25,20 +24,22 @@
  *
  * 3. Execute the following commands:
  * \verbatim
-   ./build.sh -ct
-   ./metamath_test
-   \endverbatim
+ *   ./build.sh -ct
+ *   ./metamath_test
+ *   \endverbatim
  *
- * 4. The test program produces output similar to the following:
+ * 4. Assuming \ref TEST_SILENT is set to its default value, the test program
+ * produces progress lines similar to the following:
  * \verbatim
-   > running test_mmfatl:test_fatalErrorInit... ok
-   \endverbatim
+ *   running test_mmfatl:test_fatalErrorInit... ok
+ *   \endverbatim
  *
- * If every test ends with \c ok, all regression tests have passed.
- * Otherwise, diagnostic information identifies the failed test.
+ * If every displayed test ends with \c ok, all regression tests have passed.
+ * A failed test outputs diagnostic information identifying the test and the
+ * failure.
  *
  * If the macro \c TEST_ENABLE is defined by the \c -t option of \c build.sh,
- * the script compiles regression tests into an executable named
+ * the script compiles the regression tests into an executable named
  * \c metamath_test. The value of \c TEST_ENABLE is irrelevant; only whether
  * the macro is defined matters. Defining the macro directly in this file does
  * not affect the executable's name.
@@ -52,18 +53,20 @@
  * executable does not increase in size. Thus, a disabled test suite incurs
  * neither a linking nor a runtime penalty.
  *
- * If testing is enabled, the tests report their progress to \c stdout.
- * Execution stops at the first regression failure, and a diagnostic
- * message provides further details about the context of the failure.
+ * If testing is enabled, the tests report their progress to \c stdout, if
+ * permitted by \ref TEST_SILENT. The first failed assertion aborts the test in
+ * which it occurs, and a diagnostic message always identifies the failing
+ * assertion and its source location. Remaining tests still run, and the
+ * program exits with a nonzero status if any test failed.
  *
  * We recommend running the regression tests whenever the code is modified
  * to ensure that it continues to behave as intended. The tests are also
- * run automatically by GitHub checks whenever changes are pushed.
+ * run automatically by GitHub's checks whenever changes are pushed.
  *
  * The macro \c RUN_TESTS_IF_ENABLED should be the first instruction in
  * \c main. It expands to nothing when testing is disabled. When testing
  * is enabled, it runs the regression tests and terminates the program,
- * so the normal program code is not executed:
+ * so the normal program execution does not take place:
  * \code
  * int main(int argc, char *argv[]) {
  *
@@ -76,7 +79,6 @@
  * }
  * \endcode
  */
-
 
 // Uncomment this to force-disable tests
 // #undef TEST_ENABLE

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -7,41 +7,74 @@
 #ifndef METAMATH_MMTEST_H_
 #define METAMATH_MMTEST_H_
 
-/*!
- * \file mmtest.h
- * \brief runs the regression tests
- *
- * part of the application's infrastructure
- *
- * Regression tests
- * ================
- *
- * If the macro **TEST_ENABLE** is defined (option -t of build.sh), then
- * regression tests are run. The setting can be overridden in this file.
- * Invoke in addition option -c (clean) on build.sh, should you switch
- * between with/out testing, but no intermediate source file change.
- *
- * If tests are disabled the \ref runTests line evaluates to nothing.
- * In addition, the compiler skips any test code, so the artifact size will not
- * grow.  All in all, a disabled test suite does not come with a linking or
- * runtime penalty.
- *
- * If enabled, running tests document their progress to stdout.  Testing exits
- * on the first regression found with a diagnostic message further detailing on
- * the context of the failure.
- *
- * We recommend running the tests each time you modify the code to ensure it
- * still executes as desired.  They are automatically invoked by Github checks
- * on each push request.
- */
 
 /*!
- * \def TEST_ENABLE
- * macro, no value, just defined or not.
  *
- * Controls whether the regression tests for a
- * particular module is in/excluded.
+ * \file mmtest.h
+ * \brief Framework for regression tests.
+ *
+ * This file is part of the application's test infrastructure.
+ *
+ * \section regression_tests Regression tests
+ *
+ * Regression tests can be run as follows:
+ *
+ * 1. Open a shell for running Bash commands.
+ *
+ * 2. Change to the directory containing Metamath's build script
+ * \c build.sh.
+ *
+ * 3. Execute the following commands:
+ * \verbatim
+ * ./build.sh -ct
+ * ./metamath_test
+ * \endverbatim
+ *
+ * 4. The test program produces output similar to the following:
+ * \verbatim
+ * > running test_mmfatl:test_fatalErrorInit... ok
+ * \endverbatim
+ *
+ * If every test ends with \c ok, all regression tests have passed.
+ * Otherwise, diagnostic information identifies the failed test.
+ *
+ * If the macro \c TEST_ENABLE is defined (the \c -t option of
+ * \c build.sh), the regression tests are compiled into a separate
+ * executable named \c metamath_test. The value of \c TEST_ENABLE can
+ * also be overridden in this file. If testing is switched on or off
+ * without modifying any source files in between, also pass the \c -c
+ * (clean) option to \c build.sh to remove intermediate build artifacts.
+ *
+ * If testing is disabled, the \ref RUN_TESTS_IF_ENABLED macro expands to
+ * nothing. The compiler also excludes all test code, so the resulting
+ * executable does not increase in size. Thus, a disabled test suite incurs
+ * neither a linking nor a runtime penalty.
+ *
+ * If testing is enabled, the tests report their progress to \c stdout.
+ * Execution stops at the first regression failure, and a diagnostic
+ * message provides further details about the context of the failure.
+ *
+ * We recommend running the regression tests whenever the code is modified
+ * to ensure that it continues to behave as intended. The tests are also
+ * run automatically by GitHub checks whenever changes are pushed.
+ *
+ * The macro \c RUN_TESTS_IF_ENABLED should be the first instruction in
+ * \c main. It expands to nothing when testing is disabled. When testing
+ * is enabled, it runs the regression tests and terminates the program,
+ * so the normal program code is not executed:
+ * \code
+ * int main(int argc, char *argv[]) {
+ *
+ *  // Expands to nothing if tests are not enabled.
+ *  RUN_TESTS_IF_ENABLED();
+ *
+ *  // This code is not reached if tests are enabled.
+ *
+ *  // Code performing normal execution of Metamath goes here.
+ * }
+ * \endcode
  */
+
 
 // Uncomment this to force-disable tests
 // #undef TEST_ENABLE
@@ -93,10 +126,10 @@
       ASSERTF(bool_expr, "assertion %s failed", #bool_expr)
 
   extern void runTests(void);
-  #define RUN_TESTS() runTests()
+  #define RUN_TESTS_IF_ENABLED() runTests()
 
 #else // TEST_ENABLE
-  #define RUN_TESTS()
+  #define RUN_TESTS_IF_ENABLED()
 #endif // TEST_ENABLE
 
 #endif // METAMATH_MMTEST_H_

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -24,15 +24,15 @@
  *
  * 3. Execute the following commands:
  * \verbatim
- *   ./build.sh -ct
- *   ./metamath_test
- *   \endverbatim
+   ./build.sh -ct
+   ./metamath_test
+   \endverbatim
  *
  * 4. Assuming \ref TEST_SILENT is set to its default value, the test program
  * produces progress lines similar to the following:
  * \verbatim
- *   running test_mmfatl:test_fatalErrorInit... ok
- *   \endverbatim
+   running test_mmfatl:test_fatalErrorInit... ok
+   \endverbatim
  *
  * If every displayed test ends with \c ok, all regression tests have passed.
  * A failed test outputs diagnostic information identifying the test and the

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -44,8 +44,8 @@
  * not affect the executable's name.
  *
  * After enabling or disabling testing, even without modifying any source
- * files, also pass the \c -c (clean) option to \c build.sh to rebuild all
- * intermediate artifacts.
+ * files, all intermediate artifacts must be rebuilt. Pass the \c -c (clean)
+ * option to \c build.sh to enforce this.
  *
  * If testing is disabled, the \c RUN_TESTS_IF_ENABLED macro expands to
  * nothing. The compiler also excludes all test code, so the resulting

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -28,15 +28,15 @@
    ./metamath_test
    \endverbatim
  *
- * 4. Assuming \ref TEST_SILENT is set to its default value, the test program
- * produces progress lines similar to the following:
+ * 4. The macro \ref TEST_SILENT can suppress progress and success information.
+ * When left in its default state, messages of the following kind are issued:
  * \verbatim
    running test_mmfatl:test_fatalErrorInit... ok
    \endverbatim
  *
  * If every displayed test ends with \c ok, all regression tests have passed.
- * A failed test outputs diagnostic information identifying the test and the
- * failure.
+ * Otherwise, failing tests always display diagnostic information identifying
+ * the test and the kind of failure.
  *
  * If the macro \c TEST_ENABLE is defined by the \c -t option of \c build.sh,
  * the script compiles the regression tests into an executable named
@@ -53,11 +53,11 @@
  * executable does not increase in size. Thus, a disabled test suite incurs
  * neither a linking nor a runtime penalty.
  *
- * If testing is enabled, the tests report their progress to \c stdout, if
- * permitted by \ref TEST_SILENT. The first failed assertion aborts the test in
- * which it occurs, and a diagnostic message always identifies the failing
- * assertion and its source location. Remaining tests still run, and the
- * program exits with a nonzero status if any test failed.
+ * If testing is enabled, the progress of tests is reported to \c stdout,
+ * subject to \ref TEST_SILENT. The first failed assertion aborts the test
+ * suite to which it belongs, and a diagnostic message identifying the failing
+ * assertion and its source location is always written. Remaining test suites
+ * still run, and the program exits with a nonzero status if any test failed.
  *
  * We recommend running the regression tests whenever the code is modified
  * to ensure that it continues to behave as intended. The tests are also

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -26,14 +26,14 @@
  *
  * 3. Execute the following commands:
  * \verbatim
- * ./build.sh -ct
- * ./metamath_test
- * \endverbatim
+   ./build.sh -ct
+   ./metamath_test
+   \endverbatim
  *
  * 4. The test program produces output similar to the following:
- * \verbatim
- * > running test_mmfatl:test_fatalErrorInit... ok
- * \endverbatim
+ *  \verbatim
+   > running test_mmfatl:test_fatalErrorInit... ok
+  \endverbatim
  *
  * If every test ends with \c ok, all regression tests have passed.
  * Otherwise, diagnostic information identifies the failed test.
@@ -45,7 +45,7 @@
  * without modifying any source files in between, also pass the \c -c
  * (clean) option to \c build.sh to remove intermediate build artifacts.
  *
- * If testing is disabled, the \ref RUN_TESTS_IF_ENABLED macro expands to
+ * If testing is disabled, the \c RUN_TESTS_IF_ENABLED macro expands to
  * nothing. The compiler also excludes all test code, so the resulting
  * executable does not increase in size. Thus, a disabled test suite incurs
  * neither a linking nor a runtime penalty.

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -9,7 +9,6 @@
 
 
 /*!
- *
  * \file mmtest.h
  * \brief Framework for regression tests.
  *
@@ -38,12 +37,15 @@
  * If every test ends with \c ok, all regression tests have passed.
  * Otherwise, diagnostic information identifies the failed test.
  *
- * If the macro \c TEST_ENABLE is defined (the \c -t option of \c build.sh),
- * the regression tests are compiled into a separate executable named
- * \c metamath_test. The macro may also be defined directly in this file; its
- * value is irrelevant. If testing is switched on or off without modifying any
- * source files in between, also pass the \c -c (clean) option to \c build.sh
- * to remove intermediate build artifacts.
+ * If the macro \c TEST_ENABLE is defined by the \c -t option of \c build.sh,
+ * the script compiles regression tests into an executable named
+ * \c metamath_test. The value of \c TEST_ENABLE is irrelevant; only whether
+ * the macro is defined matters. Defining the macro directly in this file does
+ * not affect the executable's name.
+ *
+ * If testing is enableded or disablrd without modifying any source files in
+ * between, also pass the \c -c (clean) option to \c build.sh to remove
+ * intermediate build artifacts.
  *
  * If testing is disabled, the \c RUN_TESTS_IF_ENABLED macro expands to
  * nothing. The compiler also excludes all test code, so the resulting

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -50,8 +50,8 @@
  * files, all intermediate artifacts must be rebuilt. Pass the \c -c (clean)
  * option to \c build.sh to enforce this.
  *
- * If testing is disabled, the \c RUN_TESTS_IF_ENABLED macro expands to
- * nothing. The compiler also excludes all test code, so the resulting
+ * If testing is disabled, the \c RUN_TESTS_AND_EXIT_IF_ENABLED macro expands
+ * to nothing. The compiler also excludes all test code, so the resulting
  * executable does not increase in size. Thus, a disabled test suite incurs
  * neither a linking nor a runtime penalty.
  *
@@ -65,15 +65,15 @@
  * to ensure that it continues to behave as intended. The tests are also
  * run automatically by GitHub's checks whenever changes are pushed.
  *
- * The macro \c RUN_TESTS_IF_ENABLED should be the first instruction in
- * \c main. It expands to nothing when testing is disabled. When testing
+ * The macro \c RUN_TESTS_AND_EXIT_IF_ENABLED should be the first instruction
+ * in \c main. It expands to nothing when testing is disabled. When testing
  * is enabled, it runs the regression tests and terminates the program,
  * so the normal program execution does not take place:
  * \code
  * int main(int argc, char *argv[]) {
  *
  *  // Expands to nothing if tests are not enabled.
- *  RUN_TESTS_IF_ENABLED();
+ *  RUN_TESTS_AND_EXIT_IF_ENABLED();
  *
  *  // This code is not reached if tests are enabled.
  *
@@ -132,10 +132,10 @@
       ASSERTF(bool_expr, "assertion %s failed", #bool_expr)
 
   extern void runTests(void);
-  #define RUN_TESTS_IF_ENABLED() runTests()
+  #define RUN_TESTS_AND_EXIT_IF_ENABLED() runTests()
 
 #else // TEST_ENABLE
-  #define RUN_TESTS_IF_ENABLED()
+  #define RUN_TESTS_AND_EXIT_IF_ENABLED()
 #endif // TEST_ENABLE
 
 #endif // METAMATH_MMTEST_H_

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -20,8 +20,8 @@
  *
  * 1. Open a shell for running Bash commands.
  *
- * 2. Change to the directory containing Metamath's build script
- * \c build.sh.
+ * 2. Change to the directory containing Metamath's build script \c build.sh,
+ * typically located at the top level of the \c metamath-exe project.
  *
  * 3. Execute the following commands:
  * \verbatim
@@ -30,9 +30,9 @@
    \endverbatim
  *
  * 4. The test program produces output similar to the following:
- *  \verbatim
+ * \verbatim
    > running test_mmfatl:test_fatalErrorInit... ok
-  \endverbatim
+   \endverbatim
  *
  * If every test ends with \c ok, all regression tests have passed.
  * Otherwise, diagnostic information identifies the failed test.

--- a/src/mmtest.h
+++ b/src/mmtest.h
@@ -14,6 +14,7 @@
  * This file is part of the application's test infrastructure.
  *
  * \section regression_tests Regression tests
+ * \subsection running_tests Running the tests
  *
  * Regression tests can be run as follows:
  *
@@ -38,6 +39,7 @@
  * Otherwise, failing tests always display diagnostic information identifying
  * the test and the kind of failure.
  *
+ * \subsection test_details Details and implementation
  * If the macro \c TEST_ENABLE is defined by the \c -t option of \c build.sh,
  * the script compiles the regression tests into an executable named
  * \c metamath_test. The value of \c TEST_ENABLE is irrelevant; only whether


### PR DESCRIPTION
Documentation is an ongoing effort, and each state is (likely) better than the one before, but still intermediate. Don't hesitate to review and merge the current version, subsequent pull requests can still apply modifications on the side.  If I think a version is too bad for acceptance, I will convert the pull request temporarily into a draft.

These are the objectives for this pull request:

1. rename macro RUN_TESTS to RUN_TESTS_AND_EXIT_IF_ENABLED for better understanding
2. give a detailed description in a doxygen formatted comment of how to run regression tests

Both the executables **metamath** and **metamath_test** can be created on my computer and run as expected.
The reworked documentation looks like this on a doxygen generated HTML page:

<img width="1065" height="1569" alt="grafik" src="https://github.com/user-attachments/assets/c295eb0e-069b-4f9a-afc2-22bea611daca" />