### PR TITLE
Give the null pntrString block the layout its accessors assume

### DIFF
--- a/src/mmdata.c
+++ b/src/mmdata.c
@@ -12,6 +12,7 @@
  * to BASIC string functions; memory management; converts between proof formats
 */
 #include <stdarg.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include "mmvstr.h"
@@ -34,6 +35,24 @@
 _Static_assert(sizeof(struct statement_struct) == 256,
     "statement_struct grew; see hasVarWithoutHyp in mmdata.h");
 #endif
+#endif
+
+/* g_NmbrNull and g_PntrNull stand in for a block from poolFixedMalloc(), which
+   writes its three administrative values into the 3 * sizeof(long) directly
+   below the data.  nmbrLen(), nmbrAllocLen(), pntrLen() and pntrAllocLen()
+   read them back from there, so the element has to sit at exactly that offset
+   in these structs too.  Unlike the size check above this is a correctness
+   property and holds on every platform: where it failed -- LLP64, where a
+   naturally aligned void* is padded out to offset 16 -- pntrLen() returned -1
+   for the empty string and metamath died during start-up (issue #164).  */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+_Static_assert(offsetof(struct nullNmbrStruct, nullElement)
+        == 3 * sizeof(long),
+    "g_NmbrNull's header must be the 3 longs poolFixedMalloc() writes");
+_Static_assert(offsetof(struct nullPntrStruct, nullElement)
+        == 3 * sizeof(long),
+    "g_PntrNull's header must be the 3 longs poolFixedMalloc() writes"
+    " -- see PACKED_ATTR in mmdata.h");
 #endif
 
 /*E*/long db=0,db0=0,db2=0,db3=0,db4=0,db5=0,db6=0,db7=0,db8=0,db9=0;
@@ -77,7 +96,12 @@ long g_sourceLen;
 struct nullNmbrStruct g_NmbrNull = {-1, sizeof(long), sizeof(long), -1};
 
 // Null pntrString
-struct nullPntrStruct g_PntrNull = {-1, sizeof(long), sizeof(long), NULL};
+// The two size fields are the size of the one element the block holds, which
+// is a pntrString and not a long; they differ on LLP64.  Both spellings happen
+// to give pntrLen() == 0 there, the old one by truncating -4/8, so this is a
+// correction of intent rather than of behaviour.
+struct nullPntrStruct g_PntrNull
+    = {-1, sizeof(pntrString), sizeof(pntrString), NULL};
 
 // nmbrString memory allocation/deallocation
 temp_nmbrString *nmbrTempAlloc(long size);

--- a/src/mmdata.h
+++ b/src/mmdata.h
@@ -12,6 +12,8 @@
  * \brief includes for some principal data structures and data-string handling
  */
 
+#include <stddef.h> // offsetof, used by NULL_PNTRSTRING
+
 #include "mmvstr.h"
 
 // debugging flags & variables
@@ -520,6 +522,20 @@ void bug(int bugNum);
  * detection, and tests grep for it. */
 #define BUG_CHECK_FATAL_FORMAT "?BUG CHECK:  *** DETECTED BUG %u\n"
 
+/*! \def PACKED_ATTR
+ * Lay a struct out with no padding between its members.  Used where a struct
+ * has to reproduce a memory layout the program computes by hand elsewhere, so
+ * that padding the compiler is otherwise free to insert would put the members
+ * at the wrong offsets.  Expands to nothing on compilers without the GNU
+ * attribute syntax; unlike the attributes in mmfatl.h this one is needed for
+ * correctness rather than diagnostics, so every use of it is paired with a
+ * _Static_assert on the resulting offsets. */
+#if defined(__GNUC__)
+# define PACKED_ATTR __attribute__((__packed__))
+#else
+# define PACKED_ATTR
+#endif
+
 /*! Null nmbrString -- -1 flags the end of a nmbrString */
 struct nullNmbrStruct {
     long poolLoc;
@@ -542,8 +558,21 @@ extern struct nullNmbrStruct g_NmbrNull;
  * The values in this administrative header are such that it is never subject to
  * memory allocation or deallocation.
  *
- * \bug The C standard does not require a long having the same size as a
- * void*.  In fact there might be **no** integer type matching a pointer in size.
+ * The header must occupy exactly the 3 * sizeof(long) that poolFixedMalloc()
+ * writes, because pntrLen() and pntrAllocLen() reach backwards from the
+ * element to read it.  The C standard does not require a long to be the size
+ * of a void*, and where it is not -- LLP64, that is 64-bit Windows -- a
+ * naturally aligned nullElement lands at offset 16 rather than 12, so
+ * pntrLen() reads the padding and returns -1 for an empty string.  Packing
+ * removes that padding.  It leaves nullElement at an offset that is not a
+ * multiple of sizeof(void*), which is where every pooled block already sits:
+ * poolFixedMalloc() returns malloc()'s result advanced by 3 * sizeof(long),
+ * so on LLP64 the data of every pntrString in the program is at that same
+ * offset.  This makes the static block agree with the allocated ones rather
+ * than differ from them.
+ *
+ * The offsets are asserted in mmdata.c, so a compiler that does not honour
+ * PACKED_ATTR fails the build instead of producing a broken executable.
  */
 struct nullPntrStruct {
   /*!
@@ -570,7 +599,7 @@ struct nullPntrStruct {
    * A null marks the end of the array.
    */
   pntrString nullElement;
-};
+} PACKED_ATTR;
 
 /*!
  * \var g_PntrNull
@@ -589,7 +618,17 @@ extern struct nullPntrStruct g_PntrNull;
  * \ref pntrString
  * stack.  Used to initialize \ref pntrString variables .
  */
-#define NULL_PNTRSTRING &(g_PntrNull.nullElement)
+/* Reached by offset from the start of the block rather than by &.  The element
+   follows a 3 * sizeof(long) header, so where a pntrString is wider than a
+   long it is deliberately not on a sizeof(pntrString) boundary -- exactly as
+   poolFixedMalloc(), which hands back malloc()'s result advanced by the same
+   header, leaves every other pntrString in the program.  Taking its address
+   with & instead reports every use of this macro as an unaligned pointer to a
+   packed member: 124 of them on LLP64 under the -Wall -Wextra in configure.ac,
+   131 with no warning flags at all. */
+#define NULL_PNTRSTRING \
+    ((pntrString *)(void *)((char *)&g_PntrNull \
+        + offsetof(struct nullPntrStruct, nullElement)))
 
 /*!
  * \def pntrString_def


### PR DESCRIPTION
Part of #164. @tirix asked for a PR, so here is the small one. It is not @wlammen's `pntrInt` change, for the reason on that issue: widening the header means widening `poolFixedMalloc()` and the ~45 other places that read it, and that reaches `nmbrString` too.

**This does not make 64-bit Windows work.** It clears the start-up crash. At least one more LLP64 defect sits behind it, measured at the bottom.

## The defect

`poolFixedMalloc()` writes a block's header as exactly `3 * sizeof(long)` directly below what it returns (mmdata.c:400-407), and `pntrLen()` reads it back by stepping backwards as `(const long *)s` (mmdata.c:2675). `g_PntrNull` imitates such a block for the empty pntrString, so its three header fields have to end where `nullElement` starts.

On LLP64 they do not. `pntrString` is `void*`, so its 8-byte alignment pads the 12-byte header out and puts the element at offset 16. `pntrLen()` reads the padding instead. `print2()` checks that value the first time it runs, which is why the first line the program prints is `BUG #1501`, and it goes on into a null dereference.

Measured by including the project's own headers, so these are the real structs and the real accessors, not a re-typing of them:

```
                                      x86_64-windows   x86-windows
  sizeof(long) / sizeof(void*)              4 / 8          4 / 4
  header written by poolFixedMalloc          12 B           12 B
  offsetof(nullPntrStruct, nullElement)        16             12
  offsetof(nullNmbrStruct, nullElement)        12             12
  pntrLen(NULL_PNTRSTRING)      must be 0      -1              0
  nmbrLen(NULL_NMBRSTRING)      must be 0       0              0
```

`g_NmbrNull` is fine because a `nmbrString` is a `long`, so nothing is padded. Only the pntrString block breaks, which is why the bug is specific to pntrStrings on Windows.

## Why packing

The accessor needs the element at offset 12 and `alignof(void*)` is 8. 12 is not a multiple of 8, so for this struct those two cannot both hold, and packing is what gives up the alignment rather than the offset.

Giving it up costs nothing here, because the allocator already has. `poolFixedMalloc()` returns `malloc()`'s result advanced by 12 bytes, so on LLP64 every pooled pntrString in the program is off a `void*` boundary by 4. Calling the real allocators from a probe:

```
  &g_PntrNull.nullElement % 8   before   0     <- the odd one out
  poolFixedMalloc() data % 8             4
  poolMalloc()      data % 8             4
  &g_PntrNull.nullElement % 8   after    4
```

The static block now matches the allocated ones instead of differing from them.

`NULL_PNTRSTRING` is reached by offset rather than with `&`, because taking the address of a packed member reports every use of the macro as an unaligned pointer — 124 of them under the `-Wall -Wextra` in configure.ac:68. By offset there are none.

`PACKED_ATTR` follows the `#if defined(__GNUC__)` pattern in mmfatl.h, but unlike those attributes it is load-bearing, so it is paired with `_Static_assert` on the offsets: a compiler that ignores it fails the build with a message rather than shipping a broken binary. CompCert is unaffected either way — it targets ILP32 and LP64, where the assert holds with no packing at all. The asserts use the same `__STDC_VERSION__ >= 201112L` guard as the existing one at mmdata.c:34.

Two smaller things in the diff. `g_PntrNull`'s size fields were `sizeof(long)`; they mean "the size of the one element this block holds", which is a `pntrString`. That is a correction of intent, not of behaviour — the old spelling also yields 0 on LLP64, by truncating `-4/8`. And the `\bug` note on `nullPntrStruct` described this exact problem, so it now describes the resolution.

## Results

`zig cc` for `x86_64-windows-gnu` and `x86-windows-gnu`, `-Wall -Wextra`, run on Windows 11.

```
                       baseline 64-bit        this branch 64-bit
  start-up             BUG #1501, SIGSEGV     reaches the prompt
  read set.mm          never gets there       51,140,933 bytes, no errors
  verify proof *       never gets there       runs to 100%, then 0xC0000005
```

`tests/run_test.sh *.in`, comparing `.produced` against `.expected` with line endings normalised:

```
                          pass   fail   no output
  baseline  32-bit          39      2           0
  this PR   32-bit          39      2           0
  baseline  64-bit           0      0          41
  this PR   64-bit          33      0           8
```

32-bit is untouched, including the same two pre-existing failures (`issue196`, `issue196-silent`) either side. 64-bit goes from every test dying at start-up to 33 passing and none failing. `metamath_test` passes on both targets. Warning count is unchanged: the same 3 pre-existing ones before and after.

## What is still broken

The 8 tests that still produce nothing on 64-bit, and the `0xC0000005` at the end of a full `verify proof *`, are a different defect. It is not this change: a variant with no packing anywhere — `unsigned char nullElement[sizeof(pntrString)]`, alignment 1, which lands at offset 12 on its own — crashes in exactly the same place. It was unreachable before only because the program died at start-up. `iset.mm`, `nf.mm` and `ql.mm` verify clean on 64-bit; only the full set.mm run reaches it. I have not tracked it down, so #164 should stay open for it.
